### PR TITLE
add sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,29 @@
+import { createClient } from '@/utils/supabase/server'
+import { MetadataRoute } from 'next'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    const supabase = createClient();
+
+    const { data: notes } = await supabase
+        .from('notes')
+        .select('slug, created_at')
+        .eq('public', true)
+        .order('created_at', { ascending: false });
+
+    const notesUrls = notes?.map((note) => ({
+        url: `${process.env.NEXT_PUBLIC_SITE_URL}/notes/${note.slug}`,
+        lastModified: new Date(note.created_at),
+    })) || [];
+
+    return [
+        {
+            url: process.env.NEXT_PUBLIC_SITE_URL!,
+            lastModified: new Date(),
+        },
+        {
+            url: `${process.env.NEXT_PUBLIC_SITE_URL}/notes`,
+            lastModified: new Date(),
+        },
+        ...notesUrls
+    ]
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,7 +20,7 @@ const nextConfig = {
         permanent: false,
       },
       {
-        source: '/:slug((?!notes|api|messages|_next|static|public|favicon.ico).+)',
+        source: '/:slug((?!notes|api|messages|_next|static|public|favicon.ico|sitemap.xml).+)',
         destination: '/notes/:slug',
         permanent: true,
       },

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,0 +1,34 @@
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export function createClient(cookieStore = cookies()) {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value, ...options })
+          } catch (error) {
+            // The `set` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+        remove(name: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value: '', ...options })
+          } catch (error) {
+            // The `delete` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+      },
+    }
+  )
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add sitemap generation using Supabase and update URL rewrites to include sitemap.
> 
>   - **Sitemap**:
>     - Adds `sitemap.ts` to generate a sitemap using Supabase data from the `notes` table.
>     - Includes URLs for the site root, `/notes`, and individual public notes.
>   - **Rewrites**:
>     - Updates `next.config.mjs` to exclude `sitemap.xml` from certain URL rewrites.
>   - **Utilities**:
>     - Adds `server.ts` to `utils/supabase` for creating a Supabase client with cookie management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=alanagoyal%2Falanagoyal&utm_source=github&utm_medium=referral)<sup> for abaabfe981bd7a019ebfb9c447865e63396dbd92. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->