### PR TITLE
Persist desktop window layout in localStorage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ read before building, update when you ship:
 
 ## conventions
 
-- **state persistence**: sessionStorage for view state, localStorage only for user-created content. window close clears view state via `clearAppState()` automatically
+- **state persistence**: sessionStorage for per-tab view state, localStorage for durable content/preferences and desktop window layout. window close clears view state via `clearAppState()` automatically
 - **window management**: `useWindowManager()` for operations, `useWindowFocus()` for focus state
 - **desktop vs mobile**: use `isMobileView` / `isDesktop` prop, never raw viewport queries
 - **hover states**: gate hover-only styles with Tailwind's `can-hover:` variant so touch devices never get sticky hover treatments

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -441,9 +441,9 @@ const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
 
 | Tier | Storage | Lifetime | Use Case |
 |------|---------|----------|----------|
-| **View/runtime state** | `sessionStorage` | Per-tab, clears on tab close | Sidebar selection, scroll position, window positions, dock scale, recents, terminal history |
+| **View/runtime state** | `sessionStorage` | Per-tab, clears on tab close | Sidebar selection, scroll position, dock scale, recents, terminal history |
 | **Session cache/runtime buffers** | `sessionStorage` | Per-tab, clears on tab close | API/UI caches and in-progress runtime state (e.g., GitHub cache, music playback queue/progress, Notes pinned ordering) |
-| **Durable data + preferences** | `localStorage` | Persistent, shared across tabs | User-created content and user preferences that should survive restarts (notes/messages data, settings, sound prefs) |
+| **Durable data + preferences** | `localStorage` | Persistent, shared across tabs | User-created content, user preferences, and desktop window layout that should survive restarts (notes/messages data, settings, sound prefs, window positions/order) |
 
 Rule of thumb: if losing it on browser restart is acceptable, use `sessionStorage`. If users expect it to persist (content or preferences), use `localStorage`.
 
@@ -451,7 +451,7 @@ Rule of thumb: if losing it on browser restart is acceptable, use `sessionStorag
 
 1. **Close = clear**: When a window is closed (red button or Cmd+Q), its view state is cleared via `clearAppState(appId)`.
 2. **Minimize = preserve**: Minimized windows keep their state in memory. Unminimizing restores exactly where the user left off.
-3. **No cross-window leaking**: Using `sessionStorage` ensures two browser tabs have independent state.
+3. **Window layout is shared across tabs**: Desktop window state lives in `localStorage`, so multiple tabs can overwrite each other's saved layout.
 4. **Mixed persistence for list apps**: Persist user-managed collections in `localStorage`, but keep active selection/sort/filter/navigation in `sessionStorage`.
 5. **Ephemeral caches belong in session storage**: Network caches and runtime buffers should use `sessionStorage` unless there's a product requirement for cross-session persistence.
 
@@ -488,7 +488,7 @@ When creating a new app, ensure:
 - [ ] Responsive patterns use `isMobileView` prop
 - [ ] ScrollArea used for scrollable content
 - [ ] If app has text inputs, add Escape handler to blur (enables `q` to quit)
-- [ ] View/runtime/cache state uses `sessionStorage` (not `localStorage`) — via `sidebar-persistence.ts` where possible
+- [ ] View/runtime/cache state uses `sessionStorage` (not `localStorage`) unless it is intentionally durable desktop layout state
 - [ ] Durable user content/preferences use `localStorage` and should not be cleared on app close
 - [ ] `clearAppState()` has a case for this app's ID
 - [ ] No manual `clear*Storage()` calls in nav bars or menu bar — handled automatically by `closeWindow`/`closeApp`

--- a/lib/window-context.tsx
+++ b/lib/window-context.tsx
@@ -192,7 +192,7 @@ function focusTopmostWindowForApp(savedState: WindowManagerState, appId: string)
 function loadStateFromStorage(): WindowManagerState | null {
   if (typeof window === "undefined") return null;
   try {
-    const saved = sessionStorage.getItem(STORAGE_KEY);
+    const saved = localStorage.getItem(STORAGE_KEY);
     if (saved) {
       const parsed = JSON.parse(saved);
       // Validate structure
@@ -222,7 +222,7 @@ function loadStateFromStorage(): WindowManagerState | null {
 function saveSerializedStateToStorage(serializedState: string): void {
   if (typeof window === "undefined") return;
   try {
-    sessionStorage.setItem(STORAGE_KEY, serializedState);
+    localStorage.setItem(STORAGE_KEY, serializedState);
   } catch (e) {
     console.error("Failed to save window state:", e);
   }
@@ -231,7 +231,7 @@ function saveSerializedStateToStorage(serializedState: string): void {
 /**
  * Get the topmost (highest z-index) open window for a specific app
  * Used by MobileShell to display the correct window when switching from desktop
- * Reads directly from sessionStorage to work outside WindowManagerProvider
+ * Reads directly from localStorage to work outside WindowManagerProvider
  */
 export function getTopmostWindowForApp(appId: string): WindowState | null {
   const savedState = loadStateFromStorage();
@@ -872,7 +872,7 @@ export function WindowManagerProvider({
   const lastPersistedStateRef = React.useRef<string | null>(null);
   /**
    * Compute initial state based on:
-   * 1. Whether user has saved state (sessionStorage)
+   * 1. Whether user has saved state (localStorage)
    * 2. Which app they're navigating to (initialAppId)
    *
    * Logic:
@@ -937,7 +937,7 @@ export function WindowManagerProvider({
     latestStateRef.current = state;
   }, [state]);
 
-  // Debounce session persistence to avoid excessive writes during drag/resize
+  // Debounce local persistence to avoid excessive writes during drag/resize
   useEffect(() => {
     if (!isHydrated) return;
 


### PR DESCRIPTION
## Summary
- persist desktop window manager state in localStorage instead of sessionStorage
- update storage-policy docs to reflect that window layout is now durable and shared across tabs
- keep close-window behavior intact so closed windows stay closed across reloads

## Testing
- npm run build