### PR TITLE
fix useeffect missing dependency

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -399,6 +399,7 @@ export default function Sidebar({
     handleNoteDelete,
     commandMenuRef,
     goToHighlightedNote,
+    setTheme,
     theme,
   ]);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `setTheme` to `useEffect` dependency array in `components/sidebar.tsx`.
> 
>   - **Fix**:
>     - Add `setTheme` to `useEffect` dependency array in `components/sidebar.tsx` to ensure effect re-runs when `setTheme` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=alanagoyal%2Falanagoyal&utm_source=github&utm_medium=referral)<sup> for f270ce04c1b1877d19fcfbca0719726e469ca4d7. You can [customize](https://app.ellipsis.dev/alanagoyal/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->