### PR TITLE
Keep podcast tweet in Notification Center

### DIFF
--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -35,15 +35,7 @@ import { getNotesSelectedSlugMemory } from "@/lib/notes/selection-state";
 import { setUrl } from "@/lib/set-url";
 import { getShellUrlForApp } from "@/lib/shell-routing";
 import { fetchGitHubFileContent } from "@/lib/github-client";
-import {
-  getPodcastNotificationPayload,
-  loadPodcastNotificationDismissed,
-  savePodcastNotificationDismissed,
-} from "@/lib/podcast-notification";
-import type {
-  DesktopNotificationPayload,
-  PodcastNotificationPayload,
-} from "@/types/desktop-notification";
+import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 import type { MessagesNotificationPayload } from "@/types/messages/notification";
 import type { MessagesConversationSelectRequest } from "@/types/messages/selection";
 import { getAppById } from "@/lib/app-config";
@@ -239,7 +231,7 @@ function DesktopContent({
     !(initialDocumentRouteAppId && !(initialDocumentRouteAppId === "textedit" ? initialTextEditFile : initialPreviewFile))
   );
   const [appBadges, setAppBadges] = useState<Record<string, number>>({});
-  const [activeNotification, setActiveNotification] = useState<DesktopNotificationPayload | null>(null);
+  const [activeNotification, setActiveNotification] = useState<MessagesNotificationPayload | null>(null);
   const [isNotificationHovered, setIsNotificationHovered] = useState(false);
   const [messagesSelectRequest, setMessagesSelectRequest] = useState<MessagesConversationSelectRequest | null>(null);
   const nextMessagesSelectRequestIdRef = useRef(1);
@@ -672,28 +664,15 @@ function DesktopContent({
     });
   }, []);
 
