### PR TITLE
chore: remove node="[object Object]" from notes

### DIFF
--- a/components/note-content.tsx
+++ b/components/note-content.tsx
@@ -30,7 +30,9 @@ export default function NoteContent({
   }, [note.content, saveNote]);
 
   const renderListItem = useCallback(({ children, ...props }: any) => {
-    delete props.node
+    if ('node' in props) {
+      delete props.node
+    }
     if (!props.className?.includes('task-list-item')) return <li {...props}>{children}</li>;
 
     const checkbox = children.find((child: any) => child.type === 'input');
@@ -73,7 +75,9 @@ export default function NoteContent({
   }, [canEdit, handleMarkdownCheckboxChange]);
 
   const renderLink = useCallback((props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
-    delete (props as any).node
+    if ('node' in props) {
+      delete props.node
+    }
     return (
       <a {...props} target="_blank" rel="noopener noreferrer">
         {props.children}

--- a/components/note-content.tsx
+++ b/components/note-content.tsx
@@ -30,6 +30,7 @@ export default function NoteContent({
   }, [note.content, saveNote]);
 
   const renderListItem = useCallback(({ children, ...props }: any) => {
+    delete props.node
     if (!props.className?.includes('task-list-item')) return <li {...props}>{children}</li>;
 
     const checkbox = children.find((child: any) => child.type === 'input');

--- a/components/note-content.tsx
+++ b/components/note-content.tsx
@@ -73,6 +73,7 @@ export default function NoteContent({
   }, [canEdit, handleMarkdownCheckboxChange]);
 
   const renderLink = useCallback((props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    delete (props as any).node
     return (
       <a {...props} target="_blank" rel="noopener noreferrer">
         {props.children}


### PR DESCRIPTION
While tweeting https://x.com/asleMammadam/status/1857168903899664870 I found out that there's a `node="[object Object]"` on each of the `components` tags.

![image](https://github.com/user-attachments/assets/62eaf65b-0b23-4e0d-b000-3db38133a0c8)

This might be coming from `hast-util-to-jsx-runtime`! cc @wooorm 

https://github.com/syntax-tree/hast-util-to-jsx-runtime/blob/35114f06175ed0d05b16b31b55a54aed9d13862f/lib/index.js#L338-L343 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `node="[object Object]"` from component tags in `note-content.tsx` by deleting `node` from `props` in `renderListItem` and `renderLink`.
> 
>   - **Behavior**:
>     - Removes `node="[object Object]"` from component tags in `note-content.tsx`.
>     - Deletes `node` property from `props` in `renderListItem` and `renderLink` callbacks.
>   - **Functions**:
>     - `renderListItem`: Deletes `node` from `props` before rendering list items.
>     - `renderLink`: Deletes `node` from `props` before rendering links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=alanagoyal%2Falanagoyal&utm_source=github&utm_medium=referral)<sup> for 03df0881f02e78a9e30d37277b907a5e047d2cff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->