### PR TITLE
Optimize note refresh by updating local notes instead of full refresh

### DIFF
--- a/app/notes/session-notes.tsx
+++ b/app/notes/session-notes.tsx
@@ -17,6 +17,7 @@ export interface SessionNotes {
   notes: any[];
   setSessionId: (sessionId: string) => void;
   refreshSessionNotes: () => Promise<void>;
+  updateSessionNote: (noteId: string, updates: Partial<any>) => void;
 }
 
 export const SessionNotesContext = createContext<SessionNotes>({
@@ -24,6 +25,7 @@ export const SessionNotesContext = createContext<SessionNotes>({
   notes: [],
   setSessionId: () => {},
   refreshSessionNotes: async () => {},
+  updateSessionNote: () => {},
 });
 
 export function SessionNotesProvider({
@@ -42,6 +44,14 @@ export function SessionNotesProvider({
     }
   }, [supabase, sessionId]);
 
+  const updateSessionNote = useCallback((noteId: string, updates: Partial<any>) => {
+    setNotes((prevNotes) =>
+      prevNotes.map((note) =>
+        note.id === noteId ? { ...note, ...updates } : note
+      )
+    );
+  }, []);
+
   useEffect(() => {
     refreshSessionNotes();
   }, [refreshSessionNotes, sessionId, supabase]);
@@ -53,6 +63,7 @@ export function SessionNotesProvider({
         notes,
         setSessionId,
         refreshSessionNotes,
+        updateSessionNote,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Reduces redundant queries by updating notes locally and revalidating ISR cache instead of performing full refresh calls after each save.
- Adds updateSessionNote to SessionNotesContext and propagates to components.

## Changes
- SessionNotesContext and provider
  - Added updateSessionNote(noteId, updates) to context interface
  - Implemented updateSessionNote using useCallback to merge updates into the corresponding note in state
  - Passed updateSessionNote down via Provider

- Note component
  - Replaced usage of refreshSessionNotes/router.refresh with updateSessionNote call after saving updates
  - Retains ISR cache revalidation via /notes/revalidate for public notes
  - Removed direct dependency on refreshSessionNotes from dependencies list; added updateSessionNote

## Why
- Improves performance by avoiding extra DB queries and full note refreshes on every save; updates are applied locally and synced to ISR cache as needed.

## How to test
- Open a session with notes; edit a note and save:
  - The note should update immediately in the UI without triggering a full refresh
  - Public notes ISR endpoint revalidates (verify network call to /notes/revalidate)
- Verify existing flows still work:
  - Creating/updating multiple notes; refreshing the session on initial load still works
- Ensure no TypeScript errors by building the project

## Notes
- No user-facing changes beyond improved performance; data consistency maintained by local update merged with server refresh via ISR.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/077b15e3-4031-4a20-9458-6d3bc95a2f6e