### PR TITLE
Fix server client usage in layout

### DIFF
--- a/app/notes/layout.tsx
+++ b/app/notes/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter as FontSans } from "next/font/google";
 import { cn } from "@/lib/utils";
 import { siteConfig } from "@/config/site";
-import { createClient as createBrowserClient } from "@/utils/supabase/client";
+import { createClient } from "@/utils/supabase/server";
 import SidebarLayout from "@/components/sidebar-layout";
 import { Analytics } from "@vercel/analytics/react";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -26,7 +26,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const supabase = createBrowserClient();
+  const supabase = createClient();
   const { data: notes } = await supabase
     .from("notes")
     .select("*")


### PR DESCRIPTION
## Summary
- Fix server/client usage in the notes layout by using the server-side Supabase client
- Prevents browser-only client from running on the server and ensures SSR compatibility

## Changes

### Code
- Import `createClient` from `@/utils/supabase/server` instead of `@/utils/supabase/client`
- Use `createClient()` to instantiate Supabase in `RootLayout`

### Files
- `app/notes/layout.tsx`

## Test plan
- [x] Build passes locally
- [x] Layout loads notes data on server without browser client
- [x] No SSR/browser boundary errors observed
- [x] Lint/TypeScript checks pass



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/dd9d1341-0dee-4a07-a182-fafd59c88389