-  useEffect(() => {
-    if (loadPodcastNotificationDismissed()) return;
-    setActiveNotification((current) => current ?? getPodcastNotificationPayload());
-  }, []);
-
   const handleMessagesNotification = useCallback((notification: MessagesNotificationPayload) => {
-    setActiveNotification((current) => {
-      if (current?.type === "podcast") {
-        savePodcastNotificationDismissed();
-      }
-      return notification;
-    });
+    setActiveNotification(notification);
     setIsNotificationHovered(false);
   }, []);
 
   const handleNotificationDismiss = useCallback(() => {
-    if (activeNotification?.type === "podcast") {
-      savePodcastNotificationDismissed();
-    }
     setActiveNotification(null);
     setIsNotificationHovered(false);
-  }, [activeNotification]);
+  }, []);
 
   useEffect(() => {
     if (notificationTimeoutRef.current) {
@@ -701,7 +680,6 @@ function DesktopContent({
       notificationTimeoutRef.current = null;
     }
     if (!activeNotification) return;
-    if (activeNotification.type === "podcast") return;
     if (isNotificationHovered) return;
     notificationTimeoutRef.current = setTimeout(() => {
       setActiveNotification(null);
@@ -718,18 +696,10 @@ function DesktopContent({
   }, []);
 
   const handlePodcastNotificationOpen = useCallback((notification: PodcastNotificationPayload) => {
-    savePodcastNotificationDismissed();
     window.open(notification.tweetUrl, "_blank", "noopener,noreferrer");
-    setActiveNotification(null);
-    setIsNotificationHovered(false);
   }, []);
 
-  const handleNotificationClick = useCallback((notification: DesktopNotificationPayload) => {
-    if (notification.type === "podcast") {
-      handlePodcastNotificationOpen(notification);
-      return;
-    }
-
+  const handleNotificationClick = useCallback((notification: MessagesNotificationPayload) => {
     const { conversationId } = notification;
     saveMessagesConversation(conversationId);
     const requestId = nextMessagesSelectRequestIdRef.current++;
@@ -747,7 +717,7 @@ function DesktopContent({
       return;
     }
     openWindow("messages");
-  }, [getWindow, restoreWindow, focusWindow, openWindow, handlePodcastNotificationOpen]);
+  }, [getWindow, restoreWindow, focusWindow, openWindow]);
 
   const handleOpenMessagesConversation = useCallback((conversationId: string) => {
     saveMessagesConversation(conversationId);

--- a/components/desktop/messages-notification-banner.tsx
+++ b/components/desktop/messages-notification-banner.tsx
@@ -2,24 +2,13 @@
 
 import { useEffect, useState, useCallback } from "react";
 import Image from "next/image";
-import { PodcastTweetCard } from "./x-podcast-notification";
-import type {
-  DesktopNotificationPayload,
-  PodcastNotificationPayload,
-} from "@/types/desktop-notification";
 import type { MessagesNotificationPayload } from "@/types/messages/notification";
 
 interface DesktopNotificationBannerProps {
-  notification: DesktopNotificationPayload | null;
-  onClick: (notification: DesktopNotificationPayload) => void;
+  notification: MessagesNotificationPayload | null;
+  onClick: (notification: MessagesNotificationPayload) => void;
   onDismiss: () => void;
   onHoverChange?: (hovered: boolean) => void;
-}
-
-function isPodcastNotification(
-  notification: DesktopNotificationPayload
-): notification is PodcastNotificationPayload {
-  return notification.type === "podcast";
 }
 
 function getAvatarInitials(notification: MessagesNotificationPayload) {
@@ -69,19 +58,6 @@ function MessagesNotificationContent({
   );
 }
 
-function PodcastNotificationContent({
-  notification,
-}: {
-  notification: PodcastNotificationPayload;
-}) {
-  return (
-    <PodcastTweetCard
-      notification={notification}
-      className="border-0 bg-transparent p-0 shadow-none dark:bg-transparent"
-    />
-  );
-}
-
 export function DesktopNotificationBanner({
   notification,
   onClick,
@@ -109,10 +85,6 @@ export function DesktopNotificationBanner({
       event.preventDefault();
       event.stopPropagation();
       if (!notification) return;
-      if (isPodcastNotification(notification)) {
-        onClick(notification);
-        return;
-      }
 
       // Defer activation so window-focus click-capture state from this click
       // cannot interfere with the newly focused Messages window.
@@ -131,9 +103,6 @@ export function DesktopNotificationBanner({
   );
 
   if (!notification) return null;
-  const isPodcast = isPodcastNotification(notification);
-  const widthClassName = isPodcast ? "w-[430px]" : "w-[390px]";
-  const paddingClassName = isPodcast ? "px-4 py-3" : "px-4 py-2.5";
 
   return (
     <div className="fixed top-10 right-4 z-[120] pointer-events-none">
@@ -143,7 +112,7 @@ export function DesktopNotificationBanner({
         onClick={handleBannerClick}
         onMouseEnter={() => onHoverChange?.(true)}
         onMouseLeave={() => onHoverChange?.(false)}
-        className={`group relative pointer-events-auto ${widthClassName} max-w-[calc(100vw-24px)] rounded-2xl border border-black/10 dark:border-white/20 bg-[#f3f3f5]/96 dark:bg-zinc-800/96 backdrop-blur-xl shadow-[0_8px_24px_rgba(0,0,0,0.26)] text-left ${paddingClassName} transition-all duration-300 ${
+        className={`group relative pointer-events-auto w-[390px] max-w-[calc(100vw-24px)] rounded-2xl border border-black/10 dark:border-white/20 bg-[#f3f3f5]/96 dark:bg-zinc-800/96 backdrop-blur-xl shadow-[0_8px_24px_rgba(0,0,0,0.26)] px-4 py-2.5 text-left transition-all duration-300 ${
           isVisible ? "translate-x-0 opacity-100" : "translate-x-[120%] opacity-0"
         }`}
       >
@@ -157,11 +126,7 @@ export function DesktopNotificationBanner({
         >
           ✕
         </span>
-        {isPodcast ? (
-          <PodcastNotificationContent notification={notification} />
-        ) : (
-          <MessagesNotificationContent notification={notification} />
-        )}
+        <MessagesNotificationContent notification={notification} />
       </button>
     </div>
   );

--- a/components/desktop/notification-center.tsx
+++ b/components/desktop/notification-center.tsx
@@ -43,10 +43,11 @@ interface NotificationCenterProps {
   onOpenPodcastNotification?: (notification: PodcastNotificationPayload) => void;
 }
 
-const cardClass = "bg-muted rounded-md p-3 mb-1.5";
+const notificationCardClass = "mb-1.5 rounded-md p-3";
+const cardClass = `${notificationCardClass} bg-muted`;
 const clickableCardClass =
-  "bg-muted rounded-md p-3 mb-1.5 transition-colors cursor-pointer";
-const weatherCardClass = "h-[134px] rounded-md p-3 mb-1.5";
+  `${cardClass} cursor-pointer text-left transition-colors`;
+const weatherCardClass = `${notificationCardClass} h-[134px]`;
 const clickableWeatherCardClass = `${weatherCardClass} transition-colors cursor-pointer`;
 
 function PodcastNotificationWidget({
@@ -61,7 +62,7 @@ function PodcastNotificationWidget({
   return (
     <button
       type="button"
-      className="mb-1.5 w-full cursor-pointer text-left"
+      className={`${clickableCardClass} w-full`}
       onClick={() => {
         if (onOpen) {
           onOpen(notification);
@@ -74,7 +75,7 @@ function PodcastNotificationWidget({
       <PodcastTweetCard
         notification={notification}
         compact
-        className="rounded-md bg-muted transition-colors dark:bg-muted"
+        className="rounded-none border-0 bg-transparent p-0 shadow-none dark:bg-transparent"
       />
     </button>
   );

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -350,7 +350,7 @@ For app-level mobile views, keep base surfaces consistent with semantic tokens:
 
 ### Desktop Notifications
 
-Top-right banners use `DesktopNotificationBanner` and should share the same placement as Messages notifications. Long-lived promo notifications may persist until dismissed, but incoming Messages notifications take priority and can replace them immediately. If a dismissed promo still needs to be discoverable, keep it available in Notification Center rather than re-showing the banner.
+Top-right banners use `DesktopNotificationBanner` for incoming Messages notifications. Keep promotional or long-lived content in Notification Center instead of showing it as a desktop banner.
 
 ### Empty State
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -352,6 +352,8 @@ For app-level mobile views, keep base surfaces consistent with semantic tokens:
 
 Top-right banners use `DesktopNotificationBanner` for incoming Messages notifications. Keep promotional or long-lived content in Notification Center instead of showing it as a desktop banner.
 
+Notification Center cards share the same outer `mb-1.5 rounded-md p-3` geometry. Apply content-specific borders, radii, and backgrounds only inside that shared container; scene-based cards such as Weather may replace the standard `bg-muted` surface.
+
 ### Empty State
 
 ```tsx

--- a/lib/podcast-notification.ts
+++ b/lib/podcast-notification.ts
@@ -12,9 +12,6 @@ const PODCAST_TWEET_TEXT = `5 things @alanaagoyal does differently
 > built her personal website using a dozen of her own portco's products
 > automated her investor updates...`;
 
-export const PODCAST_NOTIFICATION_DISMISSED_KEY =
-  `podcast-x-notification-dismissed-${PODCAST_TWEET_ID}`;
-
 export function getPodcastNotificationPayload(): PodcastNotificationPayload {
   return {
     id: `podcast-x-${PODCAST_TWEET_ID}`,
@@ -30,14 +27,4 @@ export function getPodcastNotificationPayload(): PodcastNotificationPayload {
     mediaThumbnailSrc: "/podcast/show-me-your-stack-thumb.jpg",
     mediaAlt: "Still from the Show Me Your Stack episode with Alana Goyal",
   };
-}
-
-export function loadPodcastNotificationDismissed(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(PODCAST_NOTIFICATION_DISMISSED_KEY) === "true";
-}
-
-export function savePodcastNotificationDismissed(): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(PODCAST_NOTIFICATION_DISMISSED_KEY, "true");
 }

--- a/types/desktop-notification.ts
+++ b/types/desktop-notification.ts
@@ -1,5 +1,3 @@
-import type { MessagesNotificationPayload } from "@/types/messages/notification";
-
 export interface PodcastNotificationPayload {
   id: string;
   type: "podcast";
@@ -14,7 +12,3 @@ export interface PodcastNotificationPayload {
   mediaThumbnailSrc: string;
   mediaAlt: string;
 }
-
-export type DesktopNotificationPayload =
-  | MessagesNotificationPayload
-  | PodcastNotificationPayload;


### PR DESCRIPTION
## Summary

- remove the persistent “Show Me Your Stack” tweet banner from desktop startup
- keep the existing tweet card and click behavior in Notification Center
- put the tweet on the same shared outer card geometry as Calendar, Messages, Photos, and Weather
- narrow desktop banners to incoming Messages notifications and remove the obsolete promo-dismissal storage path
- document the Notification Center card contract

## Why

The podcast tweet was rendered in two places: as a persistent desktop banner and independently inside Notification Center. That made the promotional banner reappear on startup even though the content already had a permanent home.

Inside Notification Center, the tweet also wrapped its own X-styled border, larger radius, inset shadow, and padding instead of using the same card surface as the neighboring widgets. The shared outer container now owns width, padding, radius, spacing, and background; tweet-specific styling is limited to its content.

## Verification

- `npm run check`
- verified startup renders no tweet banner or dismiss badge
- verified the full tweet card remains in Notification Center
- verified Calendar, tweet, Messages, Photos, and Weather cards all resolve to 302px width, 12px padding, 6px radius, and 6px bottom spacing
- verified no browser console errors