### PR TITLE
open links in new tab

### DIFF
--- a/components/note-content.tsx
+++ b/components/note-content.tsx
@@ -71,6 +71,14 @@ export default function NoteContent({
     );
   }, [canEdit, handleMarkdownCheckboxChange]);
 
+  const renderLink = useCallback((props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    return (
+      <a {...props} target="_blank" rel="noopener noreferrer">
+        {props.children}
+      </a>
+    );
+  }, []);
+
   return (
     <div className="px-2">
       {(isEditing && canEdit) || (!note.content && canEdit) ? (
@@ -97,6 +105,7 @@ export default function NoteContent({
             remarkPlugins={[remarkGfm]}
             components={{
               li: renderListItem,
+              a: renderLink,
             }}
           >
             {note.content || "Start writing..."}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Links in markdown content now open in a new tab in `note-content.tsx`.
> 
>   - **Behavior**:
>     - Links in markdown content now open in a new tab using `target="_blank"` and `rel="noopener noreferrer"`.
>   - **Functions**:
>     - Adds `renderLink` function in `note-content.tsx` to customize link rendering in `ReactMarkdown` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=alanagoyal%2Falanagoyal&utm_source=github&utm_medium=referral)<sup> for a478576f35802bd491226537289abd40799da65f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->