### PR TITLE
Update note date display based on category

### DIFF
--- a/components/note-header.tsx
+++ b/components/note-header.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Icons } from "./icons";
+import { getDisplayDateByCategory } from "@/lib/note-utils";
 
 export default function NoteHeader({
   note,
@@ -26,10 +27,11 @@ export default function NoteHeader({
   const [formattedDate, setFormattedDate] = useState("");
 
   useEffect(() => {
+    const displayDate = getDisplayDateByCategory(note.category);
     setFormattedDate(
-      format(parseISO(note.created_at), "MMMM d, yyyy 'at' h:mm a")
+      format(displayDate, "MMMM d, yyyy 'at' h:mm a")
     );
-  }, [note.created_at]);
+  }, [note.category]);
 
   const handleEmojiSelect = (emojiObject: any) => {
     const newEmoji = emojiObject.native;

--- a/components/note-item.tsx
+++ b/components/note-item.tsx
@@ -10,6 +10,7 @@ import {
   ContextMenuTrigger,
 } from "./ui/context-menu";
 import { Note } from "@/lib/types";
+import { getDisplayDateByCategory } from "@/lib/note-utils";
 import { Dispatch, SetStateAction } from "react";
 
 function previewContent(content: string): string {
@@ -131,7 +132,7 @@ export function NoteItem({
             }`}
           >
             <span className="text-black dark:text-white">
-              {new Date(item.created_at).toLocaleDateString("en-US")}
+              {getDisplayDateByCategory(item.category).toLocaleDateString("en-US")}
             </span>{" "}
             {previewContent(item.content)}
           </p>

--- a/lib/note-utils.ts
+++ b/lib/note-utils.ts
@@ -49,3 +49,42 @@ export function sortGroupedNotes(groupedNotes: any) {
     );
   });
 }
+
+export function getDisplayDateByCategory(category: string | undefined): Date {
+  const today = new Date();
+
+  switch (category) {
+    case "today":
+      return today;
+
+    case "yesterday":
+      const yesterday = new Date(today);
+      yesterday.setDate(yesterday.getDate() - 1);
+      return yesterday;
+
+    case "7":
+      // Random date 2-7 days ago
+      const daysAgo7 = Math.floor(Math.random() * 6) + 2; // Random between 2-7
+      const date7 = new Date(today);
+      date7.setDate(date7.getDate() - daysAgo7);
+      return date7;
+
+    case "30":
+      // Random date 8-30 days ago
+      const daysAgo30 = Math.floor(Math.random() * 23) + 8; // Random between 8-30
+      const date30 = new Date(today);
+      date30.setDate(date30.getDate() - daysAgo30);
+      return date30;
+
+    case "older":
+      // Random date 31-365 days ago
+      const daysAgoOlder = Math.floor(Math.random() * 335) + 31; // Random between 31-365
+      const dateOlder = new Date(today);
+      dateOlder.setDate(dateOlder.getDate() - daysAgoOlder);
+      return dateOlder;
+
+    default:
+      // Fallback to today if category is undefined or unknown
+      return today;
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,4 +7,5 @@ export interface Note {
     session_id: string;
     emoji?: string;
     public: boolean;
+    category?: string;
   }


### PR DESCRIPTION
## Summary
- Updates note date display logic to show dates based on note category
- Introduces `getDisplayDateByCategory` utility to generate dates for categories like today, yesterday, last 7 days, last 30 days, and older
- Applies this date logic in `NoteHeader` and `NoteItem` components
- Adds optional `category` field to `Note` type

## Changes

### Utility Functions
- Added `getDisplayDateByCategory` in `lib/note-utils.ts` to return a date based on the note's category:
  - "today" returns current date
  - "yesterday" returns one day before current date
  - "7" returns a random date between 2-7 days ago
  - "30" returns a random date between 8-30 days ago
  - "older" returns a random date between 31-365 days ago
  - Defaults to current date if category is undefined or unknown

### Components
- **NoteHeader**:
  - Uses `getDisplayDateByCategory` to format and display the date based on note category instead of created_at timestamp
- **NoteItem**:
  - Displays date using `getDisplayDateByCategory` for the note's category instead of raw created_at date

### Types
- Added optional `category` property to `Note` interface in `lib/types.ts`

## Test plan
- [x] Verify note headers display correct formatted date based on category
- [x] Verify note items show correct localized date based on category
- [x] Confirm fallback to current date for unknown or missing categories
- [x] Check no regressions in emoji selection and note display functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d6ebfb96-e01b-43d7-929a-5801051716c1