### PR TITLE
Optimize website load and sidebar performance

### DIFF
--- a/app/api/notes/public/route.ts
+++ b/app/api/notes/public/route.ts
@@ -1,0 +1,35 @@
+import { createClient } from "@/utils/supabase/server";
+import { NextResponse } from "next/server";
+
+export const revalidate = 86400; // 24 hours
+
+export async function GET() {
+  try {
+    const supabase = createClient();
+    const { data: notes, error } = await supabase
+      .from("notes")
+      .select("*")
+      .eq("public", true)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      console.error("Error fetching public notes:", error);
+      return NextResponse.json(
+        { error: "Failed to fetch public notes" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(notes || [], {
+      headers: {
+        "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=172800",
+      },
+    });
+  } catch (error) {
+    console.error("Error in public notes API:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/notes/[slug]/page.tsx
+++ b/app/notes/[slug]/page.tsx
@@ -20,15 +20,21 @@ const getNote = cache(async (slug: string) => {
 
 // Dynamically determine if this is a user note
 export async function generateStaticParams() {
-  const supabase = createBrowserClient();
-  const { data: posts } = await supabase
-    .from("notes")
-    .select("slug")
-    .eq("public", true);
+  // Skip static generation if no Supabase credentials available
+  try {
+    const supabase = createBrowserClient();
+    const { data: posts } = await supabase
+      .from("notes")
+      .select("slug")
+      .eq("public", true);
 
-  return posts!.map(({ slug }) => ({
-    slug,
-  }));
+    return posts?.map(({ slug }) => ({
+      slug,
+    })) || [];
+  } catch (error) {
+    console.log("Skipping static generation, will use dynamic rendering");
+    return [];
+  }
 }
 
 // Use dynamic rendering for non-public notes

--- a/app/notes/layout.tsx
+++ b/app/notes/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Inter as FontSans } from "next/font/google";
 import { cn } from "@/lib/utils";
 import { siteConfig } from "@/config/site";
-import { createClient } from "@/utils/supabase/server";
 import SidebarLayout from "@/components/sidebar-layout";
 import { Analytics } from "@vercel/analytics/react";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -19,19 +18,11 @@ export const metadata: Metadata = {
   description: siteConfig.title,
 };
 
-export const revalidate = 86400; // 24 hours
-
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const supabase = createClient();
-  const { data: notes } = await supabase
-    .from("notes")
-    .select("*")
-    .eq("public", true);
-
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -56,7 +47,7 @@ export default async function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <SidebarLayout notes={notes}>
+          <SidebarLayout>
             <Analytics />
             {children}
           </SidebarLayout>

--- a/components/sidebar-layout.tsx
+++ b/components/sidebar-layout.tsx
@@ -10,10 +10,9 @@ import Sidebar from "./sidebar";
 
 interface SidebarLayoutProps {
   children: React.ReactNode;
-  notes: any;
 }
 
-export default function SidebarLayout({ children, notes }: SidebarLayoutProps) {
+export default function SidebarLayout({ children }: SidebarLayoutProps) {
   const isMobile = useMobileDetect();
   const router = useRouter();
   const pathname = usePathname();
@@ -39,7 +38,6 @@ export default function SidebarLayout({ children, notes }: SidebarLayoutProps) {
       <div className="dark:text-white h-dvh flex">
         {showSidebar && (
           <Sidebar
-            notes={notes}
             onNoteSelect={isMobile ? handleNoteSelect : () => {}}
             isMobile={isMobile}
           />

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -40,17 +40,17 @@ const labels = {
 const categoryOrder = ["pinned", "today", "yesterday", "7", "30", "older"];
 
 export default function Sidebar({
-  notes: publicNotes,
   onNoteSelect,
   isMobile,
 }: {
-  notes: any[];
   onNoteSelect: (note: any) => void;
   isMobile: boolean;
 }) {
   const router = useRouter();
   const supabase = createClient();
 
+  const [publicNotes, setPublicNotes] = useState<any[]>([]);
+  const [isLoadingPublicNotes, setIsLoadingPublicNotes] = useState(true);
   const [isScrolled, setIsScrolled] = useState(false);
   const [selectedNoteSlug, setSelectedNoteSlug] = useState<string | null>(null);
   const [pinnedNotes, setPinnedNotes] = useState<Set<string>>(new Set());
@@ -67,6 +67,25 @@ export default function Sidebar({
   );
   const [highlightedNote, setHighlightedNote] = useState<Note | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+
+  // Fetch public notes client-side
+  useEffect(() => {
+    const fetchPublicNotes = async () => {
+      try {
+        const response = await fetch("/api/notes/public");
+        if (response.ok) {
+          const data = await response.json();
+          setPublicNotes(data);
+        }
+      } catch (error) {
+        console.error("Error fetching public notes:", error);
+      } finally {
+        setIsLoadingPublicNotes(false);
+      }
+    };
+
+    fetchPublicNotes();
+  }, []);
 
   const commandMenuRef = useRef<{ setOpen: (open: boolean) => void } | null>(
     null


### PR DESCRIPTION
## Summary
- Offloads public notes data fetching from server-side rendering to client-side to reduce initial payload and SSR time.
- Introduces a dedicated API route with caching for public notes.
- Streamlines notes layout and sidebar components to decouple heavy data loading from SSR.

## Changes
- Added: app/api/notes/public/route.ts to fetch public notes with 24h revalidate and cache headers.
- Removed: Server-side fetching of public notes from app/notes/layout.tsx; Root layout no longer fetches notes or passes to SidebarLayout.
- Updated: app/notes/[slug]/page.tsx to gracefully handle absence of Supabase credentials in generateStaticParams; non-public notes render dynamically.
- Updated: app/components/sidebar-layout.tsx to stop accepting notes prop; Sidebar now operates independently.
- Updated: app/components/sidebar.tsx to fetch public notes client-side via /api/notes/public and manage loading state.
- Minor compatibility adjustments to preserve existing behavior for note selection.

## Why
- Reduces initial HTML payload and server load, improving TTFB and perceived performance.
- Allows the sidebar to load public notes after page render, improving responsiveness on slower networks.
- Caches public notes at the edge for up to 24 hours, reducing repeated database calls.

## Performance considerations
- Client-side fetch may show a brief loading state for public notes until the API responds.
- API route leverages Cache-Control with s-maxage and stale-while-revalidate to optimize caching.

## How to test
- Run the app and load pages; verify public notes appear in the sidebar and initial page load is faster due to reduced SSR data.
- Inspect the API response headers for Cache-Control: public, s-maxage=86400, stale-while-revalidate=172800.
- Test with and without Supabase credentials to ensure generateStaticParams falls back gracefully and dynamic rendering kicks in for non-public notes.
- Ensure no regressions in navigation or note selection flow.

## Notes
- No schema changes required. If you rely on any SSR-only expectations for public notes, update to the client-side fetch flow accordingly.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3474c508-19ae-44f2-81b7-0e8cc50f575f