### PR TITLE
Add nested bullets support with tab indentation in notes

### DIFF
--- a/app/notes/styles/github-markdown.css
+++ b/app/notes/styles/github-markdown.css
@@ -59,14 +59,30 @@
   margin-bottom: 16px;
 }
 
+/* Nested bullet styling with different markers */
+.markdown-body ul ul {
+  list-style-type: circle;
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
+}
+
+.markdown-body ul ul ul {
+  list-style-type: square;
+}
+
 .markdown-body ul.contains-task-list {
   list-style-type: none;
   padding-left: 0;
 }
 
+/* Nested task lists should have indentation */
+.markdown-body ul.contains-task-list ul.contains-task-list {
+  padding-left: 2em;
+}
+
 .markdown-body .task-list-item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 0.5em;
 }
 


### PR DESCRIPTION
## Summary
- Adds nested bullet styling and keyboard indentation in the notes editor
- Improves nested task list indentation and marker behavior

## Changes
### Styling
- Update GitHub Markdown styles to render nested bullets with distinct markers:
  - Nested ul ul uses circle markers
  - Nested ul ul ul uses square markers
- Add indentation rules for nested task lists using `.contains-task-list` classes
- Align `.task-list-item` to flex-start for better multi-line alignment

### Editor behavior
- Add handleKeyDown in `components/note-content.tsx` to support Tab and Shift+Tab:
  - Tab indents the current line by two spaces
  - Shift+Tab outdents the current line (up to removing two spaces or a single tab/space)
  - Cursor position is preserved after indentation changes
- Attach `onKeyDown` to the note textarea so these controls are active while editing

### Accessibility & UX
- Keeps existing editing flow intact for non-indented lines while improving navigation for nested lists

## How to test
- Edit a note containing nested bullets (e.g., - A; - - B; - - - C) and use Tab on a line to indent:
  - Top level: marker remains a dash
  - First nested level shows circle markers
  - Second nested level shows square markers
- Use Shift+Tab to outdent and verify the nesting level decreases accordingly; ensure the caret stays in the expected position
- Verify indentation works for nested task lists and that styling reflects the new markers
- Ensure non-bullet lines remain unaffected by Tab/Shift+Tab

## Notes
- All changes are scoped to the note editing UI and Markdown rendering styles; no changes to core data models or external APIs

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/55914196-e9a2-4178-9068-cb7fb9c44bb8