### PR TITLE
Scope desktop window state to each tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ read before building, update when you ship:
 
 ## conventions
 
-- **state persistence**: sessionStorage for per-tab view state, localStorage for durable content/preferences and desktop window layout. window close clears view state via `clearAppState()` automatically
+- **state persistence**: sessionStorage for per-tab view/runtime state and the complete desktop window layout; localStorage for durable user content, preferences, and anonymous identity. window close clears app view state via `clearAppState()` automatically
 - **window management**: `useWindowManager()` for operations, `useWindowFocus()` for focus state
 - **desktop vs mobile**: use `isMobileView` / `isDesktop` prop, never raw viewport queries
 - **hover states**: gate hover-only styles with Tailwind's `can-hover:` variant so touch devices never get sticky hover treatments

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ this file captures the patterns and conventions that matter most when working in
 ## how to work in this repo
 
 1. read `docs/design-system.md` before touching any UI — it defines colors, tokens, sidebar patterns, and has a checklist for new apps
-2. run `npm run build` after making changes — no test framework, the build is the only gate
+2. run `npm run check` after making changes — it runs lint, Node tests, typecheck, and the production build
 
 ## key files
 

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -863,7 +863,7 @@ function DesktopContent({
                   onMove={(pos) => moveMultiWindow(windowState.id, pos)}
                   onResize={(size, pos) => resizeMultiWindow(windowState.id, size, pos)}
                   onContentChange={(newContent) => {
-                    // Update metadata and save to localStorage
+                    // Update metadata; window state persists for this tab.
                     updateWindowMetadata(windowState.id, { content: newContent });
                     if (filePath) {
                       saveTextEditContent(filePath, newContent);

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -445,9 +445,9 @@ const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
 
 | Tier | Storage | Lifetime | Use Case |
 |------|---------|----------|----------|
-| **View/runtime state** | `sessionStorage` | Per-tab, clears on tab close | Sidebar selection, scroll position, dock scale, recents, terminal history |
+| **View/runtime state** | `sessionStorage` | Per-tab, clears on tab close | Desktop window layout, sidebar selection, scroll position, dock scale, recents, terminal history |
 | **Session cache/runtime buffers** | `sessionStorage` | Per-tab, clears on tab close | API/UI caches and in-progress runtime state (e.g., GitHub cache, music playback queue/progress, Notes pinned ordering) |
-| **Durable data + preferences** | `localStorage` | Persistent, shared across tabs | User-created content, user preferences, and desktop window layout that should survive restarts (notes/messages data, settings, sound prefs, window positions/order) |
+| **Durable data + preferences** | `localStorage` | Persistent, shared across tabs | User-created content, user preferences, and anonymous identity (notes/messages data, settings, sound prefs, Notes `session_id`) |
 
 Rule of thumb: if losing it on browser restart is acceptable, use `sessionStorage`. If users expect it to persist (content or preferences), use `localStorage`.
 
@@ -455,9 +455,25 @@ Rule of thumb: if losing it on browser restart is acceptable, use `sessionStorag
 
 1. **Close = clear**: When a window is closed (red button or Cmd+Q), its view state is cleared via `clearAppState(appId)`.
 2. **Minimize = preserve**: Minimized windows keep their state in memory. Unminimizing restores exactly where the user left off.
-3. **Window layout is shared across tabs**: Desktop window state lives in `localStorage`, so multiple tabs can overwrite each other's saved layout.
+3. **Window layout is tab-scoped**: The complete desktop window graph lives in `sessionStorage`, including open/minimized/maximized state, geometry, z-order, focus, multi-window instances, and window metadata. Refresh restores it; a new tab or browser session starts independently.
 4. **Mixed persistence for list apps**: Persist user-managed collections in `localStorage`, but keep active selection/sort/filter/navigation in `sessionStorage`.
 5. **Ephemeral caches belong in session storage**: Network caches and runtime buffers should use `sessionStorage` unless there's a product requirement for cross-session persistence.
+6. **Use one policy, not one physical store**: Keep storage decisions behind focused persistence helpers. Do not move durable content into `sessionStorage` or emulate per-tab state inside `localStorage`.
+
+### Desktop Window State
+
+`lib/window-state-storage.ts` owns the browser-storage boundary for the desktop
+window graph. `lib/window-context.tsx` owns validation and the window state
+machine.
+
+- Same-tab refresh restores the complete desktop.
+- Separate tabs have independent desktops and cannot overwrite one another.
+- Closing the tab ends its desktop session.
+- Durable app content and preferences remain available when a fresh desktop starts.
+- A one-time compatibility migration copies the legacy `localStorage`
+  `desktop-window-state` value into the current tab's `sessionStorage`, then
+  removes the durable copy. If tab storage is unavailable, the legacy value is
+  retained so the user's existing layout is not discarded.
 
 ### Standard Behavior for List + Detail Apps
 
@@ -492,7 +508,7 @@ When creating a new app, ensure:
 - [ ] Responsive patterns use `isMobileView` prop
 - [ ] ScrollArea used for scrollable content
 - [ ] If app has text inputs, add Escape handler to blur (enables `q` to quit)
-- [ ] View/runtime/cache state uses `sessionStorage` (not `localStorage`) unless it is intentionally durable desktop layout state
+- [ ] View/runtime/cache state and desktop window layout use `sessionStorage`
 - [ ] Durable user content/preferences use `localStorage` and should not be cleared on app close
 - [ ] `clearAppState()` has a case for this app's ID
 - [ ] No manual `clear*Storage()` calls in nav bars or menu bar — handled automatically by `closeWindow`/`closeApp`

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -472,8 +472,9 @@ machine.
 - Durable app content and preferences remain available when a fresh desktop starts.
 - A one-time compatibility migration copies the legacy `localStorage`
   `desktop-window-state` value into the current tab's `sessionStorage`, then
-  removes the durable copy. If tab storage is unavailable, the legacy value is
-  retained so the user's existing layout is not discarded.
+  removes the durable copy only after the selected payload passes window-state
+  validation. If tab storage is unavailable, the legacy value is retained so
+  the user's existing layout is not discarded.
 
 ### Standard Behavior for List + Detail Apps
 

--- a/lib/window-context.tsx
+++ b/lib/window-context.tsx
@@ -16,8 +16,11 @@ import {
 } from "@/types/window";
 import { APPS, getAppById } from "./app-config";
 import { clearAppState, clearAllAppState } from "./sidebar-persistence";
+import {
+  loadWindowStatePayload,
+  saveWindowStatePayload,
+} from "./window-state-storage";
 
-const STORAGE_KEY = "desktop-window-state";
 const WINDOW_STATE_PERSIST_DEBOUNCE_MS = 1000;
 
 // =============================================================================
@@ -192,7 +195,7 @@ function focusTopmostWindowForApp(savedState: WindowManagerState, appId: string)
 function loadStateFromStorage(): WindowManagerState | null {
   if (typeof window === "undefined") return null;
   try {
-    const saved = localStorage.getItem(STORAGE_KEY);
+    const saved = loadWindowStatePayload(sessionStorage, localStorage);
     if (saved) {
       const parsed = JSON.parse(saved);
       // Validate structure
@@ -222,7 +225,7 @@ function loadStateFromStorage(): WindowManagerState | null {
 function saveSerializedStateToStorage(serializedState: string): void {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(STORAGE_KEY, serializedState);
+    saveWindowStatePayload(sessionStorage, serializedState);
   } catch (e) {
     console.error("Failed to save window state:", e);
   }
@@ -231,7 +234,7 @@ function saveSerializedStateToStorage(serializedState: string): void {
 /**
  * Get the topmost (highest z-index) open window for a specific app
  * Used by MobileShell to display the correct window when switching from desktop
- * Reads directly from localStorage to work outside WindowManagerProvider
+ * Reads directly from tab-scoped storage to work outside WindowManagerProvider.
  */
 export function getTopmostWindowForApp(appId: string): WindowState | null {
   const savedState = loadStateFromStorage();
@@ -872,7 +875,7 @@ export function WindowManagerProvider({
   const lastPersistedStateRef = React.useRef<string | null>(null);
   /**
    * Compute initial state based on:
-   * 1. Whether user has saved state (localStorage)
+   * 1. Whether this tab has saved window state (sessionStorage)
    * 2. Which app they're navigating to (initialAppId)
    *
    * Logic:
@@ -885,7 +888,7 @@ export function WindowManagerProvider({
     const savedState = loadStateFromStorage();
 
     if (savedState) {
-      // Returning visitor: preserve their session state as-is unless a deep link requests focus
+      // Returning tab: preserve its window state unless a deep link requests focus.
       if (initialAppId) {
         const focusedAppId = savedState.focusedWindowId
           ? getAppIdFromWindowId(savedState.focusedWindowId)

--- a/lib/window-context.tsx
+++ b/lib/window-context.tsx
@@ -17,7 +17,7 @@ import {
 import { APPS, getAppById } from "./app-config";
 import { clearAppState, clearAllAppState } from "./sidebar-persistence";
 import {
-  loadWindowStatePayload,
+  loadWindowState,
   saveWindowStatePayload,
 } from "./window-state-storage";
 
@@ -192,34 +192,37 @@ function focusTopmostWindowForApp(savedState: WindowManagerState, appId: string)
   };
 }
 
+function deserializeWindowState(serializedState: string): WindowManagerState | null {
+  try {
+    const parsed = JSON.parse(serializedState);
+    if (!parsed.windows || typeof parsed.nextZIndex !== "number") return null;
+
+    // Merge with current APPS config to pick up any new single-window apps.
+    const mergedWindows: Record<string, WindowState> = { ...parsed.windows };
+    APPS.forEach((app) => {
+      if (!app.multiWindow && !mergedWindows[app.id]) {
+        mergedWindows[app.id] = getDefaultWindowState(app.id);
+      }
+    });
+
+    return {
+      ...parsed,
+      windows: mergedWindows,
+      // Ensure nextInstanceNumber exists (migration from old state).
+      nextInstanceNumber: parsed.nextInstanceNumber || {},
+    };
+  } catch {
+    return null;
+  }
+}
+
 function loadStateFromStorage(): WindowManagerState | null {
   if (typeof window === "undefined") return null;
-  try {
-    const saved = loadWindowStatePayload(sessionStorage, localStorage);
-    if (saved) {
-      const parsed = JSON.parse(saved);
-      // Validate structure
-      if (parsed.windows && typeof parsed.nextZIndex === "number") {
-        // Merge with current APPS config to pick up any new single-window apps
-        const mergedWindows: Record<string, WindowState> = { ...parsed.windows };
-        APPS.forEach((app) => {
-          // Only add default windows for single-window apps
-          if (!app.multiWindow && !mergedWindows[app.id]) {
-            mergedWindows[app.id] = getDefaultWindowState(app.id);
-          }
-        });
-        return {
-          ...parsed,
-          windows: mergedWindows,
-          // Ensure nextInstanceNumber exists (migration from old state)
-          nextInstanceNumber: parsed.nextInstanceNumber || {},
-        };
-      }
-    }
-  } catch (e) {
-    console.error("Failed to load window state:", e);
-  }
-  return null;
+  return loadWindowState(
+    sessionStorage,
+    localStorage,
+    deserializeWindowState
+  );
 }
 
 function saveSerializedStateToStorage(serializedState: string): void {

--- a/lib/window-state-storage.ts
+++ b/lib/window-state-storage.ts
@@ -1,0 +1,63 @@
+/**
+ * Browser storage boundary for desktop window state.
+ *
+ * Window state is tab-scoped runtime state: a refresh should restore the
+ * current desktop, while a new tab or browser session should start with its
+ * own desktop. A legacy localStorage value is migrated once so existing users
+ * do not lose their current layout when this policy changes.
+ */
+
+export const WINDOW_STATE_STORAGE_KEY = "desktop-window-state";
+
+type StorageArea = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function loadWindowStatePayload(
+  tabStorage: StorageArea,
+  durableStorage: StorageArea
+): string | null {
+  try {
+    const tabValue = tabStorage.getItem(WINDOW_STATE_STORAGE_KEY);
+    if (tabValue !== null) {
+      // Best-effort cleanup for users who already have the tab-scoped value.
+      try {
+        durableStorage.removeItem(WINDOW_STATE_STORAGE_KEY);
+      } catch {
+        // Storage can be unavailable in restricted browser contexts.
+      }
+      return tabValue;
+    }
+  } catch {
+    // Fall back to the legacy durable value below.
+  }
+
+  let legacyValue: string | null;
+  try {
+    legacyValue = durableStorage.getItem(WINDOW_STATE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+
+  if (legacyValue === null) return null;
+
+  try {
+    tabStorage.setItem(WINDOW_STATE_STORAGE_KEY, legacyValue);
+  } catch {
+    // Keep the legacy value when migration cannot be completed.
+    return legacyValue;
+  }
+
+  try {
+    durableStorage.removeItem(WINDOW_STATE_STORAGE_KEY);
+  } catch {
+    // The successful tab write is enough; cleanup can be retried next load.
+  }
+
+  return legacyValue;
+}
+
+export function saveWindowStatePayload(
+  tabStorage: StorageArea,
+  serializedState: string
+): void {
+  tabStorage.setItem(WINDOW_STATE_STORAGE_KEY, serializedState);
+}

--- a/lib/window-state-storage.ts
+++ b/lib/window-state-storage.ts
@@ -11,20 +11,41 @@ export const WINDOW_STATE_STORAGE_KEY = "desktop-window-state";
 
 type StorageArea = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
-export function loadWindowStatePayload(
+function parsePayload<T>(
+  serializedState: string,
+  deserialize: (serializedState: string) => T | null
+): T | null {
+  try {
+    return deserialize(serializedState);
+  } catch {
+    return null;
+  }
+}
+
+export function loadWindowState<T>(
   tabStorage: StorageArea,
-  durableStorage: StorageArea
-): string | null {
+  durableStorage: StorageArea,
+  deserialize: (serializedState: string) => T | null
+): T | null {
   try {
     const tabValue = tabStorage.getItem(WINDOW_STATE_STORAGE_KEY);
     if (tabValue !== null) {
-      // Best-effort cleanup for users who already have the tab-scoped value.
-      try {
-        durableStorage.removeItem(WINDOW_STATE_STORAGE_KEY);
-      } catch {
-        // Storage can be unavailable in restricted browser contexts.
+      const parsedTabValue = parsePayload(tabValue, deserialize);
+      if (parsedTabValue !== null) {
+        // Only remove the legacy copy after the preferred value is valid.
+        try {
+          durableStorage.removeItem(WINDOW_STATE_STORAGE_KEY);
+        } catch {
+          // Storage can be unavailable in restricted browser contexts.
+        }
+        return parsedTabValue;
       }
-      return tabValue;
+
+      try {
+        tabStorage.removeItem(WINDOW_STATE_STORAGE_KEY);
+      } catch {
+        // Continue to the valid legacy fallback when cleanup is unavailable.
+      }
     }
   } catch {
     // Fall back to the legacy durable value below.
@@ -39,11 +60,14 @@ export function loadWindowStatePayload(
 
   if (legacyValue === null) return null;
 
+  const parsedLegacyValue = parsePayload(legacyValue, deserialize);
+  if (parsedLegacyValue === null) return null;
+
   try {
     tabStorage.setItem(WINDOW_STATE_STORAGE_KEY, legacyValue);
   } catch {
     // Keep the legacy value when migration cannot be completed.
-    return legacyValue;
+    return parsedLegacyValue;
   }
 
   try {
@@ -52,7 +76,7 @@ export function loadWindowStatePayload(
     // The successful tab write is enough; cleanup can be retried next load.
   }
 
-  return legacyValue;
+  return parsedLegacyValue;
 }
 
 export function saveWindowStatePayload(

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "eslint-config-next": "15.0.3",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.23.1",
         "typescript": "^5"
       }
     },
@@ -543,6 +544,23 @@
         "react": "^16.8 || ^17 || ^18"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
@@ -799,6 +817,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
@@ -815,6 +850,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
@@ -829,6 +881,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -12686,6 +12755,441 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
-    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test tests/*.test.ts",
+    "test": "node --import tsx --test tests/*.test.ts",
     "typecheck": "tsc --noEmit",
     "check": "npm run lint && npm run test && npm run typecheck && npm run build"
   },
@@ -76,6 +76,7 @@
     "eslint-config-next": "15.0.3",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.23.1",
     "typescript": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test tests/*.test.ts",
     "typecheck": "tsc --noEmit",
-    "check": "npm run lint && npm run typecheck && npm run build"
+    "check": "npm run lint && npm run test && npm run typecheck && npm run build"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.0.4",

--- a/tests/window-state-storage.test.ts
+++ b/tests/window-state-storage.test.ts
@@ -3,9 +3,9 @@ import test from "node:test";
 
 import {
   WINDOW_STATE_STORAGE_KEY,
-  loadWindowStatePayload,
+  loadWindowState,
   saveWindowStatePayload,
-} from "../lib/window-state-storage.ts";
+} from "../lib/window-state-storage";
 
 class MemoryStorage {
   readonly values = new Map<string, string>();
@@ -27,23 +27,46 @@ class MemoryStorage {
   }
 }
 
+const deserialize = (value: string): string | null =>
+  value.startsWith("valid:") ? value : null;
+
 test("prefers tab-scoped state and removes a stale durable copy", () => {
   const tabStorage = new MemoryStorage();
   const durableStorage = new MemoryStorage();
-  tabStorage.values.set(WINDOW_STATE_STORAGE_KEY, "tab");
-  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "legacy");
+  tabStorage.values.set(WINDOW_STATE_STORAGE_KEY, "valid:tab");
+  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "valid:legacy");
 
-  assert.equal(loadWindowStatePayload(tabStorage, durableStorage), "tab");
+  assert.equal(
+    loadWindowState(tabStorage, durableStorage, deserialize),
+    "valid:tab"
+  );
   assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), null);
 });
 
 test("migrates legacy durable state into tab storage", () => {
   const tabStorage = new MemoryStorage();
   const durableStorage = new MemoryStorage();
-  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "legacy");
+  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "valid:legacy");
 
-  assert.equal(loadWindowStatePayload(tabStorage, durableStorage), "legacy");
-  assert.equal(tabStorage.getItem(WINDOW_STATE_STORAGE_KEY), "legacy");
+  assert.equal(
+    loadWindowState(tabStorage, durableStorage, deserialize),
+    "valid:legacy"
+  );
+  assert.equal(tabStorage.getItem(WINDOW_STATE_STORAGE_KEY), "valid:legacy");
+  assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), null);
+});
+
+test("falls back to valid durable state before removing an invalid tab value", () => {
+  const tabStorage = new MemoryStorage();
+  const durableStorage = new MemoryStorage();
+  tabStorage.values.set(WINDOW_STATE_STORAGE_KEY, "invalid");
+  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "valid:legacy");
+
+  assert.equal(
+    loadWindowState(tabStorage, durableStorage, deserialize),
+    "valid:legacy"
+  );
+  assert.equal(tabStorage.getItem(WINDOW_STATE_STORAGE_KEY), "valid:legacy");
   assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), null);
 });
 
@@ -51,19 +74,25 @@ test("keeps the legacy value when tab storage rejects the migration", () => {
   const tabStorage = new MemoryStorage();
   const durableStorage = new MemoryStorage();
   tabStorage.failWrites = true;
-  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "legacy");
+  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "valid:legacy");
 
-  assert.equal(loadWindowStatePayload(tabStorage, durableStorage), "legacy");
-  assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), "legacy");
+  assert.equal(
+    loadWindowState(tabStorage, durableStorage, deserialize),
+    "valid:legacy"
+  );
+  assert.equal(
+    durableStorage.getItem(WINDOW_STATE_STORAGE_KEY),
+    "valid:legacy"
+  );
 });
 
 test("saves new window state only to tab storage", () => {
   const tabStorage = new MemoryStorage();
   const durableStorage = new MemoryStorage();
 
-  saveWindowStatePayload(tabStorage, "current");
+  saveWindowStatePayload(tabStorage, "valid:current");
 
-  assert.equal(tabStorage.getItem(WINDOW_STATE_STORAGE_KEY), "current");
+  assert.equal(tabStorage.getItem(WINDOW_STATE_STORAGE_KEY), "valid:current");
   assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), null);
 });
 
@@ -72,8 +101,14 @@ test("keeps separate tabs independent", () => {
   const secondTabStorage = new MemoryStorage();
   const durableStorage = new MemoryStorage();
 
-  saveWindowStatePayload(firstTabStorage, "first-tab");
+  saveWindowStatePayload(firstTabStorage, "valid:first-tab");
 
-  assert.equal(loadWindowStatePayload(firstTabStorage, durableStorage), "first-tab");
-  assert.equal(loadWindowStatePayload(secondTabStorage, durableStorage), null);
+  assert.equal(
+    loadWindowState(firstTabStorage, durableStorage, deserialize),
+    "valid:first-tab"
+  );
+  assert.equal(
+    loadWindowState(secondTabStorage, durableStorage, deserialize),
+    null
+  );
 });

--- a/tests/window-state-storage.test.ts
+++ b/tests/window-state-storage.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  WINDOW_STATE_STORAGE_KEY,
+  loadWindowStatePayload,
+  saveWindowStatePayload,
+} from "../lib/window-state-storage.ts";
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+  failReads = false;
+  failWrites = false;
+
+  getItem(key: string): string | null {
+    if (this.failReads) throw new Error("read unavailable");
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.failWrites) throw new Error("write unavailable");
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+test("prefers tab-scoped state and removes a stale durable copy", () => {
+  const tabStorage = new MemoryStorage();
+  const durableStorage = new MemoryStorage();
+  tabStorage.values.set(WINDOW_STATE_STORAGE_KEY, "tab");
+  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "legacy");
+
+  assert.equal(loadWindowStatePayload(tabStorage, durableStorage), "tab");
+  assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), null);
+});
+
+test("migrates legacy durable state into tab storage", () => {
+  const tabStorage = new MemoryStorage();
+  const durableStorage = new MemoryStorage();
+  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "legacy");
+
+  assert.equal(loadWindowStatePayload(tabStorage, durableStorage), "legacy");
+  assert.equal(tabStorage.getItem(WINDOW_STATE_STORAGE_KEY), "legacy");
+  assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), null);
+});
+
+test("keeps the legacy value when tab storage rejects the migration", () => {
+  const tabStorage = new MemoryStorage();
+  const durableStorage = new MemoryStorage();
+  tabStorage.failWrites = true;
+  durableStorage.values.set(WINDOW_STATE_STORAGE_KEY, "legacy");
+
+  assert.equal(loadWindowStatePayload(tabStorage, durableStorage), "legacy");
+  assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), "legacy");
+});
+
+test("saves new window state only to tab storage", () => {
+  const tabStorage = new MemoryStorage();
+  const durableStorage = new MemoryStorage();
+
+  saveWindowStatePayload(tabStorage, "current");
+
+  assert.equal(tabStorage.getItem(WINDOW_STATE_STORAGE_KEY), "current");
+  assert.equal(durableStorage.getItem(WINDOW_STATE_STORAGE_KEY), null);
+});
+
+test("keeps separate tabs independent", () => {
+  const firstTabStorage = new MemoryStorage();
+  const secondTabStorage = new MemoryStorage();
+  const durableStorage = new MemoryStorage();
+
+  saveWindowStatePayload(firstTabStorage, "first-tab");
+
+  assert.equal(loadWindowStatePayload(firstTabStorage, durableStorage), "first-tab");
+  assert.equal(loadWindowStatePayload(secondTabStorage, durableStorage), null);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "esnext"
     ],
     "allowJs": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
       "esnext"
     ],
     "allowJs": true,
-    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
## What changed

- move the complete desktop window graph from shared `localStorage` to per-tab `sessionStorage`
- preserve existing users' current layout through a one-time legacy migration that removes the durable copy only after the selected payload validates and the session write succeeds
- fall back from malformed session state to valid legacy state without data loss
- isolate the browser-storage boundary in `lib/window-state-storage.ts`
- add Node 20-compatible tests for tab precedence, validation-aware migration, migration failure safety, session-only writes, and cross-tab isolation
- document the storage lifecycle and update the repository conventions and check command

## Why

Window layout previously had a different lifetime from most app view state. A new tab or browser restart could restore open windows, geometry, focus, and z-order from `localStorage` while Photos, Messages, Calendar, and other app selections reset because they lived in `sessionStorage`. Multiple open tabs could also overwrite the same desktop layout.

After this change, a same-tab refresh restores the complete desktop, while separate tabs and new browser sessions start independently. Durable content and preferences remain in `localStorage` or Supabase.

## User impact

- refreshing a tab preserves its windows and app state
- one tab can no longer change another tab's saved window layout
- closing a tab ends that desktop session
- malformed session data cannot delete a valid legacy layout
- existing window layouts are not discarded if session storage is unavailable
- durable notes, messages, files, calendars, favorites, cities, settings, and anonymous Notes identity are unchanged

## Validation

- `npm test` — 6 passing tests
- Node `20.19.5` compatibility run — 6 passing tests
- `npm run typecheck` — passed
- `npm run lint` — passed with 0 errors and 7 pre-existing warnings in Messages and Notes
- `npm run build` — application compiled successfully and TypeScript passed; final local static page-data collection could not run because the required `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` environment variables are absent
- Vercel preview deployment validates the production build with configured environment variables
