### PR TITLE
Ignore image markdown in sidebar note previews

### DIFF
--- a/components/note-item.tsx
+++ b/components/note-item.tsx
@@ -15,6 +15,7 @@ import { Dispatch, SetStateAction } from "react";
 
 function previewContent(content: string): string {
   return content
+    .replace(/!\[([^\]]*)\]\([^\)]+\)/g, "")
     .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
     .replace(/\[[ x]\]/g, "")
     .replace(/[#*_~`>+\-]/g, "")


### PR DESCRIPTION
## Summary
- Ignores image markdown syntax in sidebar previews to prevent broken rendering

## Changes

### Core Functionality
- In `components/note-item.tsx`, updated `previewContent` to strip image markdown using regex: `.replace(/!\[[^\]]*\]\([^\)]+\)/g, "")`

### Behaviour
- Sidebar previews now display plain text content without image references
- Other markdown (links, emphasis, etc.) remains unaffected

## Test plan
- [x] Create notes containing image markdown (e.g., `![alt](url)`) and verify sidebar preview shows text without the image syntax
- [x] Ensure links and other formatting still render correctly in previews
- [x] Verify no regressions in note content rendering elsewhere

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/87c6fe84-83d7-4481-bfbe-bc47c25cff78