### PR TITLE
Fix client-side error by removing then() after router.push

### DIFF
--- a/lib/create-note.ts
+++ b/lib/create-note.ts
@@ -40,10 +40,9 @@ export async function createNote(
         router.refresh();
       });
     } else {
-      router.push(`/notes/${slug}`).then(() => {
-        refreshSessionNotes();
-        setSelectedNoteSlug(slug);
-      });
+      router.push(`/notes/${slug}`);
+      refreshSessionNotes();
+      setSelectedNoteSlug(slug);
     }
 
     toast({


### PR DESCRIPTION
## Summary
- Fixes a client-side error when creating a new note by removing the then() chain after router.push and performing follow-up actions immediately.
- Ensures the UI state (session notes and selected note) is updated reliably after navigation.

## Changes
### Core Logic
- lib/create-note.ts: In the note creation success path, replaced:
  router.push(`/notes/${slug}`).then(() => {
    refreshSessionNotes();
    setSelectedNoteSlug(slug);
  });
  with:
  router.push(`/notes/${slug}`);
  refreshSessionNotes();
  setSelectedNoteSlug(slug);

### Rationale
- The previous then() could race with the route transition, leading to inconsistent UI state or client-side errors. Updating state immediately after initiating navigation ensures consistent behavior.

## Impact
- No changes to the public API.
- Fixes the client-side error observed when creating a new note.

## Test plan
- [x] Create a new note and verify navigation to /notes/{slug}
- [x] Confirm refreshSessionNotes is invoked
- [x] Confirm setSelectedNoteSlug is called with the correct slug
- [x] Observe no client-side error during the flow

## Notes
- If future navigation sequencing becomes tricky, consider using await router.push(...) (if supported) for explicit flow control.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/cd4d43d0-cfd0-4531-9027-92d40a363b34