### PR TITLE
Sync note creation dates with UI categories for private notes

### DIFF
--- a/lib/note-utils.ts
+++ b/lib/note-utils.ts
@@ -1,7 +1,64 @@
+function getRandomDateInRange(startDate: Date, endDate: Date): Date {
+  const startTime = startDate.getTime();
+  const endTime = endDate.getTime();
+  const randomTime = startTime + Math.random() * (endTime - startTime);
+  return new Date(randomTime);
+}
+
+function syncNoteDateWithCategory(note: any, category: string): any {
+  if (note.public) {
+    return note;
+  }
+
+  const now = new Date();
+
+  let newDate: Date;
+
+  switch (category) {
+    case "today":
+      newDate = new Date(now);
+      break;
+    case "yesterday":
+      newDate = new Date(now);
+      newDate.setDate(now.getDate() - 1);
+      break;
+    case "7":
+      const sevenDaysAgo = new Date(now);
+      sevenDaysAgo.setDate(now.getDate() - 7);
+      const twoDaysAgo = new Date(now);
+      twoDaysAgo.setDate(now.getDate() - 2);
+      newDate = getRandomDateInRange(sevenDaysAgo, twoDaysAgo);
+      break;
+    case "30":
+      const thirtyDaysAgo = new Date(now);
+      thirtyDaysAgo.setDate(now.getDate() - 30);
+      const eightDaysAgo = new Date(now);
+      eightDaysAgo.setDate(now.getDate() - 8);
+      newDate = getRandomDateInRange(thirtyDaysAgo, eightDaysAgo);
+      break;
+    case "older":
+      const oneYearAgo = new Date(now);
+      oneYearAgo.setFullYear(now.getFullYear() - 1);
+      const thirtyOneDaysAgo = new Date(now);
+      thirtyOneDaysAgo.setDate(now.getDate() - 31);
+      newDate = getRandomDateInRange(oneYearAgo, thirtyOneDaysAgo);
+      break;
+    default:
+      return note;
+  }
+
+  return {
+    ...note,
+    created_at: newDate.toISOString()
+  };
+}
+
 export function groupNotesByCategory(notes: any[], pinnedNotes: Set<string>) {
   const groupedNotes: any = {
     pinned: [],
   };
+
+  const now = new Date();
 
   notes.forEach((note) => {
     if (pinnedNotes.has(note.slug)) {
@@ -12,12 +69,12 @@ export function groupNotesByCategory(notes: any[], pinnedNotes: Set<string>) {
     let category = note.category;
     if (!note.public) {
       const createdDate = new Date(note.created_at);
-      const today = new Date();
-      const yesterday = new Date(today);
+      const today = new Date(now);
+      const yesterday = new Date(now);
       yesterday.setDate(yesterday.getDate() - 1);
-      const sevenDaysAgo = new Date(today);
+      const sevenDaysAgo = new Date(now);
       sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-      const thirtyDaysAgo = new Date(today);
+      const thirtyDaysAgo = new Date(now);
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
       if (createdDate.toDateString() === today.toDateString()) {
@@ -33,10 +90,12 @@ export function groupNotesByCategory(notes: any[], pinnedNotes: Set<string>) {
       }
     }
 
+    const syncedNote = syncNoteDateWithCategory(note, category);
+
     if (!groupedNotes[category]) {
       groupedNotes[category] = [];
     }
-    groupedNotes[category].push(note);
+    groupedNotes[category].push(syncedNote);
   });
 
   return groupedNotes;


### PR DESCRIPTION
## Summary
- Synchronizes the `created_at` date of private notes with their UI category (e.g., today, yesterday, last 7 days, last 30 days, older)
- Ensures note dates reflect the category they belong to for consistent display
- Public notes remain unchanged

## Changes

### Core Functionality
- Added `syncNoteDateWithCategory` function to adjust note creation dates based on category
- Introduced helper `getRandomDateInRange` to generate random dates within specified ranges
- Updated `groupNotesByCategory` to use synced note dates for private notes
- Refactored date calculations to use a single `now` instance for consistency

### Behavior
- Notes categorized as "today" or "yesterday" get exact dates
- Notes in "7" and "30" day categories get random dates within their respective ranges
- Notes in "older" category get random dates between 31 days and 1 year ago
- Public notes are excluded from date modification

## Test plan
- [x] Verify notes in each category have `created_at` dates consistent with their category
- [x] Confirm public notes retain original creation dates
- [x] Check grouping logic remains intact and categories are assigned correctly
- [x] Test edge cases around date boundaries for each category

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d1601e56-3f89-4c30-9658-064122c28507