### PR TITLE
Load all notes instantly to prevent layout shift

### DIFF
--- a/app/notes/layout.tsx
+++ b/app/notes/layout.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/utils/supabase/server";
 import SidebarLayout from "@/components/sidebar-layout";
 import { Analytics } from "@vercel/analytics/react";
 import { ThemeProvider } from "@/components/theme-provider";
+import { cookies } from "next/headers";
 import "./globals.css";
 
 const fontSans = FontSans({
@@ -27,10 +28,26 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const supabase = createClient();
-  const { data: notes } = await supabase
+  const cookieStore = await cookies();
+  const sessionId = cookieStore.get("session_id")?.value;
+
+  // Fetch public notes
+  const { data: publicNotes } = await supabase
     .from("notes")
     .select("*")
     .eq("public", true);
+
+  // Fetch private notes if we have a session ID
+  let sessionNotes: any[] = [];
+  if (sessionId) {
+    const { data } = await supabase.rpc("select_session_notes", {
+      session_id_arg: sessionId,
+    });
+    sessionNotes = data || [];
+  }
+
+  // Combine both sets of notes
+  const notes = [...(publicNotes || []), ...sessionNotes];
 
   return (
     <html lang="en" suppressHydrationWarning>
@@ -56,7 +73,7 @@ export default async function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <SidebarLayout notes={notes}>
+          <SidebarLayout notes={notes} sessionId={sessionId} sessionNotes={sessionNotes}>
             <Analytics />
             {children}
           </SidebarLayout>

--- a/app/notes/session-notes.tsx
+++ b/app/notes/session-notes.tsx
@@ -28,12 +28,16 @@ export const SessionNotesContext = createContext<SessionNotes>({
 
 export function SessionNotesProvider({
   children,
+  initialSessionId = "",
+  initialNotes = [],
 }: {
   children: React.ReactNode;
+  initialSessionId?: string;
+  initialNotes?: any[];
 }) {
   const supabase = useMemo(() => createBrowserClient(), []);
-  const [sessionId, setSessionId] = useState<string>("");
-  const [notes, setNotes] = useState<any[]>([]);
+  const [sessionId, setSessionId] = useState<string>(initialSessionId);
+  const [notes, setNotes] = useState<any[]>(initialNotes);
 
   const refreshSessionNotes = useCallback(async () => {
     if (sessionId) {

--- a/components/session-id.tsx
+++ b/components/session-id.tsx
@@ -7,12 +7,35 @@ interface SessionIdProps {
   setSessionId: (id: string) => void;
 }
 
+function getCookie(name: string): string | undefined {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(';').shift();
+}
+
+function setCookie(name: string, value: string, days: number = 365) {
+  const expires = new Date();
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
+  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Lax`;
+}
+
 export default function SessionId({ setSessionId }: SessionIdProps) {
   useEffect(() => {
-    const currentSessionId = localStorage.getItem("session_id") || uuidv4();
+    // Try to get from cookie first, then localStorage as fallback for migration
+    let currentSessionId = getCookie("session_id");
+
+    if (!currentSessionId) {
+      // Check localStorage for existing session (migration path)
+      currentSessionId = localStorage.getItem("session_id") || uuidv4();
+      // Store in cookie
+      setCookie("session_id", currentSessionId);
+    }
+
+    // Also keep localStorage in sync for now
     if (!localStorage.getItem("session_id")) {
       localStorage.setItem("session_id", currentSessionId);
     }
+
     setSessionId(currentSessionId);
   }, [setSessionId]);
 

--- a/components/sidebar-layout.tsx
+++ b/components/sidebar-layout.tsx
@@ -11,9 +11,11 @@ import Sidebar from "./sidebar";
 interface SidebarLayoutProps {
   children: React.ReactNode;
   notes: any;
+  sessionId?: string;
+  sessionNotes?: any[];
 }
 
-export default function SidebarLayout({ children, notes }: SidebarLayoutProps) {
+export default function SidebarLayout({ children, notes, sessionId = "", sessionNotes = [] }: SidebarLayoutProps) {
   const isMobile = useMobileDetect();
   const router = useRouter();
   const pathname = usePathname();
@@ -35,7 +37,7 @@ export default function SidebarLayout({ children, notes }: SidebarLayoutProps) {
   const showSidebar = !isMobile || pathname === "/notes";
 
   return (
-    <SessionNotesProvider>
+    <SessionNotesProvider initialSessionId={sessionId} initialNotes={sessionNotes}>
       <div className="dark:text-white h-dvh flex">
         {showSidebar && (
           <Sidebar

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -104,8 +104,16 @@ export default function Sidebar({
     refreshSessionNotes,
   } = useContext(SessionNotesContext);
 
+  // Notes are already combined from server, but we still need to merge
+  // with any new session notes that were created after initial load
   const notes = useMemo(
-    () => [...publicNotes, ...sessionNotes],
+    () => {
+      // Create a set of IDs from publicNotes to avoid duplicates
+      const publicNoteIds = new Set(publicNotes.map((note: any) => note.id));
+      // Only add session notes that aren't already in publicNotes
+      const newSessionNotes = sessionNotes.filter((note: any) => !publicNoteIds.has(note.id));
+      return [...publicNotes, ...newSessionNotes];
+    },
     [publicNotes, sessionNotes]
   );
 


### PR DESCRIPTION
## Summary
- Fetches both public notes and session-scoped notes on the server and provides them to the UI upfront to prevent layout shift when the notes panel renders.
- Introduces session_id management via cookies with a migration path from localStorage, ensuring a stable session across reloads.
- Dedupe notes in the sidebar to avoid duplicates when merging public and session notes.

## Changes
### Server-Side / Data Fetching
- app/notes/layout.tsx
  - Fetch public notes
  - If a session exists (via cookie), fetch session notes via RPC select_session_notes
  - Combine notes and pass as initial data to SidebarLayout

### State Initialization
- app/notes/session-notes.tsx
  - SessionNotesProvider now accepts initialSessionId and initialNotes to hydrate state from server

### Client Session ID Management
- components/session-id.tsx
  - Add cookie helpers (getCookie/setCookie)
  - On mount, read session_id from cookie; fallback to localStorage for migration
  - Sync cookie and localStorage

### Sidebar Composition
- components/sidebar-layout.tsx
  - Accept sessionId and sessionNotes props and forward to SessionNotesProvider

- components/sidebar.tsx
  - Merge publicNotes with sessionNotes without duplicating by id

## Why this helps
- By loading both public and session notes up-front, the layout has all necessary data available during initial render, eliminating layout shifts as notes populate.
- Cookie-based session_id ensures consistent session tracking across navigations and reloads, with a migration path from localStorage for existing users.

## Test plan
- [x] Load the notes page and verify the sidebar renders without layout shift, showing both public and session notes.
- [x] Refresh/reload to confirm session_id persists via cookies and is used to fetch session notes.
- [x] Verify that notes are deduplicated in the sidebar when public and session notes share IDs.
- [x] Confirm that initial session notes hydrate correctly in SessionNotesProvider and are reflected in the UI.
- [x] Ensure no regressions in existing note interactions (e.g., selecting, filtering) after the changes.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f26e2357-b573-46da-b4ed-3d38eb40d7e3