### PR TITLE
Persist Low Power Mode in the Battery menu

### DIFF
--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -19,6 +19,8 @@ import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 
 type OpenMenu = "apple" | "appMenu" | "fileMenu" | "battery" | "wifi" | "controlCenter" | "notificationCenter" | null;
 
+const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
+
 interface MenuBarProps {
   onOpenSettings?: () => void;
   onOpenWifiSettings?: () => void;
@@ -49,6 +51,18 @@ export function MenuBar({
   const [currentTime, setCurrentTime] = useState<string>("");
   const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
   const [aboutDialogOpen, setAboutDialogOpen] = useState(false);
+  const [lowPowerMode, setLowPowerMode] = useState(false);
+  const [hasLoadedLowPowerMode, setHasLoadedLowPowerMode] = useState(false);
+
+  useEffect(() => {
+    setLowPowerMode(window.localStorage.getItem(LOW_POWER_MODE_STORAGE_KEY) === "true");
+    setHasLoadedLowPowerMode(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hasLoadedLowPowerMode) return;
+    window.localStorage.setItem(LOW_POWER_MODE_STORAGE_KEY, String(lowPowerMode));
+  }, [hasLoadedLowPowerMode, lowPowerMode]);
 
   // Sync menu open state to window context (used to prevent window focus when menu is open)
   useEffect(() => {
@@ -158,12 +172,19 @@ export function MenuBar({
         {/* Battery */}
         <button
           onClick={() => toggleMenu("battery")}
+          aria-label={`Battery, 97%${lowPowerMode ? ", Low Power Mode on" : ""}`}
           className={cn(
             "flex items-center justify-center w-7 h-5 rounded transition-colors",
             openMenu === "battery" ? "bg-white/30 dark:bg-white/20" : "can-hover:hover:bg-white/10"
           )}
         >
-          <FontAwesomeIcon icon={faBatteryFull} className="w-5 h-3.5 text-black dark:text-white" />
+          <FontAwesomeIcon
+            icon={faBatteryFull}
+            className={cn(
+              "h-3.5 w-5 transition-colors",
+              lowPowerMode ? "text-yellow-500" : "text-black dark:text-white"
+            )}
+          />
         </button>
 
         {/* Wi-Fi */}
@@ -220,6 +241,8 @@ export function MenuBar({
         isOpen={openMenu === "battery"}
         onClose={closeMenu}
         onOpenSettings={onOpenSettings}
+        lowPowerMode={lowPowerMode}
+        onLowPowerModeChange={setLowPowerMode}
       />
 
       <WifiMenu

--- a/components/desktop/status-menus.tsx
+++ b/components/desktop/status-menus.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import Image from "next/image";
 import {
   Wifi,
@@ -64,77 +64,82 @@ function MenuDivider() {
   return <div className="my-1 border-t border-black/10 dark:border-white/10" />;
 }
 
-const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
-
-function getInitialLowPowerMode(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(LOW_POWER_MODE_STORAGE_KEY) === "true";
-}
-
 // Battery Menu
 interface BatteryMenuProps {
   isOpen: boolean;
   onClose: () => void;
   onOpenSettings?: () => void;
+  lowPowerMode: boolean;
+  onLowPowerModeChange: (enabled: boolean) => void;
 }
 
-export function BatteryMenu({ isOpen, onClose }: BatteryMenuProps) {
+export function BatteryMenu({
+  isOpen,
+  onClose,
+  onOpenSettings,
+  lowPowerMode,
+  onLowPowerModeChange,
+}: BatteryMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
-  const [lowPowerMode, setLowPowerMode] = useState(getInitialLowPowerMode);
 
   useClickOutside(menuRef, onClose, isOpen);
-
-  useEffect(() => {
-    window.localStorage.setItem(LOW_POWER_MODE_STORAGE_KEY, String(lowPowerMode));
-  }, [lowPowerMode]);
 
   if (!isOpen) return null;
 
   return (
-    <div ref={menuRef} className={cn(menuContainerClass, "w-56")} style={{ right: "130px" }}>
+    <div ref={menuRef} className={cn(menuContainerClass, "w-[248px]")} style={{ right: "130px" }}>
       {/* Battery header */}
-      <div className="flex items-center justify-between px-3 py-1.5">
-        <span className="text-xs font-semibold">Battery</span>
-        <span className="text-xs">97%</span>
+      <div className="flex items-center justify-between px-3.5 pb-0.5 pt-1.5">
+        <span className="text-[13px] font-semibold leading-5">Battery</span>
+        <span className="text-[13px] leading-5">97%</span>
       </div>
 
-      <div className="flex flex-col gap-0.5 px-3 py-1">
-        <span className="text-xs text-muted-foreground">Power Source: Battery</span>
-        <span className="text-xs text-muted-foreground">
-          Energy Mode: {lowPowerMode ? "Low Power" : "Automatic"}
-        </span>
+      <div className="px-3.5 pb-1 pt-0.5">
+        <span className="text-[11px] leading-4 text-muted-foreground">Power Source: Battery</span>
       </div>
 
       <MenuDivider />
 
       {/* Energy Mode */}
-      <div className="px-3 py-1">
-        <span className="text-xs font-medium text-muted-foreground">Energy Mode</span>
+      <div className="px-3.5 pb-0.5 pt-1">
+        <span className="text-[11px] font-medium leading-4 text-muted-foreground">Energy Mode</span>
       </div>
 
       <button
-        onClick={() => setLowPowerMode(!lowPowerMode)}
+        onClick={() => onLowPowerModeChange(!lowPowerMode)}
         aria-pressed={lowPowerMode}
-        className="group flex w-full items-center justify-between px-3 py-1.5 transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+        className="group mx-1.5 flex w-[calc(100%_-_0.75rem)] items-center justify-between rounded-[5px] px-2 py-1 transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white"
       >
-        <div className="flex items-center gap-2">
-          <div className={cn(
-            "flex items-center justify-center w-6 h-6 rounded",
-            lowPowerMode ? "bg-yellow-500" : "bg-gray-200 dark:bg-gray-700"
-          )}>
-            <Battery className={cn("w-4 h-4", lowPowerMode ? "text-white" : "text-gray-600 dark:text-gray-300")} />
-          </div>
-          <span className="text-xs">Low Power</span>
+        <div className="flex items-center gap-2.5">
+          <Battery
+            className={cn(
+              "h-4 w-4 text-muted-foreground can-hover:group-hover:text-white",
+              lowPowerMode && "fill-yellow-400/35 text-yellow-500"
+            )}
+            strokeWidth={1.75}
+          />
+          <span className="text-[13px] leading-5">Low Power</span>
         </div>
-        {lowPowerMode && <Check className="h-3.5 w-3.5" aria-hidden />}
+        {lowPowerMode && <Check className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />}
       </button>
 
       <MenuDivider />
 
-      <div className="px-3 py-1.5">
-        <span className="text-xs text-muted-foreground">No Apps Using Significant Energy</span>
+      <div className="px-3.5 py-1">
+        <span className="text-[11px] leading-4 text-muted-foreground">No Apps Using Significant Energy</span>
       </div>
 
+      <MenuDivider />
+
+      <button
+        onClick={() => {
+          onClose();
+          onOpenSettings?.();
+        }}
+        className="mx-1.5 w-[calc(100%_-_0.75rem)] rounded-[5px] px-2 py-1 text-left text-[13px] leading-5 transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white"
+      >
+        Battery Settings&hellip;
+      </button>
     </div>
   );
 }

--- a/components/desktop/status-menus.tsx
+++ b/components/desktop/status-menus.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import {
   Wifi,
@@ -18,6 +18,7 @@ import {
   Pause,
   SkipBack,
   SkipForward,
+  Check,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSystemSettings, FocusMode } from "@/lib/system-settings-context";
@@ -63,6 +64,13 @@ function MenuDivider() {
   return <div className="my-1 border-t border-black/10 dark:border-white/10" />;
 }
 
+const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
+
+function getInitialLowPowerMode(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(LOW_POWER_MODE_STORAGE_KEY) === "true";
+}
+
 // Battery Menu
 interface BatteryMenuProps {
   isOpen: boolean;
@@ -72,9 +80,13 @@ interface BatteryMenuProps {
 
 export function BatteryMenu({ isOpen, onClose }: BatteryMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
-  const [lowPowerMode, setLowPowerMode] = useState(false);
+  const [lowPowerMode, setLowPowerMode] = useState(getInitialLowPowerMode);
 
   useClickOutside(menuRef, onClose, isOpen);
+
+  useEffect(() => {
+    window.localStorage.setItem(LOW_POWER_MODE_STORAGE_KEY, String(lowPowerMode));
+  }, [lowPowerMode]);
 
   if (!isOpen) return null;
 
@@ -86,8 +98,11 @@ export function BatteryMenu({ isOpen, onClose }: BatteryMenuProps) {
         <span className="text-xs">97%</span>
       </div>
 
-      <div className="px-3 py-1">
+      <div className="flex flex-col gap-0.5 px-3 py-1">
         <span className="text-xs text-muted-foreground">Power Source: Battery</span>
+        <span className="text-xs text-muted-foreground">
+          Energy Mode: {lowPowerMode ? "Low Power" : "Automatic"}
+        </span>
       </div>
 
       <MenuDivider />
@@ -99,15 +114,19 @@ export function BatteryMenu({ isOpen, onClose }: BatteryMenuProps) {
 
       <button
         onClick={() => setLowPowerMode(!lowPowerMode)}
-        className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-blue-500 hover:text-white transition-colors group"
+        aria-pressed={lowPowerMode}
+        className="group flex w-full items-center justify-between px-3 py-1.5 transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
       >
-        <div className={cn(
-          "flex items-center justify-center w-6 h-6 rounded",
-          lowPowerMode ? "bg-yellow-500" : "bg-gray-200 dark:bg-gray-700"
-        )}>
-          <Battery className={cn("w-4 h-4", lowPowerMode ? "text-white" : "text-gray-600 dark:text-gray-300")} />
+        <div className="flex items-center gap-2">
+          <div className={cn(
+            "flex items-center justify-center w-6 h-6 rounded",
+            lowPowerMode ? "bg-yellow-500" : "bg-gray-200 dark:bg-gray-700"
+          )}>
+            <Battery className={cn("w-4 h-4", lowPowerMode ? "text-white" : "text-gray-600 dark:text-gray-300")} />
+          </div>
+          <span className="text-xs">Low Power</span>
         </div>
-        <span className="text-xs">Low Power</span>
+        {lowPowerMode && <Check className="h-3.5 w-3.5" aria-hidden />}
       </button>
 
       <MenuDivider />


### PR DESCRIPTION
## Today’s delight

The Battery status menu now follows the compact macOS Sequoia layout: a clear battery header, power source, inset Energy Mode control, significant-energy status, and a Battery Settings item. Low Power Mode shows a checkmark, turns both battery glyphs yellow, and remains selected after the menu closes or the page reloads.

## Why this one

Apple documents that the Battery status menu reports whether Low Power Mode is enabled, and macOS Sequoia exposes Low Power directly in this menu. This is a small, authentic interaction that deepens the desktop without adding another app or capturing any keyboard shortcuts.

Apple reference: https://support.apple.com/guide/mac-help/change-battery-settings-mchlfc3b7879/mac

## Verification

- npm run build
- Visually inspected the menu at normal desktop scale
- Pointer-clicked Low Power and confirmed aria-pressed changes from false to true
- Confirmed the selected checkmark and yellow menu-bar battery treatment
- Reloaded the page, reopened the menu, and confirmed the state persisted
- No keyboard events were used during verification

## Scope

- Micro-sized change across the existing menu bar and status menu components
- No new dependencies or backend changes
- Avoids the areas touched by open PRs #244, #233, and #222
- Introduces no keyboard shortcut or key-driven interaction