### PR TITLE
Fix sidebar search clear button to use clearSearch function

### DIFF
--- a/components/search.tsx
+++ b/components/search.tsx
@@ -72,7 +72,7 @@ export function SearchBar({
         />
         {searchQuery && (
           <button
-            onClick={() => setSearchQuery("")}
+            onClick={clearSearch}
             className="absolute right-2 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground"
             aria-label="Clear search"
           >


### PR DESCRIPTION
## Summary
- Fixes the sidebar search clear button to call the `clearSearch` function instead of directly setting the search query to an empty string

## Changes

### Components
- **SearchBar**: Updated the clear button's `onClick` handler to use the `clearSearch` function for clearing the search query, ensuring consistent behavior and potential side effects handled by `clearSearch`.

## Test plan
- [x] Verify clicking the clear button clears the search input
- [x] Confirm no regressions in search functionality
- [x] Check that the sidebar resets correctly when clearing the search

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f218d435-ece6-46cb-8642-8a458056dc28