### PR TITLE
Improve mobile Notes long-press actions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -233,6 +233,14 @@ html, body {
   caret-color: #e2a727;
 }
 
+/* Let gallery-card long presses open Notes actions instead of selecting text. */
+.notes-gallery-context-trigger,
+.notes-gallery-context-trigger * {
+  -webkit-touch-callout: none !important;
+  -webkit-user-select: none !important;
+  user-select: none !important;
+}
+
 /* Green caret for iTerm app */
 .iterm-app * {
   caret-color: #22c55e;

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -197,7 +197,7 @@ function MobileGalleryNoteActions({
             type="button"
             aria-label={`Open ${note.title}`}
             onClick={handleOpenNote}
-            className="block h-[min(52dvh,32rem)] w-full overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl outline-none will-change-transform focus-visible:ring-2 focus-visible:ring-[#E2A727]"
+            className="block h-[min(52dvh,32rem)] w-full overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl outline-none will-change-transform"
           >
             <h2 className="text-2xl font-bold leading-tight">
               {note.emoji} {note.title}

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Pin, PinOff, Trash2 } from "lucide-react";
@@ -50,12 +57,21 @@ interface GalleryCardProps {
 
 const MOBILE_CONTEXT_MENU_DELAY_MS = 550;
 const MOBILE_CONTEXT_MENU_MOVE_TOLERANCE = 10;
+const MOBILE_NOTE_EXPAND_DURATION_MS = 320;
+
+interface GalleryCardBounds {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
 
 function MobileGalleryNoteActions({
   note,
   isPinned,
   canDelete,
   open,
+  sourceBounds,
   onOpenChange,
   onPinToggle,
   onDelete,
@@ -64,15 +80,73 @@ function MobileGalleryNoteActions({
   isPinned: boolean;
   canDelete: boolean;
   open: boolean;
+  sourceBounds: GalleryCardBounds | null;
   onOpenChange: (open: boolean) => void;
   onPinToggle: (slug: string) => void;
   onDelete: (note: Note) => Promise<void>;
 }) {
+  const previewRef = useRef<HTMLDivElement>(null);
+  const actionsRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (open) {
       window.getSelection()?.removeAllRanges();
     }
   }, [open]);
+
+  useLayoutEffect(() => {
+    const preview = previewRef.current;
+    const actions = actionsRef.current;
+    if (!open || !sourceBounds || !preview || !actions) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const targetBounds = preview.getBoundingClientRect();
+    const translateX =
+      sourceBounds.left +
+      sourceBounds.width / 2 -
+      (targetBounds.left + targetBounds.width / 2);
+    const translateY =
+      sourceBounds.top +
+      sourceBounds.height / 2 -
+      (targetBounds.top + targetBounds.height / 2);
+    const scaleX = sourceBounds.width / targetBounds.width;
+    const scaleY = sourceBounds.height / targetBounds.height;
+
+    const previewAnimation = preview.animate(
+      [
+        {
+          transform: `translate3d(${translateX}px, ${translateY}px, 0) scale(${scaleX}, ${scaleY})`,
+          borderRadius: "8px",
+        },
+        {
+          transform: "translate3d(0, 0, 0) scale(1, 1)",
+          borderRadius: "28px",
+        },
+      ],
+      {
+        duration: MOBILE_NOTE_EXPAND_DURATION_MS,
+        easing: "cubic-bezier(0.2, 0.8, 0.2, 1)",
+        fill: "both",
+      },
+    );
+    const actionsAnimation = actions.animate(
+      [
+        { opacity: 0, transform: "translateY(-10px) scale(0.97)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ],
+      {
+        duration: 170,
+        delay: MOBILE_NOTE_EXPAND_DURATION_MS - 110,
+        easing: "cubic-bezier(0.2, 0.8, 0.2, 1)",
+        fill: "both",
+      },
+    );
+
+    return () => {
+      previewAnimation.cancel();
+      actionsAnimation.cancel();
+    };
+  }, [open, sourceBounds]);
 
   const handlePinToggle = () => {
     onOpenChange(false);
@@ -88,49 +162,57 @@ function MobileGalleryNoteActions({
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-[90] bg-black/25 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <DialogPrimitive.Content className="fixed left-1/2 top-1/2 z-[91] w-full max-w-[560px] -translate-x-1/2 -translate-y-1/2 px-4 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
-          <DialogPrimitive.Title className="sr-only">
-            Note actions for {note.title}
-          </DialogPrimitive.Title>
-          <DialogPrimitive.Description className="sr-only">
-            Preview the note, then pin, unpin, or delete it.
-          </DialogPrimitive.Description>
+        <DialogPrimitive.Content className="pointer-events-none fixed inset-0 z-[91] flex items-center justify-center px-4 outline-none">
+          <div className="pointer-events-auto w-full max-w-[560px]">
+            <DialogPrimitive.Title className="sr-only">
+              Note actions for {note.title}
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Description className="sr-only">
+              Preview the note, then pin, unpin, or delete it.
+            </DialogPrimitive.Description>
 
-          <div className="h-[min(52dvh,32rem)] overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl">
-            <h2 className="text-2xl font-bold leading-tight">
-              {note.emoji} {note.title}
-            </h2>
-            <p className="mt-8 whitespace-pre-wrap text-[17px] leading-6 text-foreground">
-              {getNotePreviewText(note.content)}
-            </p>
-          </div>
-
-          <div className="mx-auto mt-3 w-[calc(100%-3rem)] max-w-sm overflow-hidden rounded-[22px] border border-muted-foreground/15 bg-background/95 shadow-2xl backdrop-blur-xl">
-            <button
-              type="button"
-              onClick={handlePinToggle}
-              className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
+            <div
+              ref={previewRef}
+              className="h-[min(52dvh,32rem)] overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl will-change-transform"
             >
-              {isPinned ? (
-                <PinOff className="h-5 w-5 shrink-0" aria-hidden />
-              ) : (
-                <Pin className="h-5 w-5 shrink-0" aria-hidden />
+              <h2 className="text-2xl font-bold leading-tight">
+                {note.emoji} {note.title}
+              </h2>
+              <p className="mt-8 whitespace-pre-wrap text-[17px] leading-6 text-foreground">
+                {getNotePreviewText(note.content)}
+              </p>
+            </div>
+
+            <div
+              ref={actionsRef}
+              className="mx-auto mt-3 w-[calc(100%-3rem)] max-w-sm overflow-hidden rounded-[22px] border border-muted-foreground/15 bg-background/95 shadow-2xl backdrop-blur-xl will-change-transform"
+            >
+              <button
+                type="button"
+                onClick={handlePinToggle}
+                className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
+              >
+                {isPinned ? (
+                  <PinOff className="h-5 w-5 shrink-0" aria-hidden />
+                ) : (
+                  <Pin className="h-5 w-5 shrink-0" aria-hidden />
+                )}
+                <span>{isPinned ? "Unpin Note" : "Pin Note"}</span>
+              </button>
+              {canDelete && (
+                <>
+                  <div className="mx-5 border-t border-muted-foreground/20" />
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] text-red-600 outline-none active:bg-muted focus-visible:bg-muted"
+                  >
+                    <Trash2 className="h-5 w-5 shrink-0" aria-hidden />
+                    <span>Delete</span>
+                  </button>
+                </>
               )}
-              <span>{isPinned ? "Unpin Note" : "Pin Note"}</span>
-            </button>
-            {canDelete && (
-              <>
-                <div className="mx-5 border-t border-muted-foreground/20" />
-                <button
-                  type="button"
-                  onClick={handleDelete}
-                  className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] text-red-600 outline-none active:bg-muted focus-visible:bg-muted"
-                >
-                  <Trash2 className="h-5 w-5 shrink-0" aria-hidden />
-                  <span>Delete</span>
-                </button>
-              </>
-            )}
+            </div>
           </div>
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>
@@ -149,6 +231,9 @@ function GalleryCard({
 }: GalleryCardProps) {
   const [hasMounted, setHasMounted] = useState(false);
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+  const [contextMenuSourceBounds, setContextMenuSourceBounds] =
+    useState<GalleryCardBounds | null>(null);
+  const cardButtonRef = useRef<HTMLButtonElement>(null);
   const longPressTimerRef = useRef<number | null>(null);
   const longPressOriginRef = useRef<{ x: number; y: number } | null>(null);
   const suppressNextClickRef = useRef(false);
@@ -175,6 +260,15 @@ function GalleryCard({
     suppressNextClickRef.current = false;
     longPressOriginRef.current = { x: event.clientX, y: event.clientY };
     longPressTimerRef.current = window.setTimeout(() => {
+      const cardBounds = cardButtonRef.current?.getBoundingClientRect();
+      if (cardBounds) {
+        setContextMenuSourceBounds({
+          top: cardBounds.top,
+          left: cardBounds.left,
+          width: cardBounds.width,
+          height: cardBounds.height,
+        });
+      }
       window.getSelection()?.removeAllRanges();
       suppressNextClickRef.current = true;
       setIsContextMenuOpen(true);
@@ -243,6 +337,7 @@ function GalleryCard({
       onPointerCancel={isMobile ? handlePointerEnd : undefined}
     >
       <button
+        ref={cardButtonRef}
         type="button"
         data-note-slug={note.slug}
         onClick={handleCardClick}
@@ -332,6 +427,7 @@ function GalleryCard({
           isPinned={isPinned}
           canDelete={canDelete}
           open={isContextMenuOpen}
+          sourceBounds={contextMenuSourceBounds}
           onOpenChange={handleMobileActionsOpenChange}
           onPinToggle={onPinToggle}
           onDelete={onDelete}

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Pin, PinOff, Trash2 } from "lucide-react";
 import { NoteItem } from "./note-item";
 import { Note, NotesViewMode } from "@/lib/notes/types";
@@ -47,6 +48,96 @@ interface GalleryCardProps {
   isMobile: boolean;
 }
 
+const MOBILE_CONTEXT_MENU_DELAY_MS = 550;
+const MOBILE_CONTEXT_MENU_MOVE_TOLERANCE = 10;
+
+function MobileGalleryNoteActions({
+  note,
+  isPinned,
+  canDelete,
+  open,
+  onOpenChange,
+  onPinToggle,
+  onDelete,
+}: {
+  note: Note;
+  isPinned: boolean;
+  canDelete: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPinToggle: (slug: string) => void;
+  onDelete: (note: Note) => Promise<void>;
+}) {
+  useEffect(() => {
+    if (open) {
+      window.getSelection()?.removeAllRanges();
+    }
+  }, [open]);
+
+  const handlePinToggle = () => {
+    onOpenChange(false);
+    onPinToggle(note.slug);
+  };
+
+  const handleDelete = () => {
+    onOpenChange(false);
+    void onDelete(note);
+  };
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[90] bg-black/25 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content className="fixed left-1/2 top-1/2 z-[91] w-full max-w-[560px] -translate-x-1/2 -translate-y-1/2 px-4 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+          <DialogPrimitive.Title className="sr-only">
+            Note actions for {note.title}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Preview the note, then pin, unpin, or delete it.
+          </DialogPrimitive.Description>
+
+          <div className="h-[min(52dvh,32rem)] overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl">
+            <h2 className="text-2xl font-bold leading-tight">
+              {note.emoji} {note.title}
+            </h2>
+            <p className="mt-8 whitespace-pre-wrap text-[17px] leading-6 text-foreground">
+              {getNotePreviewText(note.content)}
+            </p>
+          </div>
+
+          <div className="mx-auto mt-3 w-[calc(100%-3rem)] max-w-sm overflow-hidden rounded-[22px] border border-muted-foreground/15 bg-background/95 shadow-2xl backdrop-blur-xl">
+            <button
+              type="button"
+              onClick={handlePinToggle}
+              className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
+            >
+              {isPinned ? (
+                <PinOff className="h-5 w-5 shrink-0" aria-hidden />
+              ) : (
+                <Pin className="h-5 w-5 shrink-0" aria-hidden />
+              )}
+              <span>{isPinned ? "Unpin Note" : "Pin Note"}</span>
+            </button>
+            {canDelete && (
+              <>
+                <div className="mx-5 border-t border-muted-foreground/20" />
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] text-red-600 outline-none active:bg-muted focus-visible:bg-muted"
+                >
+                  <Trash2 className="h-5 w-5 shrink-0" aria-hidden />
+                  <span>Delete</span>
+                </button>
+              </>
+            )}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
 function GalleryCard({
   note,
   isPinned,
@@ -57,122 +148,214 @@ function GalleryCard({
   isMobile,
 }: GalleryCardProps) {
   const [hasMounted, setHasMounted] = useState(false);
+  const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+  const longPressTimerRef = useRef<number | null>(null);
+  const longPressOriginRef = useRef<{ x: number; y: number } | null>(null);
+  const suppressNextClickRef = useRef(false);
   const canDelete = note.session_id === sessionId;
 
   useEffect(() => {
     setHasMounted(true);
   }, []);
 
+  const clearLongPressTimer = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+    longPressOriginRef.current = null;
+  }, []);
+
+  useEffect(() => clearLongPressTimer, [clearLongPressTimer]);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLElement>) => {
+    if (!isMobile || !["touch", "pen"].includes(event.pointerType)) return;
+
+    clearLongPressTimer();
+    suppressNextClickRef.current = false;
+    longPressOriginRef.current = { x: event.clientX, y: event.clientY };
+    longPressTimerRef.current = window.setTimeout(() => {
+      window.getSelection()?.removeAllRanges();
+      suppressNextClickRef.current = true;
+      setIsContextMenuOpen(true);
+      clearLongPressTimer();
+    }, MOBILE_CONTEXT_MENU_DELAY_MS);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLElement>) => {
+    const origin = longPressOriginRef.current;
+    if (!origin) return;
+
+    if (
+      Math.abs(event.clientX - origin.x) >
+        MOBILE_CONTEXT_MENU_MOVE_TOLERANCE ||
+      Math.abs(event.clientY - origin.y) >
+        MOBILE_CONTEXT_MENU_MOVE_TOLERANCE
+    ) {
+      clearLongPressTimer();
+    }
+  };
+
+  const handlePointerEnd = () => {
+    clearLongPressTimer();
+  };
+
+  const suppressClickAfterLongPress = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    if (!suppressNextClickRef.current) return false;
+
+    event.preventDefault();
+    event.stopPropagation();
+    suppressNextClickRef.current = false;
+    return true;
+  };
+
+  const handleCardClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!suppressClickAfterLongPress(event)) {
+      onNoteSelect(note);
+    }
+  };
+
+  const handleQuickPinClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!suppressClickAfterLongPress(event)) {
+      onPinToggle(note.slug);
+    }
+  };
+
+  const handleMobileActionsOpenChange = (open: boolean) => {
+    setIsContextMenuOpen(open);
+    if (!open) suppressNextClickRef.current = false;
+  };
+
+  const cardContent = (
+    <article
+      className={cn(
+        "group relative min-w-0",
+        isMobile && "notes-gallery-context-trigger select-none",
+      )}
+      onContextMenu={
+        isMobile ? (event) => event.preventDefault() : undefined
+      }
+      onPointerDown={isMobile ? handlePointerDown : undefined}
+      onPointerMove={isMobile ? handlePointerMove : undefined}
+      onPointerUp={isMobile ? handlePointerEnd : undefined}
+      onPointerCancel={isMobile ? handlePointerEnd : undefined}
+    >
+      <button
+        type="button"
+        data-note-slug={note.slug}
+        onClick={handleCardClick}
+        className={cn(
+          "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-background text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
+          isMobile
+            ? "rounded-lg px-2 py-1.5"
+            : "rounded-xl px-4 py-3",
+        )}
+      >
+        <h4
+          className={cn(
+            "line-clamp-2 font-semibold",
+            isMobile
+              ? "pr-5 text-[9px] leading-[11px]"
+              : "pr-7 text-sm leading-5",
+          )}
+        >
+          {note.emoji} {note.title}
+        </h4>
+        <p
+          className={cn(
+            "whitespace-pre-wrap text-muted-foreground",
+            isMobile
+              ? "mt-1 line-clamp-[6] text-[7px] leading-[1.25]"
+              : "mt-2 line-clamp-[7] text-xs leading-[1.35]",
+          )}
+        >
+          {getNotePreviewText(note.content)}
+        </p>
+      </button>
+
+      {isPinned && (
+        <button
+          type="button"
+          aria-label={`Unpin ${note.title}`}
+          onClick={handleQuickPinClick}
+          className={cn(
+            "absolute flex items-center justify-center bg-muted text-muted-foreground shadow-sm transition-colors can-hover:hover:bg-muted-foreground/15 can-hover:hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
+            isMobile
+              ? "right-1.5 top-1.5 h-6 w-6 rounded-md"
+              : "right-3 top-3 h-7 w-7 rounded-lg",
+          )}
+        >
+          <Pin
+            className={cn(
+              "fill-current",
+              isMobile ? "h-3.5 w-3.5" : "h-4 w-4",
+            )}
+            aria-hidden
+          />
+        </button>
+      )}
+
+      <div className={cn("text-center", isMobile ? "mt-2" : "mt-2 px-1")}>
+        <h4
+          className={cn(
+            "font-medium",
+            isMobile
+              ? "line-clamp-2 text-[15px] leading-[18px]"
+              : "truncate text-sm",
+          )}
+        >
+          {note.title}
+        </h4>
+        <p
+          className={cn(
+            "mt-0.5 text-muted-foreground tabular-nums",
+            isMobile ? "text-[13px] leading-4" : "text-xs",
+            !hasMounted && "invisible",
+          )}
+        >
+          {hasMounted
+            ? new Date(getDisplayCreatedAt(note)).toLocaleDateString("en-US")
+            : "00/00/0000"}
+        </p>
+      </div>
+    </article>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        {cardContent}
+        <MobileGalleryNoteActions
+          note={note}
+          isPinned={isPinned}
+          canDelete={canDelete}
+          open={isContextMenuOpen}
+          onOpenChange={handleMobileActionsOpenChange}
+          onPinToggle={onPinToggle}
+          onDelete={onDelete}
+        />
+      </>
+    );
+  }
+
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <article className="group relative min-w-0 select-none">
-          <button
-            type="button"
-            data-note-slug={note.slug}
-            onClick={() => onNoteSelect(note)}
-            className={cn(
-              "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-background text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
-              isMobile
-                ? "rounded-lg px-2 py-1.5"
-                : "rounded-xl px-4 py-3",
-            )}
-          >
-            <h4
-              className={cn(
-                "line-clamp-2 font-semibold",
-                isMobile
-                  ? "pr-5 text-[9px] leading-[11px]"
-                  : "pr-7 text-sm leading-5",
-              )}
-            >
-              {note.emoji} {note.title}
-            </h4>
-            <p
-              className={cn(
-                "whitespace-pre-wrap text-muted-foreground",
-                isMobile
-                  ? "mt-1 line-clamp-[6] text-[7px] leading-[1.25]"
-                  : "mt-2 line-clamp-[7] text-xs leading-[1.35]",
-              )}
-            >
-              {getNotePreviewText(note.content)}
-            </p>
-          </button>
-
-          {isPinned && (
-            <button
-              type="button"
-              aria-label={`Unpin ${note.title}`}
-              onClick={() => onPinToggle(note.slug)}
-              className={cn(
-                "absolute flex items-center justify-center bg-muted text-muted-foreground shadow-sm transition-colors can-hover:hover:bg-muted-foreground/15 can-hover:hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
-                isMobile
-                  ? "right-1.5 top-1.5 h-6 w-6 rounded-md"
-                  : "right-3 top-3 h-7 w-7 rounded-lg",
-              )}
-            >
-              <Pin
-                className={cn(
-                  "fill-current",
-                  isMobile ? "h-3.5 w-3.5" : "h-4 w-4",
-                )}
-                aria-hidden
-              />
-            </button>
-          )}
-
-          <div className={cn("text-center", isMobile ? "mt-2" : "mt-2 px-1")}>
-            <h4
-              className={cn(
-                "font-medium",
-                isMobile
-                  ? "line-clamp-2 text-[15px] leading-[18px]"
-                  : "truncate text-sm",
-              )}
-            >
-              {note.title}
-            </h4>
-            <p
-              className={cn(
-                "mt-0.5 text-muted-foreground tabular-nums",
-                isMobile ? "text-[13px] leading-4" : "text-xs",
-                !hasMounted && "invisible",
-              )}
-            >
-              {hasMounted
-                ? new Date(getDisplayCreatedAt(note)).toLocaleDateString("en-US")
-                : "00/00/0000"}
-            </p>
-          </div>
-        </article>
-      </ContextMenuTrigger>
+      <ContextMenuTrigger asChild>{cardContent}</ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem
           onClick={() => onPinToggle(note.slug)}
-          className={cn(
-            "focus:bg-[#0A7CFF] focus:text-white",
-            isMobile && "flex items-center justify-between",
-          )}
+          className="focus:bg-[#0A7CFF] focus:text-white"
         >
-          <span>{isPinned ? "Unpin" : "Pin"}</span>
-          {isMobile &&
-            (isPinned ? (
-              <PinOff className="ml-2 h-4 w-4" aria-hidden />
-            ) : (
-              <Pin className="ml-2 h-4 w-4" aria-hidden />
-            ))}
+          {isPinned ? "Unpin" : "Pin"}
         </ContextMenuItem>
         {canDelete && (
           <ContextMenuItem
             onClick={() => void onDelete(note)}
-            className={cn(
-              "text-red-600 focus:bg-[#0A7CFF] focus:text-white",
-              isMobile && "flex items-center justify-between",
-            )}
+            className="text-red-600 focus:bg-[#0A7CFF] focus:text-white"
           >
-            <span>Delete</span>
-            {isMobile && <Trash2 className="ml-2 h-4 w-4" aria-hidden />}
+            Delete
           </ContextMenuItem>
         )}
       </ContextMenuContent>

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -78,6 +78,7 @@ function MobileGalleryNoteActions({
   sourceBounds,
   onOpenChange,
   onRestoreFocus,
+  onOpenNote,
   onPinToggle,
   onDelete,
 }: {
@@ -88,10 +89,11 @@ function MobileGalleryNoteActions({
   sourceBounds: GalleryCardBounds | null;
   onOpenChange: (open: boolean) => void;
   onRestoreFocus: () => void;
+  onOpenNote: (note: Note) => void;
   onPinToggle: (slug: string) => void;
   onDelete: (note: Note) => Promise<void>;
 }) {
-  const previewRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLButtonElement>(null);
   const actionsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -159,6 +161,11 @@ function MobileGalleryNoteActions({
     onPinToggle(note.slug);
   };
 
+  const handleOpenNote = () => {
+    onOpenChange(false);
+    onOpenNote(note);
+  };
+
   const handleDelete = () => {
     onOpenChange(false);
     void onDelete(note);
@@ -185,9 +192,12 @@ function MobileGalleryNoteActions({
             Preview the note, then pin, unpin, or delete it.
           </DialogPrimitive.Description>
 
-          <div
+          <button
             ref={previewRef}
-            className="h-[min(52dvh,32rem)] overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl will-change-transform"
+            type="button"
+            aria-label={`Open ${note.title}`}
+            onClick={handleOpenNote}
+            className="block h-[min(52dvh,32rem)] w-full overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl outline-none will-change-transform focus-visible:ring-2 focus-visible:ring-[#E2A727]"
           >
             <h2 className="text-2xl font-bold leading-tight">
               {note.emoji} {note.title}
@@ -195,7 +205,7 @@ function MobileGalleryNoteActions({
             <p className="mt-8 whitespace-pre-wrap text-[17px] leading-6 text-foreground">
               {getNotePreviewText(note.content)}
             </p>
-          </div>
+          </button>
 
           <div
             ref={actionsRef}
@@ -471,6 +481,7 @@ function GalleryCard({
           sourceBounds={contextMenuSourceBounds}
           onOpenChange={handleMobileActionsOpenChange}
           onRestoreFocus={restoreCardFocus}
+          onOpenNote={onNoteSelect}
           onPinToggle={onPinToggle}
           onDelete={onDelete}
         />

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -162,8 +162,8 @@ function MobileGalleryNoteActions({
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-[90] bg-black/25 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <DialogPrimitive.Content className="pointer-events-none fixed inset-0 z-[91] flex items-center justify-center px-4 outline-none">
-          <div className="pointer-events-auto w-full max-w-[560px]">
+        <DialogPrimitive.Content className="fixed left-1/2 top-1/2 z-[91] w-full max-w-[560px] -translate-x-1/2 -translate-y-1/2 px-4 outline-none">
+          <div>
             <DialogPrimitive.Title className="sr-only">
               Note actions for {note.title}
             </DialogPrimitive.Title>

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -66,7 +66,7 @@ function GalleryCard({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <article className="group relative min-w-0">
+        <article className="group relative min-w-0 select-none">
           <button
             type="button"
             data-note-slug={note.slug}

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -13,6 +13,12 @@ import { NoteItem } from "./note-item";
 import { Note, NotesViewMode } from "@/lib/notes/types";
 import { getDisplayCreatedAt } from "@/lib/notes/display-created-at";
 import { getNotePreviewText } from "@/lib/notes/note-utils";
+import {
+  canStartMobileNoteLongPress,
+  didMobileNoteLongPressMove,
+  isContextMenuKeyboardShortcut,
+  MOBILE_NOTE_LONG_PRESS_DELAY_MS,
+} from "@/lib/notes/mobile-gallery-interactions";
 import { cn } from "@/lib/utils";
 import {
   ContextMenu,
@@ -55,8 +61,6 @@ interface GalleryCardProps {
   isMobile: boolean;
 }
 
-const MOBILE_CONTEXT_MENU_DELAY_MS = 550;
-const MOBILE_CONTEXT_MENU_MOVE_TOLERANCE = 10;
 const MOBILE_NOTE_EXPAND_DURATION_MS = 320;
 
 interface GalleryCardBounds {
@@ -73,6 +77,7 @@ function MobileGalleryNoteActions({
   open,
   sourceBounds,
   onOpenChange,
+  onRestoreFocus,
   onPinToggle,
   onDelete,
 }: {
@@ -82,6 +87,7 @@ function MobileGalleryNoteActions({
   open: boolean;
   sourceBounds: GalleryCardBounds | null;
   onOpenChange: (open: boolean) => void;
+  onRestoreFocus: () => void;
   onPinToggle: (slug: string) => void;
   onDelete: (note: Note) => Promise<void>;
 }) {
@@ -162,57 +168,64 @@ function MobileGalleryNoteActions({
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-[90] bg-black/25 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <DialogPrimitive.Content className="fixed left-1/2 top-1/2 z-[91] w-full max-w-[560px] -translate-x-1/2 -translate-y-1/2 px-4 outline-none">
-          <div>
-            <DialogPrimitive.Title className="sr-only">
-              Note actions for {note.title}
-            </DialogPrimitive.Title>
-            <DialogPrimitive.Description className="sr-only">
-              Preview the note, then pin, unpin, or delete it.
-            </DialogPrimitive.Description>
+        <DialogPrimitive.Content
+          onClick={(event) => {
+            if (event.target === event.currentTarget) onOpenChange(false);
+          }}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            onRestoreFocus();
+          }}
+          className="fixed left-1/2 top-1/2 z-[91] w-full max-w-[560px] -translate-x-1/2 -translate-y-1/2 px-4 outline-none"
+        >
+          <DialogPrimitive.Title className="sr-only">
+            Note actions for {note.title}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Preview the note, then pin, unpin, or delete it.
+          </DialogPrimitive.Description>
 
-            <div
-              ref={previewRef}
-              className="h-[min(52dvh,32rem)] overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl will-change-transform"
-            >
-              <h2 className="text-2xl font-bold leading-tight">
-                {note.emoji} {note.title}
-              </h2>
-              <p className="mt-8 whitespace-pre-wrap text-[17px] leading-6 text-foreground">
-                {getNotePreviewText(note.content)}
-              </p>
-            </div>
+          <div
+            ref={previewRef}
+            className="h-[min(52dvh,32rem)] overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl will-change-transform"
+          >
+            <h2 className="text-2xl font-bold leading-tight">
+              {note.emoji} {note.title}
+            </h2>
+            <p className="mt-8 whitespace-pre-wrap text-[17px] leading-6 text-foreground">
+              {getNotePreviewText(note.content)}
+            </p>
+          </div>
 
-            <div
-              ref={actionsRef}
-              className="mx-auto mt-3 w-[calc(100%-3rem)] max-w-sm overflow-hidden rounded-[22px] border border-muted-foreground/15 bg-background/95 shadow-2xl backdrop-blur-xl will-change-transform"
+          <div
+            ref={actionsRef}
+            className="mx-auto mt-3 w-[calc(100%-3rem)] max-w-sm overflow-hidden rounded-[22px] border border-muted-foreground/15 bg-background/95 shadow-2xl backdrop-blur-xl will-change-transform"
+          >
+            <button
+              type="button"
+              onClick={handlePinToggle}
+              className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
             >
-              <button
-                type="button"
-                onClick={handlePinToggle}
-                className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
-              >
-                {isPinned ? (
-                  <PinOff className="h-5 w-5 shrink-0" aria-hidden />
-                ) : (
-                  <Pin className="h-5 w-5 shrink-0" aria-hidden />
-                )}
-                <span>{isPinned ? "Unpin Note" : "Pin Note"}</span>
-              </button>
-              {canDelete && (
-                <>
-                  <div className="mx-5 border-t border-muted-foreground/20" />
-                  <button
-                    type="button"
-                    onClick={handleDelete}
-                    className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] text-red-600 outline-none active:bg-muted focus-visible:bg-muted"
-                  >
-                    <Trash2 className="h-5 w-5 shrink-0" aria-hidden />
-                    <span>Delete</span>
-                  </button>
-                </>
+              {isPinned ? (
+                <PinOff className="h-5 w-5 shrink-0" aria-hidden />
+              ) : (
+                <Pin className="h-5 w-5 shrink-0" aria-hidden />
               )}
-            </div>
+              <span>{isPinned ? "Unpin Note" : "Pin Note"}</span>
+            </button>
+            {canDelete && (
+              <>
+                <div className="mx-5 border-t border-muted-foreground/20" />
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] text-red-600 outline-none active:bg-muted focus-visible:bg-muted"
+                >
+                  <Trash2 className="h-5 w-5 shrink-0" aria-hidden />
+                  <span>Delete</span>
+                </button>
+              </>
+            )}
           </div>
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>
@@ -237,6 +250,7 @@ function GalleryCard({
   const longPressTimerRef = useRef<number | null>(null);
   const longPressOriginRef = useRef<{ x: number; y: number } | null>(null);
   const suppressNextClickRef = useRef(false);
+  const shouldRestoreCardFocusRef = useRef(false);
   const canDelete = note.session_id === sessionId;
 
   useEffect(() => {
@@ -253,27 +267,32 @@ function GalleryCard({
 
   useEffect(() => clearLongPressTimer, [clearLongPressTimer]);
 
+  const openMobileActions = useCallback((restoreFocus = false) => {
+    const cardBounds = cardButtonRef.current?.getBoundingClientRect();
+    if (cardBounds) {
+      setContextMenuSourceBounds({
+        top: cardBounds.top,
+        left: cardBounds.left,
+        width: cardBounds.width,
+        height: cardBounds.height,
+      });
+    }
+    window.getSelection()?.removeAllRanges();
+    suppressNextClickRef.current = true;
+    shouldRestoreCardFocusRef.current = restoreFocus;
+    setIsContextMenuOpen(true);
+    clearLongPressTimer();
+  }, [clearLongPressTimer]);
+
   const handlePointerDown = (event: React.PointerEvent<HTMLElement>) => {
-    if (!isMobile || !["touch", "pen"].includes(event.pointerType)) return;
+    if (!isMobile || !canStartMobileNoteLongPress(event.pointerType)) return;
 
     clearLongPressTimer();
     suppressNextClickRef.current = false;
     longPressOriginRef.current = { x: event.clientX, y: event.clientY };
     longPressTimerRef.current = window.setTimeout(() => {
-      const cardBounds = cardButtonRef.current?.getBoundingClientRect();
-      if (cardBounds) {
-        setContextMenuSourceBounds({
-          top: cardBounds.top,
-          left: cardBounds.left,
-          width: cardBounds.width,
-          height: cardBounds.height,
-        });
-      }
-      window.getSelection()?.removeAllRanges();
-      suppressNextClickRef.current = true;
-      setIsContextMenuOpen(true);
-      clearLongPressTimer();
-    }, MOBILE_CONTEXT_MENU_DELAY_MS);
+      openMobileActions();
+    }, MOBILE_NOTE_LONG_PRESS_DELAY_MS);
   };
 
   const handlePointerMove = (event: React.PointerEvent<HTMLElement>) => {
@@ -281,10 +300,10 @@ function GalleryCard({
     if (!origin) return;
 
     if (
-      Math.abs(event.clientX - origin.x) >
-        MOBILE_CONTEXT_MENU_MOVE_TOLERANCE ||
-      Math.abs(event.clientY - origin.y) >
-        MOBILE_CONTEXT_MENU_MOVE_TOLERANCE
+      didMobileNoteLongPressMove(origin, {
+        x: event.clientX,
+        y: event.clientY,
+      })
     ) {
       clearLongPressTimer();
     }
@@ -322,15 +341,34 @@ function GalleryCard({
     if (!open) suppressNextClickRef.current = false;
   };
 
+  const restoreCardFocus = useCallback(() => {
+    if (shouldRestoreCardFocusRef.current) {
+      cardButtonRef.current?.focus();
+      shouldRestoreCardFocusRef.current = false;
+    }
+  }, []);
+
+  const handleMobileContextMenu = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    openMobileActions();
+  };
+
+  const handleCardKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (!isMobile || !isContextMenuKeyboardShortcut(event.key, event.shiftKey)) {
+      return;
+    }
+
+    event.preventDefault();
+    openMobileActions(true);
+  };
+
   const cardContent = (
     <article
       className={cn(
         "group relative min-w-0",
         isMobile && "notes-gallery-context-trigger select-none",
       )}
-      onContextMenu={
-        isMobile ? (event) => event.preventDefault() : undefined
-      }
+      onContextMenu={isMobile ? handleMobileContextMenu : undefined}
       onPointerDown={isMobile ? handlePointerDown : undefined}
       onPointerMove={isMobile ? handlePointerMove : undefined}
       onPointerUp={isMobile ? handlePointerEnd : undefined}
@@ -341,6 +379,9 @@ function GalleryCard({
         type="button"
         data-note-slug={note.slug}
         onClick={handleCardClick}
+        onKeyDown={handleCardKeyDown}
+        aria-haspopup={isMobile ? "dialog" : undefined}
+        aria-expanded={isMobile ? isContextMenuOpen : undefined}
         className={cn(
           "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-background text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
           isMobile
@@ -429,6 +470,7 @@ function GalleryCard({
           open={isContextMenuOpen}
           sourceBounds={contextMenuSourceBounds}
           onOpenChange={handleMobileActionsOpenChange}
+          onRestoreFocus={restoreCardFocus}
           onPinToggle={onPinToggle}
           onDelete={onDelete}
         />

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Pin } from "lucide-react";
+import { Pin, PinOff, Trash2 } from "lucide-react";
 import { NoteItem } from "./note-item";
 import { Note, NotesViewMode } from "@/lib/notes/types";
 import { getDisplayCreatedAt } from "@/lib/notes/display-created-at";
 import { getNotePreviewText } from "@/lib/notes/note-utils";
 import { cn } from "@/lib/utils";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 
 interface SidebarContentProps {
   groupedNotes: Record<string, Note[]>;
@@ -36,6 +42,8 @@ interface GalleryCardProps {
   isPinned: boolean;
   onNoteSelect: (note: Note) => void;
   onPinToggle: (slug: string) => void;
+  onDelete: (note: Note) => Promise<void>;
+  sessionId: string;
   isMobile: boolean;
 }
 
@@ -44,95 +52,131 @@ function GalleryCard({
   isPinned,
   onNoteSelect,
   onPinToggle,
+  onDelete,
+  sessionId,
   isMobile,
 }: GalleryCardProps) {
   const [hasMounted, setHasMounted] = useState(false);
+  const canDelete = note.session_id === sessionId;
 
   useEffect(() => {
     setHasMounted(true);
   }, []);
 
   return (
-    <article className="group relative min-w-0">
-      <button
-        type="button"
-        data-note-slug={note.slug}
-        onClick={() => onNoteSelect(note)}
-        className={cn(
-          "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-background text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
-          isMobile
-            ? "rounded-lg px-2 py-1.5"
-            : "rounded-xl px-4 py-3",
-        )}
-      >
-        <h4
-          className={cn(
-            "line-clamp-2 font-semibold",
-            isMobile
-              ? "pr-5 text-[9px] leading-[11px]"
-              : "pr-7 text-sm leading-5",
-          )}
-        >
-          {note.emoji} {note.title}
-        </h4>
-        <p
-          className={cn(
-            "whitespace-pre-wrap text-muted-foreground",
-            isMobile
-              ? "mt-1 line-clamp-[6] text-[7px] leading-[1.25]"
-              : "mt-2 line-clamp-[7] text-xs leading-[1.35]",
-          )}
-        >
-          {getNotePreviewText(note.content)}
-        </p>
-      </button>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <article className="group relative min-w-0">
+          <button
+            type="button"
+            data-note-slug={note.slug}
+            onClick={() => onNoteSelect(note)}
+            className={cn(
+              "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-background text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
+              isMobile
+                ? "rounded-lg px-2 py-1.5"
+                : "rounded-xl px-4 py-3",
+            )}
+          >
+            <h4
+              className={cn(
+                "line-clamp-2 font-semibold",
+                isMobile
+                  ? "pr-5 text-[9px] leading-[11px]"
+                  : "pr-7 text-sm leading-5",
+              )}
+            >
+              {note.emoji} {note.title}
+            </h4>
+            <p
+              className={cn(
+                "whitespace-pre-wrap text-muted-foreground",
+                isMobile
+                  ? "mt-1 line-clamp-[6] text-[7px] leading-[1.25]"
+                  : "mt-2 line-clamp-[7] text-xs leading-[1.35]",
+              )}
+            >
+              {getNotePreviewText(note.content)}
+            </p>
+          </button>
 
-      {isPinned && (
-        <button
-          type="button"
-          aria-label={`Unpin ${note.title}`}
+          {isPinned && (
+            <button
+              type="button"
+              aria-label={`Unpin ${note.title}`}
+              onClick={() => onPinToggle(note.slug)}
+              className={cn(
+                "absolute flex items-center justify-center bg-muted text-muted-foreground shadow-sm transition-colors can-hover:hover:bg-muted-foreground/15 can-hover:hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
+                isMobile
+                  ? "right-1.5 top-1.5 h-6 w-6 rounded-md"
+                  : "right-3 top-3 h-7 w-7 rounded-lg",
+              )}
+            >
+              <Pin
+                className={cn(
+                  "fill-current",
+                  isMobile ? "h-3.5 w-3.5" : "h-4 w-4",
+                )}
+                aria-hidden
+              />
+            </button>
+          )}
+
+          <div className={cn("text-center", isMobile ? "mt-2" : "mt-2 px-1")}>
+            <h4
+              className={cn(
+                "font-medium",
+                isMobile
+                  ? "line-clamp-2 text-[15px] leading-[18px]"
+                  : "truncate text-sm",
+              )}
+            >
+              {note.title}
+            </h4>
+            <p
+              className={cn(
+                "mt-0.5 text-muted-foreground tabular-nums",
+                isMobile ? "text-[13px] leading-4" : "text-xs",
+                !hasMounted && "invisible",
+              )}
+            >
+              {hasMounted
+                ? new Date(getDisplayCreatedAt(note)).toLocaleDateString("en-US")
+                : "00/00/0000"}
+            </p>
+          </div>
+        </article>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem
           onClick={() => onPinToggle(note.slug)}
           className={cn(
-            "absolute flex items-center justify-center bg-muted text-muted-foreground shadow-sm transition-colors can-hover:hover:bg-muted-foreground/15 can-hover:hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
-            isMobile
-              ? "right-1.5 top-1.5 h-6 w-6 rounded-md"
-              : "right-3 top-3 h-7 w-7 rounded-lg",
+            "focus:bg-[#0A7CFF] focus:text-white",
+            isMobile && "flex items-center justify-between",
           )}
         >
-          <Pin
+          <span>{isPinned ? "Unpin" : "Pin"}</span>
+          {isMobile &&
+            (isPinned ? (
+              <PinOff className="ml-2 h-4 w-4" aria-hidden />
+            ) : (
+              <Pin className="ml-2 h-4 w-4" aria-hidden />
+            ))}
+        </ContextMenuItem>
+        {canDelete && (
+          <ContextMenuItem
+            onClick={() => void onDelete(note)}
             className={cn(
-              "fill-current",
-              isMobile ? "h-3.5 w-3.5" : "h-4 w-4",
+              "text-red-600 focus:bg-[#0A7CFF] focus:text-white",
+              isMobile && "flex items-center justify-between",
             )}
-            aria-hidden
-          />
-        </button>
-      )}
-
-      <div className={cn("text-center", isMobile ? "mt-2" : "mt-2 px-1")}>
-        <h4
-          className={cn(
-            "font-medium",
-            isMobile
-              ? "line-clamp-2 text-[15px] leading-[18px]"
-              : "truncate text-sm",
-          )}
-        >
-          {note.title}
-        </h4>
-        <p
-          className={cn(
-            "mt-0.5 text-muted-foreground tabular-nums",
-            isMobile ? "text-[13px] leading-4" : "text-xs",
-            !hasMounted && "invisible",
-          )}
-        >
-          {hasMounted
-            ? new Date(getDisplayCreatedAt(note)).toLocaleDateString("en-US")
-            : "00/00/0000"}
-        </p>
-      </div>
-    </article>
+          >
+            <span>Delete</span>
+            {isMobile && <Trash2 className="ml-2 h-4 w-4" aria-hidden />}
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
@@ -141,12 +185,16 @@ function GalleryGrid({
   pinnedNotes,
   onNoteSelect,
   onPinToggle,
+  onDelete,
+  sessionId,
   isMobile,
 }: {
   notes: Note[];
   pinnedNotes: Set<string>;
   onNoteSelect: (note: Note) => void;
   onPinToggle: (slug: string) => void;
+  onDelete: (note: Note) => Promise<void>;
+  sessionId: string;
   isMobile: boolean;
 }) {
   return (
@@ -165,6 +213,8 @@ function GalleryGrid({
           isPinned={pinnedNotes.has(note.slug)}
           onNoteSelect={onNoteSelect}
           onPinToggle={onPinToggle}
+          onDelete={onDelete}
+          sessionId={sessionId}
           isMobile={isMobile}
         />
       ))}
@@ -259,6 +309,8 @@ export function SidebarContent({
                     pinnedNotes={pinnedNotes}
                     onNoteSelect={onNoteSelect}
                     onPinToggle={handleGalleryPinToggle}
+                    onDelete={handleDelete}
+                    sessionId={sessionId}
                     isMobile={isMobile}
                   />
                 </section>
@@ -275,6 +327,8 @@ export function SidebarContent({
               pinnedNotes={pinnedNotes}
               onNoteSelect={onNoteSelect}
               onPinToggle={handleGalleryPinToggle}
+              onDelete={handleDelete}
+              sessionId={sessionId}
               isMobile={isMobile}
             />
           </section>

--- a/lib/notes/mobile-gallery-interactions.ts
+++ b/lib/notes/mobile-gallery-interactions.ts
@@ -1,0 +1,30 @@
+export const MOBILE_NOTE_LONG_PRESS_DELAY_MS = 550;
+export const MOBILE_NOTE_LONG_PRESS_MOVE_TOLERANCE = 10;
+
+interface PointerCoordinates {
+  x: number;
+  y: number;
+}
+
+export function canStartMobileNoteLongPress(pointerType: string): boolean {
+  return pointerType === "touch" || pointerType === "pen";
+}
+
+export function didMobileNoteLongPressMove(
+  origin: PointerCoordinates,
+  current: PointerCoordinates,
+): boolean {
+  return (
+    Math.abs(current.x - origin.x) >
+      MOBILE_NOTE_LONG_PRESS_MOVE_TOLERANCE ||
+    Math.abs(current.y - origin.y) >
+      MOBILE_NOTE_LONG_PRESS_MOVE_TOLERANCE
+  );
+}
+
+export function isContextMenuKeyboardShortcut(
+  key: string,
+  shiftKey: boolean,
+): boolean {
+  return key === "ContextMenu" || (key === "F10" && shiftKey);
+}

--- a/tests/mobile-gallery-interactions.test.ts
+++ b/tests/mobile-gallery-interactions.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canStartMobileNoteLongPress,
+  didMobileNoteLongPressMove,
+  isContextMenuKeyboardShortcut,
+} from "../lib/notes/mobile-gallery-interactions";
+
+test("starts note long presses only for touch-style pointers", () => {
+  assert.equal(canStartMobileNoteLongPress("touch"), true);
+  assert.equal(canStartMobileNoteLongPress("pen"), true);
+  assert.equal(canStartMobileNoteLongPress("mouse"), false);
+});
+
+test("cancels a note long press after meaningful movement", () => {
+  const origin = { x: 100, y: 100 };
+
+  assert.equal(didMobileNoteLongPressMove(origin, { x: 110, y: 90 }), false);
+  assert.equal(didMobileNoteLongPressMove(origin, { x: 111, y: 100 }), true);
+  assert.equal(didMobileNoteLongPressMove(origin, { x: 100, y: 111 }), true);
+});
+
+test("recognizes keyboard context-menu shortcuts", () => {
+  assert.equal(isContextMenuKeyboardShortcut("ContextMenu", false), true);
+  assert.equal(isContextMenuKeyboardShortcut("F10", true), true);
+  assert.equal(isContextMenuKeyboardShortcut("F10", false), false);
+  assert.equal(isContextMenuKeyboardShortcut("Enter", false), false);
+});


### PR DESCRIPTION
## What changed

- Add press-and-hold actions to every Notes gallery card on mobile.
- Present the selected note in a large, centered preview with a native-style action sheet beneath it.
- Animate the preview from the pressed grid card’s exact position and dimensions, then fade the actions in beneath it.
- Open the selected note when the user taps or activates the expanded preview.
- Add Pin Note / Unpin Note for every note and Delete for session-owned notes.
- Close the focused preview from every visible backdrop area, including the gutters and gap around the narrower action sheet.
- Support secondary click, the Context Menu key, and Shift+F10 on mobile-layout devices with a trackpad or keyboard.
- Preserve focus for keyboard users after the dialog closes.
- Keep the compact shared context menu for desktop right-click.
- Suppress WebKit touch callouts and text selection across Notes gallery cards.
- Cancel the hold when the finger moves, preserving normal scrolling and tap-to-open behavior.
- Respect reduced-motion preferences by skipping the expansion animation.

## Why

The mobile Notes gallery had no way to pin an unpinned note. The first context-menu implementation also let iOS Safari begin text selection and placed a small pointer menu over the grid. This revision follows the native Notes interaction more closely: the background dims, the pressed card expands into a prominent note preview, and its actions appear directly below it.

## Impact

Mobile users can press and hold any gallery card to preview, open, pin, or unpin it, and can delete notes owned by their current session. A normal tap still opens the note, scrolling cancels the hold, tapping outside closes the focused view, and desktop users retain right-click actions. iPad-style mobile layouts also work with trackpads and external keyboards.

## Verification

- `npm run check`
  - lint passes with 7 pre-existing warnings
  - 19 tests pass, including gesture and keyboard regression coverage
  - TypeScript passes
  - production build passes
- Vercel preview deployment
- Final touch-device verification on the preview deployment is recommended
