### PR TITLE
Fix search functionality to trim trailing spaces in queries

### DIFF
--- a/components/search.tsx
+++ b/components/search.tsx
@@ -45,8 +45,8 @@ export function SearchBar({
     const filteredNotes = notes.filter(
       (note) =>
         (note.public || note.session_id === sessionId) &&
-        (note.title.toLowerCase().includes(query.toLowerCase()) ||
-          note.content.toLowerCase().includes(query.toLowerCase()))
+        (note.title.toLowerCase().includes(query.trim().toLowerCase()) ||
+          note.content.toLowerCase().includes(query.trim().toLowerCase()))
     );
 
     onSearchResults(filteredNotes);

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,7 +1,7 @@
 import { Note } from "./types";
 
 export function searchNotes(notes: Note[], searchTerm: string, sessionId: string): Note[] {
-    const searchLower = searchTerm.toLowerCase();
+    const searchLower = searchTerm.trim().toLowerCase();
     
     return notes.filter((note) => {
       const isPublic = note.public;


### PR DESCRIPTION
## Summary
- Fixes search functionality to ignore trailing and leading spaces in search queries
- Ensures consistent search behavior by trimming spaces before matching notes

## Changes

### Components
- **SearchBar (components/search.tsx)**: Trimmed whitespace from the search query before converting to lowercase and filtering notes

### Library
- **searchNotes function (lib/search.ts)**: Trimmed whitespace from the search term before converting to lowercase and filtering notes

## Test plan
- [ ] Verify that searching with trailing or leading spaces returns correct results
- [ ] Confirm that search results are consistent with and without extra spaces in the query
- [ ] Test both title and content fields for accurate matching after trimming spaces

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9a75352b-9d61-4bad-b106-db0b50625858