### PR TITLE
Add mobile Messages long-press previews

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -233,6 +233,14 @@ html, body {
   caret-color: #e2a727;
 }
 
+/* Let Messages long presses open actions instead of selecting row text. */
+.messages-context-menu-trigger,
+.messages-context-menu-trigger * {
+  -webkit-touch-callout: none !important;
+  -webkit-user-select: none !important;
+  user-select: none !important;
+}
+
 /* Green caret for iTerm app */
 .iterm-app * {
   caret-color: #22c55e;

--- a/components/apps/messages/conversation-context-actions.tsx
+++ b/components/apps/messages/conversation-context-actions.tsx
@@ -5,7 +5,6 @@ import { Slot } from "@radix-ui/react-slot";
 import {
   Bell,
   BellOff,
-  LockKeyhole,
   Pin,
   PinOff,
   Trash2,
@@ -54,6 +53,7 @@ interface ConversationContextActionsProps {
   onPinToggle: () => void;
   onToggleAlerts: () => void;
   onDelete: () => void;
+  onOpenConversation: () => void;
   onPreviewOpen?: () => void;
 }
 
@@ -63,6 +63,7 @@ function MobileConversationPreview({
   sourceBounds,
   onOpenChange,
   onRestoreFocus,
+  onOpenConversation,
   onPinToggle,
   onToggleAlerts,
   onDelete,
@@ -72,11 +73,12 @@ function MobileConversationPreview({
   sourceBounds: TriggerBounds | null;
   onOpenChange: (open: boolean) => void;
   onRestoreFocus: () => void;
+  onOpenConversation: () => void;
   onPinToggle: () => void;
   onToggleAlerts: () => void;
   onDelete: () => void;
 }) {
-  const previewRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLButtonElement>(null);
   const actionsRef = useRef<HTMLDivElement>(null);
   const displayName = getConversationDisplayName(conversation);
   const previewMessages = getConversationPreviewMessages(conversation);
@@ -164,23 +166,23 @@ function MobileConversationPreview({
             Conversation actions for {displayName}
           </DialogPrimitive.Title>
           <DialogPrimitive.Description className="sr-only">
-            Preview the conversation, then pin, change alerts, or delete it.
+            Preview or open the conversation, then pin, change alerts, or
+            delete it.
           </DialogPrimitive.Description>
 
-          <div
+          <button
             ref={previewRef}
-            className="flex h-[min(50dvh,30rem)] min-h-64 flex-col overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background text-left shadow-2xl will-change-transform"
+            type="button"
+            aria-label={`Open conversation with ${displayName}`}
+            onClick={() => runAction(onOpenConversation)}
+            className="flex h-[min(50dvh,30rem)] min-h-64 w-full flex-col overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background text-left shadow-2xl outline-none will-change-transform focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
           >
-            <header className="shrink-0 px-5 pb-3 pt-4 text-center">
+            <header className="w-full shrink-0 px-5 pb-4 pt-4 text-center">
               <h2 className="truncate text-[18px] font-semibold leading-6">
                 {displayName}
               </h2>
               <p className="text-[13px] leading-5 text-muted-foreground">
                 iMessage
-              </p>
-              <p className="flex items-center justify-center gap-1 text-[12px] leading-4 text-muted-foreground">
-                <LockKeyhole className="h-3 w-3" aria-hidden />
-                <span>Encrypted</span>
               </p>
             </header>
 
@@ -221,7 +223,7 @@ function MobileConversationPreview({
                 </div>
               )}
             </div>
-          </div>
+          </button>
 
           <div
             ref={actionsRef}
@@ -277,6 +279,7 @@ export function ConversationContextActions({
   onPinToggle,
   onToggleAlerts,
   onDelete,
+  onOpenConversation,
   onPreviewOpen,
 }: ConversationContextActionsProps) {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
@@ -452,6 +455,7 @@ export function ConversationContextActions({
         sourceBounds={sourceBounds}
         onOpenChange={handlePreviewOpenChange}
         onRestoreFocus={restoreFocus}
+        onOpenConversation={onOpenConversation}
         onPinToggle={onPinToggle}
         onToggleAlerts={onToggleAlerts}
         onDelete={onDelete}

--- a/components/apps/messages/conversation-context-actions.tsx
+++ b/components/apps/messages/conversation-context-actions.tsx
@@ -175,7 +175,7 @@ function MobileConversationPreview({
             type="button"
             aria-label={`Open conversation with ${displayName}`}
             onClick={() => runAction(onOpenConversation)}
-            className="flex h-[min(50dvh,30rem)] min-h-64 w-full flex-col overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background text-left shadow-2xl outline-none will-change-transform focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
+            className="flex h-[min(50dvh,30rem)] min-h-64 w-full flex-col overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background text-left shadow-2xl outline-none will-change-transform"
           >
             <header className="w-full shrink-0 px-5 pb-4 pt-4 text-center">
               <h2 className="truncate text-[18px] font-semibold leading-6">

--- a/components/apps/messages/conversation-context-actions.tsx
+++ b/components/apps/messages/conversation-context-actions.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  Bell,
+  BellOff,
+  LockKeyhole,
+  Pin,
+  PinOff,
+  Trash2,
+} from "lucide-react";
+import {
+  type ReactElement,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  canStartMobileConversationLongPress,
+  didMobileConversationLongPressMove,
+  getConversationDisplayName,
+  getConversationPreviewMessages,
+  isConversationContextMenuKeyboardShortcut,
+  MOBILE_CONVERSATION_LONG_PRESS_DELAY_MS,
+} from "@/lib/messages/mobile-conversation-interactions";
+import type { Conversation } from "@/types/messages";
+
+const MOBILE_CONVERSATION_EXPAND_DURATION_MS = 320;
+
+interface TriggerBounds {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface ConversationContextActionsProps {
+  conversation: Conversation;
+  isMobileView: boolean;
+  children: ReactElement;
+  onPinToggle: () => void;
+  onToggleAlerts: () => void;
+  onDelete: () => void;
+  onPreviewOpen?: () => void;
+}
+
+function MobileConversationPreview({
+  conversation,
+  open,
+  sourceBounds,
+  onOpenChange,
+  onRestoreFocus,
+  onPinToggle,
+  onToggleAlerts,
+  onDelete,
+}: {
+  conversation: Conversation;
+  open: boolean;
+  sourceBounds: TriggerBounds | null;
+  onOpenChange: (open: boolean) => void;
+  onRestoreFocus: () => void;
+  onPinToggle: () => void;
+  onToggleAlerts: () => void;
+  onDelete: () => void;
+}) {
+  const previewRef = useRef<HTMLDivElement>(null);
+  const actionsRef = useRef<HTMLDivElement>(null);
+  const displayName = getConversationDisplayName(conversation);
+  const previewMessages = getConversationPreviewMessages(conversation);
+  const isGroupConversation = conversation.recipients.length > 1;
+
+  useEffect(() => {
+    if (open) window.getSelection()?.removeAllRanges();
+  }, [open]);
+
+  useLayoutEffect(() => {
+    const preview = previewRef.current;
+    const actions = actionsRef.current;
+    if (!open || !sourceBounds || !preview || !actions) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const targetBounds = preview.getBoundingClientRect();
+    const translateX =
+      sourceBounds.left +
+      sourceBounds.width / 2 -
+      (targetBounds.left + targetBounds.width / 2);
+    const translateY =
+      sourceBounds.top +
+      sourceBounds.height / 2 -
+      (targetBounds.top + targetBounds.height / 2);
+    const scaleX = sourceBounds.width / targetBounds.width;
+    const scaleY = sourceBounds.height / targetBounds.height;
+    const sourceRadius = sourceBounds.width <= 96 ? "16px" : "10px";
+
+    const previewAnimation = preview.animate(
+      [
+        {
+          transform: `translate3d(${translateX}px, ${translateY}px, 0) scale(${scaleX}, ${scaleY})`,
+          borderRadius: sourceRadius,
+        },
+        {
+          transform: "translate3d(0, 0, 0) scale(1, 1)",
+          borderRadius: "28px",
+        },
+      ],
+      {
+        duration: MOBILE_CONVERSATION_EXPAND_DURATION_MS,
+        easing: "cubic-bezier(0.2, 0.8, 0.2, 1)",
+        fill: "both",
+      },
+    );
+    const actionsAnimation = actions.animate(
+      [
+        { opacity: 0, transform: "translateY(-10px) scale(0.97)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ],
+      {
+        duration: 170,
+        delay: MOBILE_CONVERSATION_EXPAND_DURATION_MS - 110,
+        easing: "cubic-bezier(0.2, 0.8, 0.2, 1)",
+        fill: "both",
+      },
+    );
+
+    return () => {
+      previewAnimation.cancel();
+      actionsAnimation.cancel();
+    };
+  }, [open, sourceBounds]);
+
+  const runAction = (action: () => void) => {
+    onOpenChange(false);
+    action();
+  };
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[90] bg-black/25 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          onClick={(event) => {
+            if (event.target === event.currentTarget) onOpenChange(false);
+          }}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            onRestoreFocus();
+          }}
+          className="fixed left-1/2 top-1/2 z-[91] max-h-[calc(100dvh-2rem)] w-full max-w-[560px] -translate-x-1/2 -translate-y-1/2 overflow-y-auto px-4 outline-none"
+        >
+          <DialogPrimitive.Title className="sr-only">
+            Conversation actions for {displayName}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Preview the conversation, then pin, change alerts, or delete it.
+          </DialogPrimitive.Description>
+
+          <div
+            ref={previewRef}
+            className="flex h-[min(50dvh,30rem)] min-h-64 flex-col overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background text-left shadow-2xl will-change-transform"
+          >
+            <header className="shrink-0 px-5 pb-3 pt-4 text-center">
+              <h2 className="truncate text-[18px] font-semibold leading-6">
+                {displayName}
+              </h2>
+              <p className="text-[13px] leading-5 text-muted-foreground">
+                iMessage
+              </p>
+              <p className="flex items-center justify-center gap-1 text-[12px] leading-4 text-muted-foreground">
+                <LockKeyhole className="h-3 w-3" aria-hidden />
+                <span>Encrypted</span>
+              </p>
+            </header>
+
+            <div className="min-h-0 flex-1 overflow-hidden px-4 pb-5">
+              {previewMessages.length === 0 ? (
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                  No messages yet
+                </div>
+              ) : (
+                <div className="flex h-full flex-col justify-end gap-2">
+                  {previewMessages.map((message) => {
+                    const isMe = message.sender === "me";
+
+                    return (
+                      <div
+                        key={message.id}
+                        className={`flex flex-col ${
+                          isMe ? "items-end" : "items-start"
+                        }`}
+                      >
+                        {!isMe && isGroupConversation && (
+                          <span className="mb-0.5 max-w-[78%] truncate px-3 text-[11px] text-muted-foreground">
+                            {message.sender}
+                          </span>
+                        )}
+                        <div
+                          className={`max-w-[82%] whitespace-pre-wrap break-words rounded-[19px] px-3 py-2 text-[15px] leading-5 ${
+                            isMe
+                              ? "rounded-br-md bg-[#0A7CFF] text-white"
+                              : "rounded-bl-md bg-muted text-foreground"
+                          }`}
+                        >
+                          <span className="line-clamp-3">{message.content}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div
+            ref={actionsRef}
+            className="mx-auto mt-3 w-[calc(100%-3rem)] max-w-sm overflow-hidden rounded-[22px] border border-muted-foreground/15 bg-background/95 shadow-2xl backdrop-blur-xl will-change-transform"
+          >
+            <button
+              type="button"
+              onClick={() => runAction(onPinToggle)}
+              className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
+            >
+              {conversation.pinned ? (
+                <PinOff className="h-5 w-5 shrink-0" aria-hidden />
+              ) : (
+                <Pin className="h-5 w-5 shrink-0" aria-hidden />
+              )}
+              <span>{conversation.pinned ? "Unpin" : "Pin"}</span>
+            </button>
+            <div className="mx-5 border-t border-muted-foreground/20" />
+            <button
+              type="button"
+              onClick={() => runAction(onToggleAlerts)}
+              className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
+            >
+              {conversation.hideAlerts ? (
+                <Bell className="h-5 w-5 shrink-0" aria-hidden />
+              ) : (
+                <BellOff className="h-5 w-5 shrink-0" aria-hidden />
+              )}
+              <span>
+                {conversation.hideAlerts ? "Show Alerts" : "Hide Alerts"}
+              </span>
+            </button>
+            <div className="mx-5 border-t border-muted-foreground/20" />
+            <button
+              type="button"
+              onClick={() => runAction(onDelete)}
+              className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] text-red-600 outline-none active:bg-muted focus-visible:bg-muted"
+            >
+              <Trash2 className="h-5 w-5 shrink-0" aria-hidden />
+              <span>Delete</span>
+            </button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+export function ConversationContextActions({
+  conversation,
+  isMobileView,
+  children,
+  onPinToggle,
+  onToggleAlerts,
+  onDelete,
+  onPreviewOpen,
+}: ConversationContextActionsProps) {
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [sourceBounds, setSourceBounds] = useState<TriggerBounds | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const focusTargetRef = useRef<HTMLElement | null>(null);
+  const longPressTimerRef = useRef<number | null>(null);
+  const longPressOriginRef = useRef<{ x: number; y: number } | null>(null);
+  const suppressNextClickRef = useRef(false);
+  const shouldRestoreFocusRef = useRef(false);
+
+  const clearLongPressTimer = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+    longPressOriginRef.current = null;
+  }, []);
+
+  useEffect(() => clearLongPressTimer, [clearLongPressTimer]);
+
+  const openMobilePreview = useCallback(
+    ({
+      restoreFocus = false,
+      suppressClick = false,
+      focusTarget = null,
+    }: {
+      restoreFocus?: boolean;
+      suppressClick?: boolean;
+      focusTarget?: HTMLElement | null;
+    } = {}) => {
+      const bounds = triggerRef.current?.getBoundingClientRect();
+      if (bounds) {
+        setSourceBounds({
+          top: bounds.top,
+          left: bounds.left,
+          width: bounds.width,
+          height: bounds.height,
+        });
+      }
+      window.getSelection()?.removeAllRanges();
+      suppressNextClickRef.current = suppressClick;
+      shouldRestoreFocusRef.current = restoreFocus;
+      focusTargetRef.current = focusTarget;
+      onPreviewOpen?.();
+      setIsPreviewOpen(true);
+      clearLongPressTimer();
+    },
+    [clearLongPressTimer, onPreviewOpen],
+  );
+
+  const handlePointerDown = (event: PointerEvent<HTMLElement>) => {
+    if (
+      !event.isPrimary ||
+      !canStartMobileConversationLongPress(event.pointerType)
+    ) {
+      return;
+    }
+
+    clearLongPressTimer();
+    suppressNextClickRef.current = false;
+    longPressOriginRef.current = { x: event.clientX, y: event.clientY };
+    longPressTimerRef.current = window.setTimeout(() => {
+      openMobilePreview({ suppressClick: true });
+    }, MOBILE_CONVERSATION_LONG_PRESS_DELAY_MS);
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLElement>) => {
+    const origin = longPressOriginRef.current;
+    if (
+      origin &&
+      didMobileConversationLongPressMove(origin, {
+        x: event.clientX,
+        y: event.clientY,
+      })
+    ) {
+      clearLongPressTimer();
+    }
+  };
+
+  const handlePointerEnd = () => {
+    clearLongPressTimer();
+  };
+
+  const handleClickCapture = (event: MouseEvent<HTMLElement>) => {
+    if (!suppressNextClickRef.current) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    suppressNextClickRef.current = false;
+  };
+
+  const handleContextMenu = (event: MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    openMobilePreview({ suppressClick: true });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (
+      !isConversationContextMenuKeyboardShortcut(event.key, event.shiftKey)
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    const focusTarget =
+      event.target instanceof HTMLElement ? event.target : triggerRef.current;
+    openMobilePreview({ restoreFocus: true, focusTarget });
+  };
+
+  const handlePreviewOpenChange = (open: boolean) => {
+    setIsPreviewOpen(open);
+    if (!open) suppressNextClickRef.current = false;
+  };
+
+  const restoreFocus = useCallback(() => {
+    if (shouldRestoreFocusRef.current) {
+      focusTargetRef.current?.focus();
+      shouldRestoreFocusRef.current = false;
+    }
+  }, []);
+
+  if (!isMobileView) {
+    return (
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem
+            className="focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
+            onClick={onPinToggle}
+          >
+            <span>{conversation.pinned ? "Unpin" : "Pin"}</span>
+          </ContextMenuItem>
+          <ContextMenuItem
+            className="focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
+            onClick={onToggleAlerts}
+          >
+            <span>
+              {conversation.hideAlerts ? "Show Alerts" : "Hide Alerts"}
+            </span>
+          </ContextMenuItem>
+          <ContextMenuItem
+            className="text-red-600 focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
+            onClick={onDelete}
+          >
+            <span>Delete</span>
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    );
+  }
+
+  return (
+    <>
+      <Slot
+        ref={triggerRef}
+        className="messages-context-menu-trigger select-none"
+        onClickCapture={handleClickCapture}
+        onContextMenu={handleContextMenu}
+        onKeyDown={handleKeyDown}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        aria-haspopup="dialog"
+        aria-expanded={isPreviewOpen}
+      >
+        {children}
+      </Slot>
+      <MobileConversationPreview
+        conversation={conversation}
+        open={isPreviewOpen}
+        sourceBounds={sourceBounds}
+        onOpenChange={handlePreviewOpenChange}
+        onRestoreFocus={restoreFocus}
+        onPinToggle={onPinToggle}
+        onToggleAlerts={onToggleAlerts}
+        onDelete={onDelete}
+      />
+    </>
+  );
+}

--- a/components/apps/messages/conversation-item.tsx
+++ b/components/apps/messages/conversation-item.tsx
@@ -3,12 +3,7 @@ import Image from "next/image";
 import { useSwipeable } from "react-swipeable";
 import { Conversation, REACTION_TEXT } from "@/types/messages";
 import { SwipeActions } from "./swipe-actions";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ConversationContextActions } from "./conversation-context-actions";
 import { Icons } from "./icons";
 import { useTheme } from "next-themes";
 
@@ -275,91 +270,39 @@ export const ConversationItem = memo(function ConversationItem({
     </button>
   );
 
-  if (isMobileView) {
-    return (
-      <ContextMenu>
-        <ContextMenuTrigger asChild>
-          <div {...handlers} className="relative overflow-hidden">
-            <div
-              className={`transition-transform duration-300 ease-out w-full ${
-                isSwipeOpen ? "transform -translate-x-24" : ""
-              }`}
-            >
-              {ConversationContent}
-            </div>
-            <SwipeActions
-              isOpen={isSwipeOpen}
-              onPin={handleSwipePin}
-              onDelete={handleSwipeDelete}
-              onHideAlerts={handleSwipeHideAlerts}
-              isPinned={conversation.pinned}
-              hideAlerts={conversation.hideAlerts}
-              aria-hidden={!isSwipeOpen}
-            />
-          </div>
-        </ContextMenuTrigger>
-        <ContextMenuContent>
-          <ContextMenuItem
-            className={`focus:bg-[#0A7CFF] focus:text-white ${
-              isMobileView ? "flex items-center justify-between" : ""
-            }`}
-            onClick={handleContextMenuPin}
-          >
-            <span>{conversation.pinned ? "Unpin" : "Pin"}</span>
-            {isMobileView && <Icons.pin className="h-4 w-4 ml-2" />}
-          </ContextMenuItem>
-          <ContextMenuItem
-            className={`focus:bg-[#0A7CFF] focus:text-white ${
-              isMobileView ? "flex items-center justify-between" : ""
-            }`}
-            onClick={handleContextMenuHideAlerts}
-          >
-            <span>{conversation.hideAlerts ? "Show Alerts" : "Hide Alerts"}</span>
-            {isMobileView && (
-              conversation.hideAlerts ? 
-                <Icons.bell className="h-4 w-4 ml-2" /> :
-                <Icons.bellOff className="h-4 w-4 ml-2" />
-            )}
-          </ContextMenuItem>
-          <ContextMenuItem
-            className={`focus:bg-[#0A7CFF] focus:text-white ${
-              isMobileView ? "flex items-center justify-between" : ""
-            } text-red-600`}
-            onClick={handleContextMenuDelete}
-          >
-            <span>Delete</span>
-            {isMobileView && <Icons.trash className="h-4 w-4 ml-2" />}
-          </ContextMenuItem>
-        </ContextMenuContent>
-      </ContextMenu>
-    );
-  } else {
-    return (
-      <ContextMenu>
-        <ContextMenuTrigger className="w-full">
-          {ConversationContent}
-        </ContextMenuTrigger>
-        <ContextMenuContent>
-          <ContextMenuItem
-            className={`focus:bg-[#0A7CFF] focus:text-white focus:rounded-md`}
-            onClick={handleContextMenuPin}
-          >
-            <span>{conversation.pinned ? "Unpin" : "Pin"}</span>
-          </ContextMenuItem>
-          <ContextMenuItem
-            className={`focus:bg-[#0A7CFF] focus:text-white focus:rounded-md`}
-            onClick={handleContextMenuHideAlerts}
-          >
-            <span>{conversation.hideAlerts ? "Show Alerts" : "Hide Alerts"}</span>
-          </ContextMenuItem>
-          <ContextMenuItem
-            className={`focus:bg-[#0A7CFF] focus:text-white focus:rounded-md text-red-600`}
-            onClick={handleContextMenuDelete}
-          >
-            <span>Delete</span>
-          </ContextMenuItem>
-        </ContextMenuContent>
-      </ContextMenu>
-    );
-  }
+  const trigger = isMobileView ? (
+    <div {...handlers} className="relative overflow-hidden">
+      <div
+        className={`w-full transition-transform duration-300 ease-out ${
+          isSwipeOpen ? "transform -translate-x-24" : ""
+        }`}
+      >
+        {ConversationContent}
+      </div>
+      <SwipeActions
+        isOpen={isSwipeOpen}
+        onPin={handleSwipePin}
+        onDelete={handleSwipeDelete}
+        onHideAlerts={handleSwipeHideAlerts}
+        isPinned={conversation.pinned}
+        hideAlerts={conversation.hideAlerts}
+        aria-hidden={!isSwipeOpen}
+      />
+    </div>
+  ) : (
+    ConversationContent
+  );
+
+  return (
+    <ConversationContextActions
+      conversation={conversation}
+      isMobileView={Boolean(isMobileView)}
+      onPinToggle={handleContextMenuPin}
+      onToggleAlerts={handleContextMenuHideAlerts}
+      onDelete={handleContextMenuDelete}
+      onPreviewOpen={() => setOpenSwipedConvo(null)}
+    >
+      {trigger}
+    </ConversationContextActions>
+  );
 });

--- a/components/apps/messages/conversation-item.tsx
+++ b/components/apps/messages/conversation-item.tsx
@@ -300,6 +300,7 @@ export const ConversationItem = memo(function ConversationItem({
       onPinToggle={handleContextMenuPin}
       onToggleAlerts={handleContextMenuHideAlerts}
       onDelete={handleContextMenuDelete}
+      onOpenConversation={() => onSelectConversation(conversation.id)}
       onPreviewOpen={() => setOpenSwipedConvo(null)}
     >
       {trigger}

--- a/components/apps/messages/sidebar.tsx
+++ b/components/apps/messages/sidebar.tsx
@@ -395,6 +395,9 @@ export function Sidebar({
                                 onDelete={() =>
                                   onDeleteConversation(conversation.id)
                                 }
+                                onOpenConversation={() =>
+                                  onSelectConversation(conversation.id)
+                                }
                               >
                                 <button
                                   onClick={() =>

--- a/components/apps/messages/sidebar.tsx
+++ b/components/apps/messages/sidebar.tsx
@@ -2,14 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Conversation } from "@/types/messages";
 import { SearchBar } from "./search-bar";
 import { format, isToday, isYesterday, isThisWeek, parseISO } from "date-fns";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ConversationContextActions } from "./conversation-context-actions";
 import { ConversationItem } from "./conversation-item";
-import { Icons } from "./icons";
 import { useTheme } from "next-themes";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
@@ -368,18 +362,51 @@ export function Sidebar({
                               data-conversation-id={conversation.id}
                               className="flex justify-center"
                             >
-                              <ContextMenu>
-                                <ContextMenuTrigger>
-                                  <button
-                                    onClick={() =>
-                                      onSelectConversation(conversation.id)
-                                    }
-                                    className={`w-20 aspect-square rounded-lg flex flex-col items-center justify-center p-2 relative ${
-                                      activeConversation === conversation.id && !isMobileView
-                                        ? "bg-[#0A7CFF] text-white"
-                                        : ""
-                                    }`}
-                                  >
+                              <ConversationContextActions
+                                conversation={conversation}
+                                isMobileView={isMobileView}
+                                onPinToggle={() => {
+                                  const updatedConversations =
+                                    conversations.map((conv) =>
+                                      conv.id === conversation.id
+                                        ? { ...conv, pinned: false }
+                                        : conv,
+                                    );
+                                  onUpdateConversation(
+                                    updatedConversations,
+                                    "pin",
+                                  );
+                                }}
+                                onToggleAlerts={() => {
+                                  const updatedConversations =
+                                    conversations.map((conv) =>
+                                      conv.id === conversation.id
+                                        ? {
+                                            ...conv,
+                                            hideAlerts: !conv.hideAlerts,
+                                          }
+                                        : conv,
+                                    );
+                                  onUpdateConversation(
+                                    updatedConversations,
+                                    "mute",
+                                  );
+                                }}
+                                onDelete={() =>
+                                  onDeleteConversation(conversation.id)
+                                }
+                              >
+                                <button
+                                  onClick={() =>
+                                    onSelectConversation(conversation.id)
+                                  }
+                                  className={`w-20 aspect-square rounded-lg flex flex-col items-center justify-center p-2 relative ${
+                                    activeConversation === conversation.id &&
+                                    !isMobileView
+                                      ? "bg-[#0A7CFF] text-white"
+                                      : ""
+                                  }`}
+                                >
                                     <div className="relative">
                                       {typingStatus?.conversationId ===
                                         conversation.id &&
@@ -541,84 +568,8 @@ export function Sidebar({
                                         </span>
                                       </div>
                                     </div>
-                                  </button>
-                                </ContextMenuTrigger>
-                                <ContextMenuContent>
-                                  <ContextMenuItem
-                                    className={`focus:bg-[#0A7CFF] focus:text-white ${
-                                      isMobileView
-                                        ? "flex items-center justify-between"
-                                        : ""
-                                    }`}
-                                    onClick={() => {
-                                      const updatedConversations =
-                                        conversations.map((conv) =>
-                                          conv.id === conversation.id
-                                            ? { ...conv, pinned: false }
-                                            : conv
-                                        );
-                                      onUpdateConversation(
-                                        updatedConversations,
-                                        "pin"
-                                      );
-                                    }}
-                                  >
-                                    <span>Unpin</span>
-                                    {isMobileView && (
-                                      <Icons.pinOff className="h-4 w-4 ml-2" />
-                                    )}
-                                  </ContextMenuItem>
-                                  <ContextMenuItem
-                                    className={`focus:bg-[#0A7CFF] focus:text-white ${
-                                      isMobileView
-                                        ? "flex items-center justify-between"
-                                        : ""
-                                    }`}
-                                    onClick={() => {
-                                      const updatedConversations =
-                                        conversations.map((conv) =>
-                                          conv.id === conversation.id
-                                            ? {
-                                                ...conv,
-                                                hideAlerts: !conv.hideAlerts,
-                                              }
-                                            : conv
-                                        );
-                                      onUpdateConversation(
-                                        updatedConversations,
-                                        "mute"
-                                      );
-                                    }}
-                                  >
-                                    <span>
-                                      {conversation.hideAlerts
-                                        ? "Show Alerts"
-                                        : "Hide Alerts"}
-                                    </span>
-                                    {isMobileView &&
-                                      (conversation.hideAlerts ? (
-                                        <Icons.bell className="h-4 w-4 ml-2" />
-                                      ) : (
-                                        <Icons.bellOff className="h-4 w-4 ml-2" />
-                                      ))}
-                                  </ContextMenuItem>
-                                  <ContextMenuItem
-                                    className={`focus:bg-[#0A7CFF] focus:text-white ${
-                                      isMobileView
-                                        ? "flex items-center justify-between"
-                                        : ""
-                                    } text-red-600`}
-                                    onClick={() =>
-                                      onDeleteConversation(conversation.id)
-                                    }
-                                  >
-                                    <span>Delete</span>
-                                    {isMobileView && (
-                                      <Icons.trash className="h-4 w-4 ml-2" />
-                                    )}
-                                  </ContextMenuItem>
-                                </ContextMenuContent>
-                              </ContextMenu>
+                                </button>
+                              </ConversationContextActions>
                             </div>
                           ))}
                       </div>

--- a/lib/messages/mobile-conversation-interactions.ts
+++ b/lib/messages/mobile-conversation-interactions.ts
@@ -1,0 +1,54 @@
+import type { Conversation, Message } from "@/types/messages";
+
+export const MOBILE_CONVERSATION_LONG_PRESS_DELAY_MS = 550;
+export const MOBILE_CONVERSATION_LONG_PRESS_MOVE_TOLERANCE = 10;
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+export function canStartMobileConversationLongPress(pointerType: string) {
+  return pointerType === "touch" || pointerType === "pen";
+}
+
+export function didMobileConversationLongPressMove(
+  origin: Point,
+  current: Point,
+) {
+  return (
+    Math.abs(current.x - origin.x) >
+      MOBILE_CONVERSATION_LONG_PRESS_MOVE_TOLERANCE ||
+    Math.abs(current.y - origin.y) >
+      MOBILE_CONVERSATION_LONG_PRESS_MOVE_TOLERANCE
+  );
+}
+
+export function isConversationContextMenuKeyboardShortcut(
+  key: string,
+  shiftKey: boolean,
+) {
+  return key === "ContextMenu" || (shiftKey && key === "F10");
+}
+
+export function getConversationDisplayName(conversation: Conversation) {
+  return (
+    conversation.name ||
+    conversation.recipients.map((recipient) => recipient.name).join(", ") ||
+    "New Message"
+  );
+}
+
+export function getConversationPreviewMessages(
+  conversation: Conversation,
+  limit = 4,
+): Message[] {
+  if (limit <= 0) return [];
+
+  return conversation.messages
+    .filter(
+      (message) =>
+        message.sender !== "system" && message.content.trim().length > 0,
+    )
+    .slice(-limit);
+}

--- a/tests/mobile-conversation-interactions.test.ts
+++ b/tests/mobile-conversation-interactions.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canStartMobileConversationLongPress,
+  didMobileConversationLongPressMove,
+  getConversationDisplayName,
+  getConversationPreviewMessages,
+  isConversationContextMenuKeyboardShortcut,
+} from "../lib/messages/mobile-conversation-interactions";
+import type { Conversation } from "../types/messages";
+
+const conversation: Conversation = {
+  id: "conversation-1",
+  name: "Design chat",
+  recipients: [{ id: "person-1", name: "Ada Lovelace" }],
+  lastMessageTime: "2026-07-27T12:00:00.000Z",
+  unreadCount: 0,
+  messages: [
+    {
+      id: "system",
+      content: "Ada joined the conversation",
+      sender: "system",
+      timestamp: "2026-07-27T11:57:00.000Z",
+    },
+    {
+      id: "empty",
+      content: "   ",
+      sender: "Ada Lovelace",
+      timestamp: "2026-07-27T11:58:00.000Z",
+    },
+    {
+      id: "incoming",
+      content: "Does this interaction feel native?",
+      sender: "Ada Lovelace",
+      timestamp: "2026-07-27T11:59:00.000Z",
+    },
+    {
+      id: "outgoing",
+      content: "The expanded preview does.",
+      sender: "me",
+      timestamp: "2026-07-27T12:00:00.000Z",
+    },
+  ],
+};
+
+test("starts conversation long presses only for touch-style pointers", () => {
+  assert.equal(canStartMobileConversationLongPress("touch"), true);
+  assert.equal(canStartMobileConversationLongPress("pen"), true);
+  assert.equal(canStartMobileConversationLongPress("mouse"), false);
+});
+
+test("cancels a conversation long press after meaningful movement", () => {
+  assert.equal(
+    didMobileConversationLongPressMove({ x: 10, y: 10 }, { x: 20, y: 20 }),
+    false,
+  );
+  assert.equal(
+    didMobileConversationLongPressMove({ x: 10, y: 10 }, { x: 21, y: 10 }),
+    true,
+  );
+});
+
+test("recognizes conversation context-menu keyboard shortcuts", () => {
+  assert.equal(
+    isConversationContextMenuKeyboardShortcut("ContextMenu", false),
+    true,
+  );
+  assert.equal(isConversationContextMenuKeyboardShortcut("F10", true), true);
+  assert.equal(isConversationContextMenuKeyboardShortcut("F10", false), false);
+});
+
+test("builds a useful static conversation preview", () => {
+  assert.equal(getConversationDisplayName(conversation), "Design chat");
+  assert.deepEqual(
+    getConversationPreviewMessages(conversation).map((message) => message.id),
+    ["incoming", "outgoing"],
+  );
+  assert.deepEqual(getConversationPreviewMessages(conversation, 1), [
+    conversation.messages[3],
+  ]);
+});


### PR DESCRIPTION
## What changed

- Add a native-style focused conversation preview when a user presses and holds a Messages conversation on mobile.
- Apply the same interaction to pinned conversation tiles and regular conversation rows.
- Animate the preview outward from the exact pressed tile or row, then reveal the action sheet beneath it.
- Show the latest four non-system messages in a static iMessage-style preview.
- Open the selected conversation when the user taps or activates the expanded preview.
- Preserve the existing Pin / Unpin, Show / Hide Alerts, and Delete actions.
- Close the preview when the user taps the dimmed backdrop or any visible gap around the preview and action sheet.
- Suppress iOS touch callouts and text selection on both Messages trigger types.
- Cancel long press after meaningful finger movement so normal scrolling and swipe actions continue to work.
- Support secondary click, the Context Menu key, and Shift+F10 in mobile layouts with a trackpad or keyboard.
- Restore focus after keyboard-triggered previews and respect reduced-motion preferences.
- Keep the existing compact right-click menu on desktop.

## Why

The mobile Messages context menu exposed useful actions but did not provide the focused conversation preview used by native iOS Messages, and iOS Safari could select row text during the hold. This makes the interaction easier to understand and closer to the system behavior while preserving the app's existing actions and swipe gestures.

This work is intentionally separated from the Notes implementation in #259.

## Impact

Mobile users can preview and enter a conversation before taking another action. Pinned and unpinned conversations behave consistently, normal taps still open a conversation, scrolling cancels the hold, tapping outside dismisses the preview, and desktop behavior is unchanged.

## Verification

- `npm run check`
  - lint passes with 7 pre-existing warnings
  - 20 tests pass, including gesture, keyboard, and preview-selection coverage
  - TypeScript passes
  - production build passes
- Local mobile-layout interaction audit
  - pinned and unpinned previews open with the correct Pin / Unpin action
  - the preview itself opens the correct conversation
  - the preview contains no encryption subtitle
  - outside dismissal closes the focused view
  - a normal tap still opens the conversation
