### PR TITLE
Memoize NoteItem to reduce re-renders

### DIFF
--- a/components/note-item.tsx
+++ b/components/note-item.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { useSwipeable } from "react-swipeable";
 import { useMobileDetect } from "@/components/mobile-detector";
@@ -39,7 +39,7 @@ interface NoteItemProps {
   showDivider?: boolean;
 }
 
-export function NoteItem({
+export const NoteItem = React.memo(function NoteItem({
   item,
   selectedNoteSlug,
   sessionId,
@@ -205,4 +205,4 @@ export function NoteItem({
       </ContextMenu>
     );
   }
-}
+});


### PR DESCRIPTION
## Summary
- Memoizes the NoteItem component to prevent unnecessary re-renders
- Exports a memoized component while preserving existing behavior and UI
- No user-facing changes expected

## Changes

### Core Functionality
- Wraps NoteItem with React.memo to skip re-renders when props haven't changed

### Code Quality
- Updates import to include React since React.memo is used
- Re-exports the memoized component: `export const NoteItem = React.memo(function NoteItem({ ... }) { ... })`
- Maintains existing component structure and behavior; only memoization added

### Performance
- Reduces render churn for NoteItem when parent components re-render without changing NoteItem props

## Test plan
- [x] Ensure UI remains visually unchanged
- [x] Verify NoteItem does not re-render when parent re-renders with unchanged props (use render-count checks in dev tools)
- [x] Validate interactions (swipe gestures, context menu, links) still function correctly
- [x] Check TypeScript types compile with the memoized export

**Note:** React.memo uses shallow prop comparison. If you pass new object references on every render, re-renders will still occur. Consider stabilizing prop references if needed in the future.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/434f2b85-75ec-4855-a1c3-40407baf81b0