### PR TITLE
Optimize date calculations in groupNotesByCategory

### DIFF
--- a/lib/note-utils.ts
+++ b/lib/note-utils.ts
@@ -3,6 +3,15 @@ export function groupNotesByCategory(notes: any[], pinnedNotes: Set<string>) {
     pinned: [],
   };
 
+  // Calculate date boundaries once before the loop
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const sevenDaysAgo = new Date(today);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const thirtyDaysAgo = new Date(today);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
   notes.forEach((note) => {
     if (pinnedNotes.has(note.slug)) {
       groupedNotes.pinned.push(note);
@@ -12,13 +21,6 @@ export function groupNotesByCategory(notes: any[], pinnedNotes: Set<string>) {
     let category = note.category;
     if (!note.public) {
       const createdDate = new Date(note.created_at);
-      const today = new Date();
-      const yesterday = new Date(today);
-      yesterday.setDate(yesterday.getDate() - 1);
-      const sevenDaysAgo = new Date(today);
-      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-      const thirtyDaysAgo = new Date(today);
-      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
       if (createdDate.toDateString() === today.toDateString()) {
         category = "today";


### PR DESCRIPTION
## Summary
- Precompute common date boundaries (today, yesterday, 7 days ago, 30 days ago) before iterating notes in `groupNotesByCategory`.
- Remove redundant date calculations inside the loop to minimize Date object allocations.

## Changes

### Core Functionality
- Compute and reuse date boundaries at the start of `groupNotesByCategory` so all subsequent logic uses the same reference points.
- Eliminate per-note recreation of date boundary values, ensuring consistency across notes.

### Performance
- Reduces per-note Date object allocations, improving performance for large sets of notes.

### Code Quality
- Centralizes and clarifies date boundary logic, reducing in-loop boilerplate and potential drift.

## Test plan
- [x] Run existing unit tests to ensure behavior remains unchanged.
- [x] Manual QA: verify notes are categorized correctly (today, yesterday, last 7 days, last 30 days, older) and that pinned notes are unaffected.
- [x] Confirm no API changes and no regressions in note grouping logic.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/159ca00d-8a5e-4875-b936-3bd3c2b30ee0