### PR TITLE
Show real photo metadata on desktop and mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ the app uses next.js app router with a route group for the desktop environment. 
 **photos** use supabase storage:
 - images stored in supabase storage bucket
 - metadata (filename, timestamp, collections) in database
+- embedded camera and exposure metadata is read from each image on demand in the info panel; GPS remains unused
 - favorites are per-browser (stored in localstorage)
 - upload via api with ai auto-categorization (openai gpt-4o-mini)
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the app uses next.js app router with a route group for the desktop environment. 
 **photos** use supabase storage:
 - images stored in supabase storage bucket
 - metadata (filename, timestamp, collections) in database
-- embedded camera and exposure metadata is read from each image on demand in the info panel; GPS remains unused
+- embedded camera and exposure metadata is read from each image on demand in the desktop Info panel and mobile swipe-up details; GPS remains unused
 - favorites are per-browser (stored in localstorage)
 - upload via api with ai auto-categorization (openai gpt-4o-mini)
 

--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -105,6 +105,11 @@ export default function App({ isDesktop = false }: AppProps) {
   const selectedPhotoIndex = selectedPhoto
     ? filteredPhotos.findIndex((p) => p.id === selectedPhotoId)
     : -1;
+  const selectedPhotoCollectionNames = selectedPhoto
+    ? collections
+        .filter((collection) => selectedPhoto.collections.includes(collection.id))
+        .map((collection) => collection.name)
+    : [];
 
   const handlePreviousPhoto = useCallback(() => {
     if (selectedPhotoIndex > 0) {
@@ -197,6 +202,7 @@ export default function App({ isDesktop = false }: AppProps) {
                 onPrevious={handlePreviousPhoto}
                 onNext={handleNextPhoto}
                 onToggleFavorite={toggleFavorite}
+                collectionNames={selectedPhotoCollectionNames}
                 isMobileView={isMobileView}
                 isDesktop={isDesktop}
               />

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSwipeable } from "react-swipeable";
 import { Photo } from "@/types/photos";
-import { ChevronLeft, Heart } from "lucide-react";
+import { ChevronLeft, Heart, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useClickOutside } from "@/lib/hooks/use-click-outside";
 import { useWindowFocus } from "@/lib/window-focus-context";
 import { toZonedTime } from "date-fns-tz";
 import { format, parseISO } from "date-fns";
@@ -27,6 +28,7 @@ interface PhotoViewerProps {
   onPrevious: () => void;
   onNext: () => void;
   onToggleFavorite?: (photoId: string) => void;
+  collectionNames: string[];
   isMobileView: boolean;
   isDesktop?: boolean;
 }
@@ -40,12 +42,18 @@ export function PhotoViewer({
   onPrevious,
   onNext,
   onToggleFavorite,
+  collectionNames,
   isMobileView,
   isDesktop = false,
 }: PhotoViewerProps) {
   const windowFocus = useWindowFocus();
   const inShell = isDesktop && windowFocus;
   const [isSwiping, setIsSwiping] = useState(false);
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const infoContainerRef = useRef<HTMLDivElement>(null);
+  const closeInfo = useCallback(() => setIsInfoOpen(false), []);
+
+  useClickOutside(infoContainerRef, closeInfo, isInfoOpen);
 
   // Prevent default touch move when swiping to avoid scroll interference
   useEffect(() => {
@@ -138,19 +146,87 @@ export function PhotoViewer({
           </p>
         </div>
 
-        {/* Favorite button */}
-        <button
-          onClick={() => onToggleFavorite?.(photo.id)}
-          onMouseDown={(e) => e.stopPropagation()}
-          className="p-1 -mr-1"
-        >
-          <Heart
-            className={cn(
-              "w-5 h-5 transition-colors text-foreground",
-              photo.isFavorite && "fill-foreground"
+        <div className="flex items-center gap-1 -mr-1">
+          <div
+            ref={infoContainerRef}
+            className="relative"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              aria-label={isInfoOpen ? "Hide photo information" : "Show photo information"}
+              aria-expanded={isInfoOpen}
+              aria-controls="photo-info-panel"
+              onClick={() => setIsInfoOpen((open) => !open)}
+              className={cn(
+                "rounded-md p-1 text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]",
+                isInfoOpen
+                  ? "bg-foreground/10"
+                  : "can-hover:hover:bg-foreground/10"
+              )}
+            >
+              <Info className="h-5 w-5" />
+            </button>
+
+            {isInfoOpen && (
+              <aside
+                id="photo-info-panel"
+                aria-label="Photo information"
+                className="absolute right-0 top-[calc(100%+12px)] z-20 w-[min(320px,calc(100vw-24px))] overflow-hidden rounded-xl border border-black/10 bg-muted/95 text-foreground shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-2xl dark:border-white/15"
+              >
+                <div className="relative flex h-8 items-center justify-center border-b border-black/10 px-3 dark:border-white/10">
+                  <div className="absolute left-3 flex gap-1.5" aria-hidden="true">
+                    <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+                  </div>
+                  <p className="text-xs font-medium text-muted-foreground">Info</p>
+                </div>
+
+                <div className="flex items-start justify-between gap-3 px-3 py-3">
+                  <div className="min-w-0">
+                    <p className="break-all text-sm font-medium leading-5">{photo.filename}</p>
+                    <time
+                      dateTime={photo.timestamp}
+                      className="mt-0.5 block text-xs leading-4 text-muted-foreground"
+                    >
+                      {formattedDate}
+                    </time>
+                  </div>
+                  <Heart
+                    aria-label={photo.isFavorite ? "Favorite" : "Not a favorite"}
+                    className={cn(
+                      "mt-0.5 h-4 w-4 shrink-0 text-muted-foreground",
+                      photo.isFavorite && "fill-foreground text-foreground"
+                    )}
+                  />
+                </div>
+
+                <dl className="grid grid-cols-[88px_minmax(0,1fr)] gap-x-3 gap-y-2 border-t border-black/10 px-3 py-3 text-xs dark:border-white/10">
+                  <dt className="text-muted-foreground">Favorite</dt>
+                  <dd>{photo.isFavorite ? "Yes" : "No"}</dd>
+                  <dt className="text-muted-foreground">Collections</dt>
+                  <dd className="min-w-0 break-words">
+                    {collectionNames.length > 0 ? collectionNames.join(", ") : "None"}
+                  </dd>
+                </dl>
+              </aside>
             )}
-          />
-        </button>
+          </div>
+
+          <button
+            onClick={() => onToggleFavorite?.(photo.id)}
+            onMouseDown={(e) => e.stopPropagation()}
+            className="p-1"
+          >
+            <Heart
+              className={cn(
+                "w-5 h-5 transition-colors text-foreground",
+                photo.isFavorite && "fill-foreground"
+              )}
+            />
+          </button>
+        </div>
       </div>
 
       {/* Photo with swipe support */}

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -408,17 +408,17 @@ export function PhotoViewer({
                   className="absolute right-0 top-[calc(100%+12px)] z-20 w-[min(320px,calc(100vw-24px))] overflow-hidden rounded-xl border border-black/10 bg-muted/95 text-foreground shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-2xl dark:border-white/15"
                 >
                   <div className="relative flex h-8 items-center justify-center border-b border-black/10 px-3 dark:border-white/10">
-                    <div className="absolute left-3 flex gap-1.5">
+                    <div className="group absolute left-3 flex gap-1.5">
                       <button
                         type="button"
                         aria-label="Close photo information"
                         onClick={closeInfo}
-                        className="group relative flex h-2.5 w-2.5 items-center justify-center rounded-full bg-muted-foreground/30 transition-colors can-hover:hover:bg-[#FF5F57] focus-visible:bg-[#FF5F57] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
+                        className="relative flex h-2.5 w-2.5 items-center justify-center rounded-full bg-muted-foreground/30 transition-colors can-hover:group-hover:bg-[#FF5F57] focus-visible:bg-[#FF5F57] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
                       >
                         <svg
                           aria-hidden="true"
                           viewBox="0 0 10 10"
-                          className="h-2 w-2 text-black/55 opacity-0 transition-opacity can-hover:group-hover:opacity-100 group-focus-visible:opacity-100"
+                          className="h-2 w-2 text-black/55 opacity-0 transition-opacity can-hover:group-hover:opacity-100 group-focus-within:opacity-100"
                           fill="currentColor"
                         >
                           <path d="M2.2 1.4 5 4.2l2.8-2.8.8.8L5.8 5l2.8 2.8-.8.8L5 5.8 2.2 8.6l-.8-.8L4.2 5 1.4 2.2z" />
@@ -428,7 +428,10 @@ export function PhotoViewer({
                         aria-hidden="true"
                         className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30"
                       />
-                      <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+                      <span
+                        aria-hidden="true"
+                        className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30"
+                      />
                     </div>
                     <p className="text-xs font-medium text-muted-foreground">Info</p>
                   </div>

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -45,6 +45,188 @@ interface PhotoViewerProps {
   isDesktop?: boolean;
 }
 
+interface CameraDetailsProps {
+  metadata: PhotoMetadata | null;
+  isLoading: boolean;
+  hasError: boolean;
+  filename: string;
+  variant: "desktop" | "mobile";
+}
+
+function CameraDetails({
+  metadata,
+  isLoading,
+  hasError,
+  filename,
+  variant,
+}: CameraDetailsProps) {
+  const isMobile = variant === "mobile";
+  const cameraName = metadata ? formatCameraName(metadata) : undefined;
+  const lensDescription = metadata
+    ? formatLensDescription(metadata)
+    : undefined;
+  const dimensions = metadata ? formatDimensions(metadata) : undefined;
+  const megapixels = metadata ? formatMegapixels(metadata) : undefined;
+  const photoType = metadata
+    ? formatPhotoType(metadata.mimeType, filename)
+    : undefined;
+  const hasExposureDetails = Boolean(
+    metadata &&
+      (metadata.iso !== undefined ||
+        metadata.focalLength35mm !== undefined ||
+        metadata.exposureCompensation !== undefined ||
+        metadata.fNumber !== undefined ||
+        metadata.exposureTime !== undefined)
+  );
+
+  return (
+    <section
+      aria-label="Camera details"
+      aria-live="polite"
+      className={cn(
+        isMobile
+          ? "overflow-hidden rounded-xl bg-muted/70"
+          : "border-t border-black/10 px-3 py-3 dark:border-white/10"
+      )}
+    >
+      {isLoading && (
+        <div
+          className={cn("animate-pulse space-y-2", isMobile && "p-3")}
+          aria-label="Loading camera details"
+        >
+          <div className="h-3 w-32 rounded bg-muted-foreground/20" />
+          <div className="h-3 w-48 rounded bg-muted-foreground/15" />
+          <div className="h-3 w-40 rounded bg-muted-foreground/15" />
+        </div>
+      )}
+
+      {hasError && (
+        <p className={cn("text-xs text-muted-foreground", isMobile && "p-3")}>
+          Camera information unavailable
+        </p>
+      )}
+
+      {metadata && (
+        <>
+          <div
+            className={cn(
+              "flex items-start justify-between gap-3",
+              isMobile && "px-3 py-2.5"
+            )}
+          >
+            <div className="min-w-0">
+              <p
+                className={cn(
+                  "font-medium leading-5",
+                  isMobile ? "text-base" : "text-sm"
+                )}
+              >
+                {cameraName ?? "Photo"}
+              </p>
+              {lensDescription && (
+                <p
+                  className={cn(
+                    "text-muted-foreground",
+                    isMobile ? "mt-2 text-sm leading-5" : "text-xs leading-4"
+                  )}
+                >
+                  {lensDescription}
+                </p>
+              )}
+              <div
+                className={cn(
+                  "flex flex-wrap items-center text-muted-foreground",
+                  isMobile
+                    ? "mt-1 gap-x-1.5 text-sm leading-5"
+                    : "mt-1 gap-x-2 gap-y-1 text-xs"
+                )}
+              >
+                {isMobile ? (
+                  <>
+                    {megapixels && <span>{megapixels}</span>}
+                    {megapixels && dimensions && <span aria-hidden="true">•</span>}
+                    {dimensions && <span>{dimensions}</span>}
+                    {metadata.fileSize > 0 && <span aria-hidden="true">•</span>}
+                    <span>{formatFileSize(metadata.fileSize)}</span>
+                  </>
+                ) : (
+                  <>
+                    {dimensions && <span>{dimensions}</span>}
+                    {megapixels && <span>{megapixels}</span>}
+                    <span>{formatFileSize(metadata.fileSize)}</span>
+                    <span className="rounded bg-muted-foreground/20 px-1 py-0.5 text-[10px] font-semibold leading-none text-foreground/70">
+                      {photoType}
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {isMobile ? (
+              <span className="rounded bg-muted-foreground/20 px-1.5 py-1 text-[11px] font-semibold leading-none text-foreground/70">
+                {photoType}
+              </span>
+            ) : (
+              <Camera
+                aria-hidden="true"
+                className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground"
+              />
+            )}
+          </div>
+
+          {hasExposureDetails && (
+            <dl
+              className={cn(
+                "grid grid-cols-5 gap-1 border-t border-black/10 text-center text-muted-foreground dark:border-white/10",
+                isMobile
+                  ? "px-2 py-2 text-[11px] leading-4"
+                  : "mt-3 pt-2 text-[10px] leading-4"
+              )}
+            >
+              <div>
+                <dt className="sr-only">ISO</dt>
+                <dd>{metadata.iso !== undefined ? `ISO ${metadata.iso}` : "—"}</dd>
+              </div>
+              <div>
+                <dt className="sr-only">Focal length</dt>
+                <dd>
+                  {metadata.focalLength35mm !== undefined
+                    ? `${Math.round(metadata.focalLength35mm)} mm`
+                    : "—"}
+                </dd>
+              </div>
+              <div>
+                <dt className="sr-only">Exposure compensation</dt>
+                <dd>
+                  {metadata.exposureCompensation !== undefined
+                    ? formatExposureCompensation(metadata.exposureCompensation)
+                    : "—"}
+                </dd>
+              </div>
+              <div>
+                <dt className="sr-only">Aperture</dt>
+                <dd>
+                  {metadata.fNumber !== undefined
+                    ? `ƒ${metadata.fNumber.toFixed(1)}`
+                    : "—"}
+                </dd>
+              </div>
+              <div>
+                <dt className="sr-only">Shutter speed</dt>
+                <dd>
+                  {metadata.exposureTime !== undefined
+                    ? formatExposureTime(metadata.exposureTime)
+                    : "—"}
+                </dd>
+              </div>
+            </dl>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
 export function PhotoViewer({
   photo,
   photos,
@@ -66,12 +248,13 @@ export function PhotoViewer({
   const [isMetadataLoading, setIsMetadataLoading] = useState(false);
   const [metadataError, setMetadataError] = useState(false);
   const infoContainerRef = useRef<HTMLDivElement>(null);
+  const mobileScrollRef = useRef<HTMLDivElement>(null);
   const closeInfo = useCallback(() => setIsInfoOpen(false), []);
 
   useClickOutside(infoContainerRef, closeInfo, isInfoOpen);
 
   useEffect(() => {
-    if (!isInfoOpen) return;
+    if (!isInfoOpen && !isMobileView) return;
 
     let isCurrent = true;
     setMetadata(null);
@@ -92,7 +275,11 @@ export function PhotoViewer({
     return () => {
       isCurrent = false;
     };
-  }, [isInfoOpen, photo.url]);
+  }, [isInfoOpen, isMobileView, photo.url]);
+
+  useEffect(() => {
+    mobileScrollRef.current?.scrollTo({ top: 0 });
+  }, [photo.id]);
 
   // Prevent default touch move when swiping to avoid scroll interference
   useEffect(() => {
@@ -111,13 +298,15 @@ export function PhotoViewer({
 
   // Swipe handlers for mobile navigation
   const swipeHandlers = useSwipeable({
-    onSwipeStart: () => setIsSwiping(true),
+    onSwipeStart: ({ dir }) => {
+      setIsSwiping(dir === "Left" || dir === "Right");
+    },
     onSwiped: () => setIsSwiping(false),
     onSwipedLeft: () => onNext(),
     onSwipedRight: () => onPrevious(),
     trackMouse: false,
     delta: 50,
-    preventScrollOnSwipe: true,
+    preventScrollOnSwipe: !isMobileView,
   });
 
   // Preload adjacent photos (3 in each direction) when current photo changes
@@ -157,19 +346,9 @@ export function PhotoViewer({
 
   const pstDate = toZonedTime(parseISO(photo.timestamp), "America/Los_Angeles");
   const formattedDate = format(pstDate, "MMMM d, yyyy 'at' h:mm:ss a");
-  const cameraName = metadata ? formatCameraName(metadata) : undefined;
-  const lensDescription = metadata
-    ? formatLensDescription(metadata)
-    : undefined;
-  const dimensions = metadata ? formatDimensions(metadata) : undefined;
-  const megapixels = metadata ? formatMegapixels(metadata) : undefined;
-  const hasExposureDetails = Boolean(
-    metadata &&
-      (metadata.iso !== undefined ||
-        metadata.focalLength35mm !== undefined ||
-        metadata.exposureCompensation !== undefined ||
-        metadata.fNumber !== undefined ||
-        metadata.exposureTime !== undefined)
+  const mobileFormattedDate = format(
+    pstDate,
+    "EEEE · MMMM d, yyyy · h:mm a"
   );
 
   return (
@@ -200,164 +379,84 @@ export function PhotoViewer({
         </div>
 
         <div className="flex items-center gap-1 -mr-1">
-          <div
-            ref={infoContainerRef}
-            className="relative"
-            onMouseDown={(event) => event.stopPropagation()}
-          >
-            <button
-              type="button"
-              aria-label={isInfoOpen ? "Hide photo information" : "Show photo information"}
-              aria-expanded={isInfoOpen}
-              aria-controls="photo-info-panel"
-              onClick={() => setIsInfoOpen((open) => !open)}
-              className={cn(
-                "rounded-md p-1 text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]",
-                isInfoOpen
-                  ? "bg-foreground/10"
-                  : "can-hover:hover:bg-foreground/10"
-              )}
+          {!isMobileView && (
+            <div
+              ref={infoContainerRef}
+              className="relative"
+              onMouseDown={(event) => event.stopPropagation()}
             >
-              <Info className="h-5 w-5" />
-            </button>
-
-            {isInfoOpen && (
-              <aside
-                id="photo-info-panel"
-                aria-label="Photo information"
-                className="absolute right-0 top-[calc(100%+12px)] z-20 w-[min(320px,calc(100vw-24px))] overflow-hidden rounded-xl border border-black/10 bg-muted/95 text-foreground shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-2xl dark:border-white/15"
+              <button
+                type="button"
+                aria-label={isInfoOpen ? "Hide photo information" : "Show photo information"}
+                aria-expanded={isInfoOpen}
+                aria-controls="photo-info-panel"
+                onClick={() => setIsInfoOpen((open) => !open)}
+                className={cn(
+                  "rounded-md p-1 text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]",
+                  isInfoOpen
+                    ? "bg-foreground/10"
+                    : "can-hover:hover:bg-foreground/10"
+                )}
               >
-                <div className="relative flex h-8 items-center justify-center border-b border-black/10 px-3 dark:border-white/10">
-                  <div className="absolute left-3 flex gap-1.5" aria-hidden="true">
-                    <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
-                    <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
-                    <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
-                  </div>
-                  <p className="text-xs font-medium text-muted-foreground">Info</p>
-                </div>
+                <Info className="h-5 w-5" />
+              </button>
 
-                <div className="max-h-[calc(100vh-112px)] overflow-y-auto">
-                  <div className="flex items-start justify-between gap-3 px-3 py-3">
-                    <div className="min-w-0">
-                      <p className="break-all text-sm font-medium leading-5">{photo.filename}</p>
-                      <time
-                        dateTime={photo.timestamp}
-                        className="mt-0.5 block text-xs leading-4 text-muted-foreground"
-                      >
-                        {formattedDate}
-                      </time>
+              {isInfoOpen && (
+                <aside
+                  id="photo-info-panel"
+                  aria-label="Photo information"
+                  className="absolute right-0 top-[calc(100%+12px)] z-20 w-[min(320px,calc(100vw-24px))] overflow-hidden rounded-xl border border-black/10 bg-muted/95 text-foreground shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-2xl dark:border-white/15"
+                >
+                  <div className="relative flex h-8 items-center justify-center border-b border-black/10 px-3 dark:border-white/10">
+                    <div className="absolute left-3 flex gap-1.5" aria-hidden="true">
+                      <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+                      <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+                      <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
                     </div>
-                    <Heart
-                      aria-label={photo.isFavorite ? "Favorite" : "Not a favorite"}
-                      className={cn(
-                        "mt-0.5 h-4 w-4 shrink-0 text-muted-foreground",
-                        photo.isFavorite && "fill-foreground text-foreground"
-                      )}
-                    />
+                    <p className="text-xs font-medium text-muted-foreground">Info</p>
                   </div>
 
-                  <section
-                    aria-label="Camera details"
-                    aria-live="polite"
-                    className="border-t border-black/10 px-3 py-3 dark:border-white/10"
-                  >
-                    {isMetadataLoading && (
-                      <div className="animate-pulse space-y-2" aria-label="Loading camera details">
-                        <div className="h-3 w-32 rounded bg-muted-foreground/20" />
-                        <div className="h-3 w-48 rounded bg-muted-foreground/15" />
-                        <div className="h-3 w-40 rounded bg-muted-foreground/15" />
+                  <div className="max-h-[calc(100vh-112px)] overflow-y-auto">
+                    <div className="flex items-start justify-between gap-3 px-3 py-3">
+                      <div className="min-w-0">
+                        <p className="break-all text-sm font-medium leading-5">{photo.filename}</p>
+                        <time
+                          dateTime={photo.timestamp}
+                          className="mt-0.5 block text-xs leading-4 text-muted-foreground"
+                        >
+                          {formattedDate}
+                        </time>
                       </div>
-                    )}
-
-                    {metadataError && (
-                      <p className="text-xs text-muted-foreground">
-                        Camera information unavailable
-                      </p>
-                    )}
-
-                    {metadata && (
-                      <>
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <p className="text-sm font-medium leading-5">
-                              {cameraName ?? "Photo"}
-                            </p>
-                            {lensDescription && (
-                              <p className="text-xs leading-4 text-muted-foreground">
-                                {lensDescription}
-                              </p>
-                            )}
-                            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                              {dimensions && <span>{dimensions}</span>}
-                              {megapixels && <span>{megapixels}</span>}
-                              <span>{formatFileSize(metadata.fileSize)}</span>
-                              <span className="rounded bg-muted-foreground/20 px-1 py-0.5 text-[10px] font-semibold leading-none text-foreground/70">
-                                {formatPhotoType(metadata.mimeType, photo.filename)}
-                              </span>
-                            </div>
-                          </div>
-                          <Camera
-                            aria-hidden="true"
-                            className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground"
-                          />
-                        </div>
-
-                        {hasExposureDetails && (
-                          <dl className="mt-3 grid grid-cols-5 gap-1 border-t border-black/10 pt-2 text-center text-[10px] leading-4 text-muted-foreground dark:border-white/10">
-                            <div>
-                              <dt className="sr-only">ISO</dt>
-                              <dd>{metadata.iso !== undefined ? `ISO ${metadata.iso}` : "—"}</dd>
-                            </div>
-                            <div>
-                              <dt className="sr-only">Focal length</dt>
-                              <dd>
-                                {metadata.focalLength35mm !== undefined
-                                  ? `${Math.round(metadata.focalLength35mm)} mm`
-                                  : "—"}
-                              </dd>
-                            </div>
-                            <div>
-                              <dt className="sr-only">Exposure compensation</dt>
-                              <dd>
-                                {metadata.exposureCompensation !== undefined
-                                  ? formatExposureCompensation(metadata.exposureCompensation)
-                                  : "—"}
-                              </dd>
-                            </div>
-                            <div>
-                              <dt className="sr-only">Aperture</dt>
-                              <dd>
-                                {metadata.fNumber !== undefined
-                                  ? `ƒ${metadata.fNumber.toFixed(1)}`
-                                  : "—"}
-                              </dd>
-                            </div>
-                            <div>
-                              <dt className="sr-only">Shutter speed</dt>
-                              <dd>
-                                {metadata.exposureTime !== undefined
-                                  ? formatExposureTime(metadata.exposureTime)
-                                  : "—"}
-                              </dd>
-                            </div>
-                          </dl>
+                      <Heart
+                        aria-label={photo.isFavorite ? "Favorite" : "Not a favorite"}
+                        className={cn(
+                          "mt-0.5 h-4 w-4 shrink-0 text-muted-foreground",
+                          photo.isFavorite && "fill-foreground text-foreground"
                         )}
-                      </>
-                    )}
-                  </section>
+                      />
+                    </div>
 
-                  <dl className="grid grid-cols-[88px_minmax(0,1fr)] gap-x-3 gap-y-2 border-t border-black/10 px-3 py-3 text-xs dark:border-white/10">
-                    <dt className="text-muted-foreground">Favorite</dt>
-                    <dd>{photo.isFavorite ? "Yes" : "No"}</dd>
-                    <dt className="text-muted-foreground">Collections</dt>
-                    <dd className="min-w-0 break-words">
-                      {collectionNames.length > 0 ? collectionNames.join(", ") : "None"}
-                    </dd>
-                  </dl>
-                </div>
-              </aside>
-            )}
-          </div>
+                    <CameraDetails
+                      metadata={metadata}
+                      isLoading={isMetadataLoading}
+                      hasError={metadataError}
+                      filename={photo.filename}
+                      variant="desktop"
+                    />
+
+                    <dl className="grid grid-cols-[88px_minmax(0,1fr)] gap-x-3 gap-y-2 border-t border-black/10 px-3 py-3 text-xs dark:border-white/10">
+                      <dt className="text-muted-foreground">Favorite</dt>
+                      <dd>{photo.isFavorite ? "Yes" : "No"}</dd>
+                      <dt className="text-muted-foreground">Collections</dt>
+                      <dd className="min-w-0 break-words">
+                        {collectionNames.length > 0 ? collectionNames.join(", ") : "None"}
+                      </dd>
+                    </dl>
+                  </div>
+                </aside>
+              )}
+            </div>
+          )}
 
           <button
             onClick={() => onToggleFavorite?.(photo.id)}
@@ -374,23 +473,71 @@ export function PhotoViewer({
         </div>
       </div>
 
-      {/* Photo with swipe support */}
       <div
-        {...swipeHandlers}
-        className="flex-1 flex items-center justify-center min-h-0 bg-muted/30"
+        ref={mobileScrollRef}
+        className={cn(
+          "flex-1 min-h-0 bg-background",
+          isMobileView ? "overflow-y-auto" : "overflow-hidden"
+        )}
       >
-        <div className="relative w-full h-full">
-          <Image
-            key={photo.id}
-            src={getViewerUrl(photo.url)}
-            alt=""
-            fill
-            className="object-contain"
-            sizes="(max-width: 768px) 100vw, 80vw"
-            priority
-            unoptimized
-          />
+        {/* Photo with horizontal swipe navigation and native vertical reveal on mobile */}
+        <div
+          {...swipeHandlers}
+          className={cn(
+            "flex h-full items-center justify-center bg-muted/30",
+            isMobileView && "touch-pan-y"
+          )}
+        >
+          <div className="relative h-full w-full">
+            <Image
+              key={photo.id}
+              src={getViewerUrl(photo.url)}
+              alt=""
+              fill
+              className="object-contain"
+              sizes="(max-width: 768px) 100vw, 80vw"
+              priority
+              unoptimized
+            />
+          </div>
         </div>
+
+        {isMobileView && (
+          <section
+            id="mobile-photo-info"
+            aria-label="Photo information"
+            className="border-t border-muted-foreground/20 bg-background px-4 pb-16 pt-5"
+          >
+            <div className="mb-4">
+              <time
+                dateTime={photo.timestamp}
+                className="block text-base font-medium leading-6"
+              >
+                {mobileFormattedDate}
+              </time>
+              <p className="mt-1 break-all text-sm text-muted-foreground">
+                {photo.filename}
+              </p>
+            </div>
+
+            <CameraDetails
+              metadata={metadata}
+              isLoading={isMetadataLoading}
+              hasError={metadataError}
+              filename={photo.filename}
+              variant="mobile"
+            />
+
+            <dl className="mt-4 grid grid-cols-[96px_minmax(0,1fr)] gap-x-3 gap-y-2 rounded-xl bg-muted/70 px-3 py-3 text-sm">
+              <dt className="text-muted-foreground">Favorite</dt>
+              <dd>{photo.isFavorite ? "Yes" : "No"}</dd>
+              <dt className="text-muted-foreground">Collections</dt>
+              <dd className="min-w-0 break-words">
+                {collectionNames.length > 0 ? collectionNames.join(", ") : "None"}
+              </dd>
+            </dl>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSwipeable } from "react-swipeable";
 import { Photo } from "@/types/photos";
-import { ChevronLeft, Heart, Info } from "lucide-react";
+import { Camera, ChevronLeft, Heart, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useClickOutside } from "@/lib/hooks/use-click-outside";
 import { useWindowFocus } from "@/lib/window-focus-context";
@@ -11,6 +11,18 @@ import { toZonedTime } from "date-fns-tz";
 import { format, parseISO } from "date-fns";
 import Image from "next/image";
 import { getViewerUrl } from "@/lib/photos/image-utils";
+import {
+  formatCameraName,
+  formatDimensions,
+  formatExposureCompensation,
+  formatExposureTime,
+  formatFileSize,
+  formatLensDescription,
+  formatMegapixels,
+  formatPhotoType,
+  loadPhotoMetadata,
+} from "@/lib/photos/photo-metadata";
+import type { PhotoMetadata } from "@/lib/photos/photo-metadata";
 
 // Preload an image for faster navigation
 function preloadImage(url: string) {
@@ -50,10 +62,37 @@ export function PhotoViewer({
   const inShell = isDesktop && windowFocus;
   const [isSwiping, setIsSwiping] = useState(false);
   const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const [metadata, setMetadata] = useState<PhotoMetadata | null>(null);
+  const [isMetadataLoading, setIsMetadataLoading] = useState(false);
+  const [metadataError, setMetadataError] = useState(false);
   const infoContainerRef = useRef<HTMLDivElement>(null);
   const closeInfo = useCallback(() => setIsInfoOpen(false), []);
 
   useClickOutside(infoContainerRef, closeInfo, isInfoOpen);
+
+  useEffect(() => {
+    if (!isInfoOpen) return;
+
+    let isCurrent = true;
+    setMetadata(null);
+    setMetadataError(false);
+    setIsMetadataLoading(true);
+
+    loadPhotoMetadata(photo.url)
+      .then((photoMetadata) => {
+        if (isCurrent) setMetadata(photoMetadata);
+      })
+      .catch(() => {
+        if (isCurrent) setMetadataError(true);
+      })
+      .finally(() => {
+        if (isCurrent) setIsMetadataLoading(false);
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [isInfoOpen, photo.url]);
 
   // Prevent default touch move when swiping to avoid scroll interference
   useEffect(() => {
@@ -118,6 +157,20 @@ export function PhotoViewer({
 
   const pstDate = toZonedTime(parseISO(photo.timestamp), "America/Los_Angeles");
   const formattedDate = format(pstDate, "MMMM d, yyyy 'at' h:mm:ss a");
+  const cameraName = metadata ? formatCameraName(metadata) : undefined;
+  const lensDescription = metadata
+    ? formatLensDescription(metadata)
+    : undefined;
+  const dimensions = metadata ? formatDimensions(metadata) : undefined;
+  const megapixels = metadata ? formatMegapixels(metadata) : undefined;
+  const hasExposureDetails = Boolean(
+    metadata &&
+      (metadata.iso !== undefined ||
+        metadata.focalLength35mm !== undefined ||
+        metadata.exposureCompensation !== undefined ||
+        metadata.fNumber !== undefined ||
+        metadata.exposureTime !== undefined)
+  );
 
   return (
     <div className="h-full flex flex-col bg-background">
@@ -183,33 +236,125 @@ export function PhotoViewer({
                   <p className="text-xs font-medium text-muted-foreground">Info</p>
                 </div>
 
-                <div className="flex items-start justify-between gap-3 px-3 py-3">
-                  <div className="min-w-0">
-                    <p className="break-all text-sm font-medium leading-5">{photo.filename}</p>
-                    <time
-                      dateTime={photo.timestamp}
-                      className="mt-0.5 block text-xs leading-4 text-muted-foreground"
-                    >
-                      {formattedDate}
-                    </time>
+                <div className="max-h-[calc(100vh-112px)] overflow-y-auto">
+                  <div className="flex items-start justify-between gap-3 px-3 py-3">
+                    <div className="min-w-0">
+                      <p className="break-all text-sm font-medium leading-5">{photo.filename}</p>
+                      <time
+                        dateTime={photo.timestamp}
+                        className="mt-0.5 block text-xs leading-4 text-muted-foreground"
+                      >
+                        {formattedDate}
+                      </time>
+                    </div>
+                    <Heart
+                      aria-label={photo.isFavorite ? "Favorite" : "Not a favorite"}
+                      className={cn(
+                        "mt-0.5 h-4 w-4 shrink-0 text-muted-foreground",
+                        photo.isFavorite && "fill-foreground text-foreground"
+                      )}
+                    />
                   </div>
-                  <Heart
-                    aria-label={photo.isFavorite ? "Favorite" : "Not a favorite"}
-                    className={cn(
-                      "mt-0.5 h-4 w-4 shrink-0 text-muted-foreground",
-                      photo.isFavorite && "fill-foreground text-foreground"
-                    )}
-                  />
-                </div>
 
-                <dl className="grid grid-cols-[88px_minmax(0,1fr)] gap-x-3 gap-y-2 border-t border-black/10 px-3 py-3 text-xs dark:border-white/10">
-                  <dt className="text-muted-foreground">Favorite</dt>
-                  <dd>{photo.isFavorite ? "Yes" : "No"}</dd>
-                  <dt className="text-muted-foreground">Collections</dt>
-                  <dd className="min-w-0 break-words">
-                    {collectionNames.length > 0 ? collectionNames.join(", ") : "None"}
-                  </dd>
-                </dl>
+                  <section
+                    aria-label="Camera details"
+                    aria-live="polite"
+                    className="border-t border-black/10 px-3 py-3 dark:border-white/10"
+                  >
+                    {isMetadataLoading && (
+                      <div className="animate-pulse space-y-2" aria-label="Loading camera details">
+                        <div className="h-3 w-32 rounded bg-muted-foreground/20" />
+                        <div className="h-3 w-48 rounded bg-muted-foreground/15" />
+                        <div className="h-3 w-40 rounded bg-muted-foreground/15" />
+                      </div>
+                    )}
+
+                    {metadataError && (
+                      <p className="text-xs text-muted-foreground">
+                        Camera information unavailable
+                      </p>
+                    )}
+
+                    {metadata && (
+                      <>
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium leading-5">
+                              {cameraName ?? "Photo"}
+                            </p>
+                            {lensDescription && (
+                              <p className="text-xs leading-4 text-muted-foreground">
+                                {lensDescription}
+                              </p>
+                            )}
+                            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                              {dimensions && <span>{dimensions}</span>}
+                              {megapixels && <span>{megapixels}</span>}
+                              <span>{formatFileSize(metadata.fileSize)}</span>
+                              <span className="rounded bg-muted-foreground/20 px-1 py-0.5 text-[10px] font-semibold leading-none text-foreground/70">
+                                {formatPhotoType(metadata.mimeType, photo.filename)}
+                              </span>
+                            </div>
+                          </div>
+                          <Camera
+                            aria-hidden="true"
+                            className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground"
+                          />
+                        </div>
+
+                        {hasExposureDetails && (
+                          <dl className="mt-3 grid grid-cols-5 gap-1 border-t border-black/10 pt-2 text-center text-[10px] leading-4 text-muted-foreground dark:border-white/10">
+                            <div>
+                              <dt className="sr-only">ISO</dt>
+                              <dd>{metadata.iso !== undefined ? `ISO ${metadata.iso}` : "—"}</dd>
+                            </div>
+                            <div>
+                              <dt className="sr-only">Focal length</dt>
+                              <dd>
+                                {metadata.focalLength35mm !== undefined
+                                  ? `${Math.round(metadata.focalLength35mm)} mm`
+                                  : "—"}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className="sr-only">Exposure compensation</dt>
+                              <dd>
+                                {metadata.exposureCompensation !== undefined
+                                  ? formatExposureCompensation(metadata.exposureCompensation)
+                                  : "—"}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className="sr-only">Aperture</dt>
+                              <dd>
+                                {metadata.fNumber !== undefined
+                                  ? `ƒ${metadata.fNumber.toFixed(1)}`
+                                  : "—"}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className="sr-only">Shutter speed</dt>
+                              <dd>
+                                {metadata.exposureTime !== undefined
+                                  ? formatExposureTime(metadata.exposureTime)
+                                  : "—"}
+                              </dd>
+                            </div>
+                          </dl>
+                        )}
+                      </>
+                    )}
+                  </section>
+
+                  <dl className="grid grid-cols-[88px_minmax(0,1fr)] gap-x-3 gap-y-2 border-t border-black/10 px-3 py-3 text-xs dark:border-white/10">
+                    <dt className="text-muted-foreground">Favorite</dt>
+                    <dd>{photo.isFavorite ? "Yes" : "No"}</dd>
+                    <dt className="text-muted-foreground">Collections</dt>
+                    <dd className="min-w-0 break-words">
+                      {collectionNames.length > 0 ? collectionNames.join(", ") : "None"}
+                    </dd>
+                  </dl>
+                </div>
               </aside>
             )}
           </div>

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -408,9 +408,26 @@ export function PhotoViewer({
                   className="absolute right-0 top-[calc(100%+12px)] z-20 w-[min(320px,calc(100vw-24px))] overflow-hidden rounded-xl border border-black/10 bg-muted/95 text-foreground shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-2xl dark:border-white/15"
                 >
                   <div className="relative flex h-8 items-center justify-center border-b border-black/10 px-3 dark:border-white/10">
-                    <div className="absolute left-3 flex gap-1.5" aria-hidden="true">
-                      <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
-                      <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
+                    <div className="absolute left-3 flex gap-1.5">
+                      <button
+                        type="button"
+                        aria-label="Close photo information"
+                        onClick={closeInfo}
+                        className="group relative flex h-2.5 w-2.5 items-center justify-center rounded-full bg-muted-foreground/30 transition-colors can-hover:hover:bg-[#FF5F57] focus-visible:bg-[#FF5F57] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          viewBox="0 0 10 10"
+                          className="h-2 w-2 text-black/55 opacity-0 transition-opacity can-hover:group-hover:opacity-100 group-focus-visible:opacity-100"
+                          fill="currentColor"
+                        >
+                          <path d="M2.2 1.4 5 4.2l2.8-2.8.8.8L5.8 5l2.8 2.8-.8.8L5 5.8 2.2 8.6l-.8-.8L4.2 5 1.4 2.2z" />
+                        </svg>
+                      </button>
+                      <span
+                        aria-hidden="true"
+                        className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30"
+                      />
                       <span className="h-2.5 w-2.5 rounded-full bg-muted-foreground/30" />
                     </div>
                     <p className="text-xs font-medium text-muted-foreground">Info</p>

--- a/lib/photos/photo-metadata.ts
+++ b/lib/photos/photo-metadata.ts
@@ -1,0 +1,213 @@
+export interface PhotoMetadata {
+  make?: string;
+  model?: string;
+  lensModel?: string;
+  width?: number;
+  height?: number;
+  fileSize: number;
+  mimeType: string;
+  fNumber?: number;
+  focalLength?: number;
+  focalLength35mm?: number;
+  iso?: number;
+  exposureTime?: number;
+  exposureCompensation?: number;
+}
+
+interface RawExif {
+  Make?: unknown;
+  Model?: unknown;
+  LensModel?: unknown;
+  ExifImageWidth?: unknown;
+  ExifImageHeight?: unknown;
+  FNumber?: unknown;
+  FocalLength?: unknown;
+  FocalLengthIn35mmFormat?: unknown;
+  ISO?: unknown;
+  ExposureTime?: unknown;
+  ExposureCompensation?: unknown;
+}
+
+const metadataCache = new Map<string, Promise<PhotoMetadata>>();
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+async function getImageDimensions(
+  blob: Blob
+): Promise<{ width: number; height: number } | undefined> {
+  if (typeof createImageBitmap !== "function") return undefined;
+
+  try {
+    const bitmap = await createImageBitmap(blob);
+    const dimensions = { width: bitmap.width, height: bitmap.height };
+    bitmap.close();
+    return dimensions;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readPhotoMetadata(url: string): Promise<PhotoMetadata> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Could not load photo metadata (${response.status})`);
+  }
+
+  const blob = await response.blob();
+  let rawExif: RawExif = {};
+
+  try {
+    const { parse } = await import("exifr");
+    rawExif =
+      ((await parse(blob, {
+        ifd0: { pick: ["Make", "Model"] },
+        exif: {
+          pick: [
+            "LensModel",
+            "ExifImageWidth",
+            "ExifImageHeight",
+            "FNumber",
+            "FocalLength",
+            "FocalLengthIn35mmFormat",
+            "ISO",
+            "ExposureTime",
+            "ExposureCompensation",
+          ],
+        },
+        gps: false,
+        mergeOutput: true,
+      })) as RawExif | undefined) ?? {};
+  } catch {
+    // File-level details can still be shown when a photo has no readable EXIF.
+  }
+
+  const exifWidth = numberValue(rawExif.ExifImageWidth);
+  const exifHeight = numberValue(rawExif.ExifImageHeight);
+  const dimensions =
+    exifWidth && exifHeight
+      ? { width: exifWidth, height: exifHeight }
+      : await getImageDimensions(blob);
+
+  return {
+    make: stringValue(rawExif.Make),
+    model: stringValue(rawExif.Model),
+    lensModel: stringValue(rawExif.LensModel),
+    width: dimensions?.width,
+    height: dimensions?.height,
+    fileSize: blob.size,
+    mimeType: blob.type,
+    fNumber: numberValue(rawExif.FNumber),
+    focalLength: numberValue(rawExif.FocalLength),
+    focalLength35mm: numberValue(rawExif.FocalLengthIn35mmFormat),
+    iso: numberValue(rawExif.ISO),
+    exposureTime: numberValue(rawExif.ExposureTime),
+    exposureCompensation: numberValue(rawExif.ExposureCompensation),
+  };
+}
+
+export function loadPhotoMetadata(url: string): Promise<PhotoMetadata> {
+  const cached = metadataCache.get(url);
+  if (cached) return cached;
+
+  const request = readPhotoMetadata(url).catch((error) => {
+    metadataCache.delete(url);
+    throw error;
+  });
+  metadataCache.set(url, request);
+  return request;
+}
+
+export function formatCameraName(metadata: PhotoMetadata): string | undefined {
+  if (metadata.make && metadata.model) {
+    if (metadata.model.toLowerCase().startsWith(metadata.make.toLowerCase())) {
+      return metadata.model;
+    }
+    return `${metadata.make} ${metadata.model}`;
+  }
+  return metadata.model ?? metadata.make;
+}
+
+export function formatLensDescription(
+  metadata: PhotoMetadata
+): string | undefined {
+  let lensName = metadata.lensModel;
+  if (lensName && metadata.model) {
+    lensName = lensName.replace(
+      new RegExp(`^${escapeRegExp(metadata.model)}\\s*`, "i"),
+      ""
+    );
+  }
+  lensName = lensName
+    ?.replace(/\s+\d+(?:\.\d+)?mm\s+f\/\d+(?:\.\d+)?$/i, "")
+    .trim();
+  if (lensName) {
+    lensName = lensName.charAt(0).toUpperCase() + lensName.slice(1);
+  }
+
+  const details = [
+    metadata.focalLength35mm
+      ? `${Math.round(metadata.focalLength35mm)} mm`
+      : undefined,
+    metadata.fNumber ? `ƒ${formatDecimal(metadata.fNumber)}` : undefined,
+  ].filter(Boolean);
+
+  if (lensName && details.length > 0) {
+    return `${lensName} — ${details.join(" ")}`;
+  }
+  return lensName ?? (details.length > 0 ? details.join(" ") : undefined);
+}
+
+export function formatDimensions(metadata: PhotoMetadata): string | undefined {
+  if (!metadata.width || !metadata.height) return undefined;
+  return `${metadata.width} × ${metadata.height}`;
+}
+
+export function formatMegapixels(metadata: PhotoMetadata): string | undefined {
+  if (!metadata.width || !metadata.height) return undefined;
+  const megapixels = (metadata.width * metadata.height) / 1_000_000;
+  return `${formatDecimal(megapixels)} MP`;
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1_000) return `${bytes} B`;
+  if (bytes < 1_000_000) return `${formatDecimal(bytes / 1_000)} KB`;
+  return `${formatDecimal(bytes / 1_000_000)} MB`;
+}
+
+export function formatPhotoType(mimeType: string, filename: string): string {
+  const normalizedMimeType = mimeType.toLowerCase();
+  if (normalizedMimeType === "image/jpeg") return "JPEG";
+  if (normalizedMimeType === "image/png") return "PNG";
+  if (normalizedMimeType === "image/webp") return "WEBP";
+  if (normalizedMimeType === "image/heic") return "HEIC";
+
+  const extension = filename.split(".").pop()?.toUpperCase();
+  return extension || "IMAGE";
+}
+
+export function formatExposureTime(seconds: number): string {
+  if (seconds >= 1) return `${formatDecimal(seconds)} s`;
+  if (seconds <= 0) return "—";
+  return `1/${Math.round(1 / seconds)} s`;
+}
+
+export function formatExposureCompensation(value: number): string {
+  const normalized = Math.abs(value) < 0.05 ? 0 : value;
+  return `${normalized > 0 ? "+" : ""}${formatDecimal(normalized)} ev`;
+}
+
+function formatDecimal(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "emoji-mart": "^5.6.0",
+        "exifr": "7.1.3",
         "lodash": "^4.17.21",
         "lucide-react": "^0.460.0",
         "next": "^16.1.1",
@@ -7838,6 +7839,12 @@
       "engines": {
         "node": ">=14.18"
       }
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "emoji-mart": "^5.6.0",
+    "exifr": "7.1.3",
     "lodash": "^4.17.21",
     "lucide-react": "^0.460.0",
     "next": "^16.1.1",

--- a/tests/photo-metadata.test.ts
+++ b/tests/photo-metadata.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatCameraName,
+  formatExposureCompensation,
+  formatExposureTime,
+  formatFileSize,
+  formatLensDescription,
+  formatMegapixels,
+} from "../lib/photos/photo-metadata";
+import type { PhotoMetadata } from "../lib/photos/photo-metadata";
+
+const iphoneMetadata: PhotoMetadata = {
+  make: "Apple",
+  model: "iPhone 16 Pro",
+  lensModel: "iPhone 16 Pro back triple camera 6.765mm f/1.78",
+  width: 2048,
+  height: 2731,
+  fileSize: 978_903,
+  mimeType: "image/jpeg",
+  fNumber: 1.78,
+  focalLength: 6.765,
+  focalLength35mm: 24,
+  iso: 80,
+  exposureTime: 0.0001099989,
+  exposureCompensation: 0,
+};
+
+test("formats the native-style camera and lens labels", () => {
+  assert.equal(formatCameraName(iphoneMetadata), "Apple iPhone 16 Pro");
+  assert.equal(
+    formatLensDescription(iphoneMetadata),
+    "Back triple camera — 24 mm ƒ1.8"
+  );
+});
+
+test("formats file size and megapixels compactly", () => {
+  assert.equal(formatFileSize(iphoneMetadata.fileSize), "978.9 KB");
+  assert.equal(formatMegapixels(iphoneMetadata), "5.6 MP");
+});
+
+test("formats sub-second shutter speeds as fractions", () => {
+  assert.equal(formatExposureTime(iphoneMetadata.exposureTime!), "1/9091 s");
+  assert.equal(formatExposureTime(1.5), "1.5 s");
+});
+
+test("normalizes zero and positive exposure compensation", () => {
+  assert.equal(formatExposureCompensation(0.01), "0 ev");
+  assert.equal(formatExposureCompensation(0.7), "+0.7 ev");
+});


### PR DESCRIPTION
## Today's delight

Photos now exposes the real metadata embedded in uploaded images in the way each platform expects:

- Desktop keeps the toolbar Info control and native-inspired floating panel.
- Mobile removes that Info button entirely. Swiping upward on the photo naturally reveals the date, filename, camera/lens card, dimensions, megapixels, file size, format, ISO, focal length, exposure compensation, aperture, shutter speed, favorite state, and collections below the image.

Existing photos work without re-uploading, changing the database, or backfilling production data. New photos added through the existing iOS Shortcut flow are read the same way as long as the uploaded image contains the metadata. Precise GPS metadata is intentionally neither parsed nor displayed.

## Built result

The mobile viewer was verified at 390 × 844 with an actual uploaded JPEG. Before the gesture, the toolbar contains only Back and Favorite—there is no mobile Info button. After an upward swipe, it renders:

- Sunday · July 5, 2026 · 10:42 AM
- IMG_1783393934191.jpeg
- Apple iPhone 16 Pro
- Back triple camera — 24 mm ƒ1.8
- 5.6 MP · 2048 × 2731 · 978.9 KB · JPEG
- ISO 80 · 24 mm · 0 ev · ƒ1.8 · 1/9091 s

_The verified desktop and mobile captures are ready outside the repository, but GitHub attachment upload is blocked because the ChatGPT Chrome Extension does not have file-URL access enabled. No screenshot was committed as a workaround._

## macOS and iOS inspiration

Apple's current [Photos User Guide for macOS Tahoe](https://support.apple.com/fr-fr/guide/photos/phta8b25fa42/mac) documents the desktop Info control. The mobile treatment follows the supplied iOS Photos reference instead: the image and its capture details form one vertically scrollable view, with the camera metadata summarized in a rounded card beneath the photo.

## Why this one

The original app stopped at database fields because the upload API records only filename, timestamp, and collections. Inspection of an actual storage object confirmed that the Shortcut's resized JPEG still preserves rich EXIF metadata, so the native camera block can be reconstructed directly from the existing library without backend work.

## Verification

- `npm run check` (20 tests, typecheck, production build; seven pre-existing lint warnings, zero errors)
- Parsed a real uploaded JPEG and cross-checked its values against macOS ImageIO
- Visually verified the desktop Info panel
- Verified hovering anywhere across the Info panel's three-dot cluster reveals the native red × state on the left close control; only that control is actionable, while the other two dots remain inert gray
- Visually verified the mobile viewer at 390 × 844 before and after an upward swipe
- Confirmed the mobile Info-button count is zero
- Confirmed no new browser console errors during metadata loading or the swipe-up interaction

## Scope

Bounded to Photos: one viewer component, one focused metadata helper, one test file, the pinned zero-dependency `exifr` package and lockfile, plus the existing Photos architecture note in README. No schema migration, production-data write, external service, shortcut change, key-driven navigation, or GPS exposure.
