### PR TITLE
Apply responsive typography for note UI at md breakpoint

### DIFF
--- a/components/note-content.tsx
+++ b/components/note-content.tsx
@@ -93,7 +93,7 @@ export default function NoteContent({
         />
       ) : (
         <div
-          className="h-full text-base"
+          className="h-full text-base md:text-sm"
           onClick={(e) => {
             if (canEdit && !note.public) {
               setIsEditing(true);

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex h-full w-full rounded-md bg-background text-base placeholder:text-muted-foreground focus:outline-none",
+          "flex h-full w-full rounded-md bg-background text-base md:text-sm placeholder:text-muted-foreground focus:outline-none",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- Adds responsive font sizing to improve readability across breakpoints by applying a smaller text size on medium screens and up.
- Changes affect only styling; no functional changes implemented.

## Changes

### UI/Typography
- **Note content**: In `components/note-content.tsx`, non-editing note container now uses `className="h-full text-base md:text-sm"` to apply a smaller text size on medium screens and above.
- **Textarea**: In `components/ui/textarea.tsx`, textarea styling now includes `md:text-sm`, resulting in smaller text on medium and larger viewports while keeping mobile default as base size.

## Rationale
- Improves readability and layout across larger viewports by preventing overly long lines and maintaining comfortable text sizing. Maintains a larger base size on mobile for readability while tightening typography on larger screens.

## Tests
- [x] Verify on mobile widths (sm) that text remains at the base size.
- [x] Resize to md and above to confirm text size switches to small (`text-sm`).
- [x] Ensure no layout shifts or overflow in note content and textarea at different breakpoints.
- [x] Confirm no functional changes in editing behavior or interactions.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8f7ff887-1171-4510-8e2c-032df333e501