### PR TITLE
Deduplicate note fetches using React cache

### DIFF
--- a/app/notes/[slug]/page.tsx
+++ b/app/notes/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import Note from "@/components/note";
 import { createClient as createBrowserClient } from "@/utils/supabase/client";
 import { redirect } from "next/navigation";
@@ -6,6 +7,15 @@ import { Note as NoteType } from "@/lib/types";
 
 // Enable ISR with a reasonable revalidation period for public notes
 export const revalidate = 60 * 60; // 1 hour
+
+// Cached function to fetch a note by slug - eliminates duplicate fetches
+const getNote = cache(async (slug: string) => {
+  const supabase = createBrowserClient();
+  const { data: note } = await supabase.rpc("select_note", {
+    note_slug_arg: slug,
+  }).single() as { data: NoteType | null };
+  return note;
+});
 
 // Dynamically determine if this is a user note
 export async function generateStaticParams() {
@@ -28,15 +38,15 @@ export async function generateMetadata({
 }: {
   params: { slug: string };
 }): Promise<Metadata> {
-  const supabase = createBrowserClient();
   const slug = params.slug.replace(/^notes\//, '');
+  const note = await getNote(slug);
 
-  const { data: note } = await supabase.rpc("select_note", {
-    note_slug_arg: slug,
-  }).single() as { data: NoteType | null };
+  if (!note) {
+    return { title: "Note not found" };
+  }
 
-  const title = note?.title || "new note";
-  const emoji = note?.emoji || "👋🏼";
+  const title = note.title || "new note";
+  const emoji = note.emoji || "👋🏼";
 
   return {
     title: `alana goyal | ${title}`,
@@ -55,12 +65,8 @@ export default async function NotePage({
 }: {
   params: { slug: string };
 }) {
-  const supabase = createBrowserClient();
   const slug = params.slug.replace(/^notes\//, '');
-
-  const { data: note } = await supabase.rpc("select_note", {
-    note_slug_arg: slug,
-  }).single();
+  const note = await getNote(slug);
 
   if (!note) {
     return redirect("/notes/error");


### PR DESCRIPTION
## Summary
- Introduces a React cache-powered fetch for notes and reuses it in both metadata generation and page rendering to prevent duplicate RPC calls.

## Changes
### Core Functionality
- Added a cached getNote(slug) function using React cache to fetch a note via Supabase RPC and cache concurrent calls.

### Data Fetching
- Replaced inline RPC fetches in generateMetadata and NotePage with getNote to avoid duplicate requests.

### ISR / Caching
- ISR revalidation remains at 1 hour (60 * 60).

### Type Safety
- Utilizes NoteType; gracefully handles null results by returning a "Note not found" title in metadata.

## How it works
- On the server, the first call to getNote(slug) fires the RPC; subsequent concurrent calls with the same slug reuse the same fetch, preventing duplicate requests within the same render path.

## Tests
- [ ] Build succeeds locally and app runs.
- [ ] Metadata shows correct title and emoji for existing notes.
- [ ] Not-found slug returns a metadata title of "Note not found".
- [ ] No duplicate RPC calls observed when page renders and metadata resolves.

## Notes
- caching is scoped to the server render/request boundary; no cross-request persistence is introduced. The changes aim to reduce redundant RPC calls and improve render performance without altering public APIs.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c74b1399-120f-4464-adff-8f6405077ae7