### PR TITLE
Add photo rotation controls in Photos

### DIFF
--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -7,7 +7,15 @@ import { PhotoViewer } from "./photo-viewer";
 import { Nav } from "./nav";
 import { Photo, PhotosView, TimeFilter } from "@/types/photos";
 import { usePhotos } from "@/lib/photos/use-photos";
-import { loadPhotosView, savePhotosView, loadPhotosSelectedId, savePhotosSelectedId } from "@/lib/sidebar-persistence";
+import {
+  loadPhotosRotations,
+  loadPhotosSelectedId,
+  loadPhotosView,
+  savePhotosRotations,
+  savePhotosSelectedId,
+  savePhotosView,
+} from "@/lib/sidebar-persistence";
+import type { PhotoRotations } from "@/lib/sidebar-persistence";
 
 interface AppProps {
   isDesktop?: boolean;
@@ -29,6 +37,9 @@ export default function App({ isDesktop = false }: AppProps) {
   const [showGrid, setShowGrid] = useState(() => loadPhotosSelectedId() !== null);
   const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(() => loadPhotosSelectedId());
   const [selectedInGridId, setSelectedInGridId] = useState<string | null>(null);
+  const [photoRotations, setPhotoRotations] = useState<PhotoRotations>(() =>
+    loadPhotosRotations(),
+  );
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -56,6 +67,12 @@ export default function App({ isDesktop = false }: AppProps) {
       savePhotosSelectedId(selectedPhotoId);
     }
   }, [selectedPhotoId, isViewLoaded]);
+
+  useEffect(() => {
+    if (isViewLoaded) {
+      savePhotosRotations(photoRotations);
+    }
+  }, [photoRotations, isViewLoaded]);
 
   // Filter and sort photos based on active view (oldest first, newest at bottom)
   const filteredPhotos = useMemo(() => {
@@ -96,6 +113,13 @@ export default function App({ isDesktop = false }: AppProps) {
 
   const handleCloseViewer = useCallback(() => {
     setSelectedPhotoId(null);
+  }, []);
+
+  const handleRotatePhoto = useCallback((photoId: string) => {
+    setPhotoRotations((currentRotations) => ({
+      ...currentRotations,
+      [photoId]: (currentRotations[photoId] ?? 0) - 90,
+    }));
   }, []);
 
   // Get the selected photo and its index in the filtered list
@@ -197,6 +221,8 @@ export default function App({ isDesktop = false }: AppProps) {
                 onPrevious={handlePreviousPhoto}
                 onNext={handleNextPhoto}
                 onToggleFavorite={toggleFavorite}
+                rotation={photoRotations[selectedPhoto.id] ?? 0}
+                onRotate={() => handleRotatePhoto(selectedPhoto.id)}
                 isMobileView={isMobileView}
                 isDesktop={isDesktop}
               />

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -253,6 +253,7 @@ export function PhotoViewer({
   const windowFocus = useWindowFocus();
   const inShell = isDesktop && windowFocus;
   const [isSwiping, setIsSwiping] = useState(false);
+  const [shouldAnimateRotation, setShouldAnimateRotation] = useState(false);
   const [naturalSize, setNaturalSize] = useState<{
     photoId: string;
     width: number;
@@ -270,6 +271,10 @@ export function PhotoViewer({
   const infoContainerRef = useRef<HTMLDivElement>(null);
   const mobileScrollRef = useRef<HTMLDivElement>(null);
   const closeInfo = useCallback(() => setIsInfoOpen(false), []);
+  const rotateLeft = useCallback(() => {
+    setShouldAnimateRotation(true);
+    onRotate();
+  }, [onRotate]);
 
   useClickOutside(infoContainerRef, closeInfo, isInfoOpen);
 
@@ -314,6 +319,7 @@ export function PhotoViewer({
 
   useEffect(() => {
     mobileScrollRef.current?.scrollTo({ top: 0 });
+    setShouldAnimateRotation(false);
   }, [photo.id]);
 
   // Prevent default touch move when swiping to avoid scroll interference
@@ -387,6 +393,7 @@ export function PhotoViewer({
 
   let displayedImageSize: { width: number; height: number } | null = null;
   if (
+    rotation !== 0 &&
     currentNaturalSize &&
     containerSize &&
     containerSize.width > 0 &&
@@ -570,7 +577,7 @@ export function PhotoViewer({
             />
           </button>
           <button
-            onClick={onRotate}
+            onClick={rotateLeft}
             className="p-1 rounded text-foreground transition-colors can-hover:hover:bg-muted"
             aria-label="Rotate left"
             title="Rotate Left"
@@ -615,8 +622,9 @@ export function PhotoViewer({
                   width: displayedImageSize.width,
                   height: displayedImageSize.height,
                   transform: rotation ? `rotate(${rotation}deg)` : undefined,
-                  transition:
-                    "width 0.15s ease-out, height 0.15s ease-out, transform 0.2s ease-out",
+                  transition: shouldAnimateRotation
+                    ? "width 0.15s ease-out, height 0.15s ease-out, transform 0.2s ease-out"
+                    : undefined,
                 }}
                 onLoad={(event) => handleImageLoad(event.currentTarget)}
                 priority

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSwipeable } from "react-swipeable";
 import { Photo } from "@/types/photos";
-import { ChevronLeft, Heart } from "lucide-react";
+import { ChevronLeft, Heart, RotateCcwSquare } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useWindowFocus } from "@/lib/window-focus-context";
 import { toZonedTime } from "date-fns-tz";
@@ -27,6 +27,8 @@ interface PhotoViewerProps {
   onPrevious: () => void;
   onNext: () => void;
   onToggleFavorite?: (photoId: string) => void;
+  rotation: number;
+  onRotate: () => void;
   isMobileView: boolean;
   isDesktop?: boolean;
 }
@@ -40,12 +42,39 @@ export function PhotoViewer({
   onPrevious,
   onNext,
   onToggleFavorite,
+  rotation,
+  onRotate,
   isMobileView,
   isDesktop = false,
 }: PhotoViewerProps) {
   const windowFocus = useWindowFocus();
   const inShell = isDesktop && windowFocus;
   const [isSwiping, setIsSwiping] = useState(false);
+  const [naturalSize, setNaturalSize] = useState<{
+    photoId: string;
+    width: number;
+    height: number;
+  } | null>(null);
+  const [containerSize, setContainerSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  const imageContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = imageContainerRef.current;
+    if (!container) return;
+
+    const updateSize = () => {
+      const rect = container.getBoundingClientRect();
+      setContainerSize({ width: rect.width, height: rect.height });
+    };
+
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
 
   // Prevent default touch move when swiping to avoid scroll interference
   useEffect(() => {
@@ -110,6 +139,42 @@ export function PhotoViewer({
 
   const pstDate = toZonedTime(parseISO(photo.timestamp), "America/Los_Angeles");
   const formattedDate = format(pstDate, "MMMM d, yyyy 'at' h:mm:ss a");
+  const currentNaturalSize =
+    naturalSize?.photoId === photo.id ? naturalSize : null;
+  const isQuarterTurn = rotation % 180 !== 0;
+
+  let displayedImageSize: { width: number; height: number } | null = null;
+  if (
+    currentNaturalSize &&
+    containerSize &&
+    containerSize.width > 0 &&
+    containerSize.height > 0
+  ) {
+    const rotatedWidth = isQuarterTurn
+      ? currentNaturalSize.height
+      : currentNaturalSize.width;
+    const rotatedHeight = isQuarterTurn
+      ? currentNaturalSize.width
+      : currentNaturalSize.height;
+    const scale = Math.min(
+      containerSize.width / rotatedWidth,
+      containerSize.height / rotatedHeight,
+    );
+    const fittedWidth = rotatedWidth * scale;
+    const fittedHeight = rotatedHeight * scale;
+
+    displayedImageSize = isQuarterTurn
+      ? { width: fittedHeight, height: fittedWidth }
+      : { width: fittedWidth, height: fittedHeight };
+  }
+
+  const handleImageLoad = (image: HTMLImageElement) => {
+    setNaturalSize({
+      photoId: photo.id,
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+    });
+  };
 
   return (
     <div className="h-full flex flex-col bg-background">
@@ -138,19 +203,39 @@ export function PhotoViewer({
           </p>
         </div>
 
-        {/* Favorite button */}
-        <button
-          onClick={() => onToggleFavorite?.(photo.id)}
+        {/* Photo actions */}
+        <div
+          className="flex items-center gap-1 -mr-1"
           onMouseDown={(e) => e.stopPropagation()}
-          className="p-1 -mr-1"
         >
-          <Heart
-            className={cn(
-              "w-5 h-5 transition-colors text-foreground",
-              photo.isFavorite && "fill-foreground"
-            )}
-          />
-        </button>
+          <button
+            onClick={() => onToggleFavorite?.(photo.id)}
+            className="p-1 rounded can-hover:hover:bg-muted"
+            aria-label={
+              photo.isFavorite ? "Remove from favorites" : "Add to favorites"
+            }
+            title={photo.isFavorite ? "Remove from Favorites" : "Add to Favorites"}
+          >
+            <Heart
+              className={cn(
+                "w-5 h-5 transition-colors text-foreground",
+                photo.isFavorite && "fill-foreground"
+              )}
+            />
+          </button>
+          <button
+            onClick={onRotate}
+            className="p-1 rounded text-foreground transition-colors can-hover:hover:bg-muted"
+            aria-label="Rotate left"
+            title="Rotate Left"
+          >
+            <RotateCcwSquare
+              aria-hidden="true"
+              className="h-4 w-4"
+              strokeWidth={2}
+            />
+          </button>
+        </div>
       </div>
 
       {/* Photo with swipe support */}
@@ -158,17 +243,42 @@ export function PhotoViewer({
         {...swipeHandlers}
         className="flex-1 flex items-center justify-center min-h-0 bg-muted/30"
       >
-        <div className="relative w-full h-full">
-          <Image
-            key={photo.id}
-            src={getViewerUrl(photo.url)}
-            alt=""
-            fill
-            className="object-contain"
-            sizes="(max-width: 768px) 100vw, 80vw"
-            priority
-            unoptimized
-          />
+        <div
+          ref={imageContainerRef}
+          className="relative flex h-full w-full items-center justify-center overflow-hidden"
+        >
+          {displayedImageSize ? (
+            <Image
+              key={photo.id}
+              src={getViewerUrl(photo.url)}
+              alt=""
+              width={Math.max(1, Math.round(displayedImageSize.width))}
+              height={Math.max(1, Math.round(displayedImageSize.height))}
+              draggable={false}
+              style={{
+                width: displayedImageSize.width,
+                height: displayedImageSize.height,
+                transform: rotation ? `rotate(${rotation}deg)` : undefined,
+                transition:
+                  "width 0.15s ease-out, height 0.15s ease-out, transform 0.2s ease-out",
+              }}
+              onLoad={(event) => handleImageLoad(event.currentTarget)}
+              priority
+              unoptimized
+            />
+          ) : (
+            <Image
+              key={photo.id}
+              src={getViewerUrl(photo.url)}
+              alt=""
+              fill
+              className="object-contain"
+              sizes="(max-width: 768px) 100vw, 80vw"
+              onLoad={(event) => handleImageLoad(event.currentTarget)}
+              priority
+              unoptimized
+            />
+          )}
         </div>
       </div>
     </div>

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -584,7 +584,7 @@ export function PhotoViewer({
           >
             <RotateCcwSquare
               aria-hidden="true"
-              className="h-4 w-4"
+              className="h-5 w-5"
               strokeWidth={2}
             />
           </button>

--- a/lib/sidebar-persistence.ts
+++ b/lib/sidebar-persistence.ts
@@ -35,6 +35,7 @@ const STORAGE_KEYS = {
   FINDER_PATH: "finder-path",
   PHOTOS_VIEW: "photos-view",
   PHOTOS_SELECTED: "photos-selected-id",
+  PHOTOS_ROTATIONS: "photos-rotations",
   SETTINGS_STATE: "settings-state",
   CALENDAR_VIEW: "calendar-view",
   CALENDAR_DATE: "calendar-date",
@@ -47,6 +48,8 @@ const STORAGE_KEYS = {
   // Local storage (durable user content)
   WEATHER_CUSTOM_CITIES: "weather-custom-cities",
 } as const;
+
+type StorageArea = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
 // ============================================================================
 // Generic Factory (for simple enum-like sidebar values)
@@ -206,11 +209,68 @@ export function savePhotosSelectedId(photoId: string | null): void {
   }
 }
 
-export function clearPhotosState(): void {
-  if (typeof window === "undefined") return;
+export type PhotoRotations = Record<string, number>;
+
+function getPhotosSessionStorage(storage?: StorageArea): StorageArea | null {
+  if (storage) return storage;
+  if (typeof window === "undefined") return null;
+
   try {
-    sessionStorage.removeItem(STORAGE_KEYS.PHOTOS_VIEW);
-    sessionStorage.removeItem(STORAGE_KEYS.PHOTOS_SELECTED);
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadPhotosRotations(storage?: StorageArea): PhotoRotations {
+  const target = getPhotosSessionStorage(storage);
+  if (!target) return {};
+
+  try {
+    const saved = target.getItem(STORAGE_KEYS.PHOTOS_ROTATIONS);
+    if (!saved) return {};
+
+    const parsed: unknown = JSON.parse(saved);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        ([photoId, rotation]) =>
+          photoId.length > 0 &&
+          typeof rotation === "number" &&
+          Number.isFinite(rotation) &&
+          rotation % 90 === 0,
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function savePhotosRotations(
+  rotations: PhotoRotations,
+  storage?: StorageArea,
+): void {
+  const target = getPhotosSessionStorage(storage);
+  if (!target) return;
+
+  try {
+    target.setItem(STORAGE_KEYS.PHOTOS_ROTATIONS, JSON.stringify(rotations));
+  } catch {
+    // Ignore storage errors (e.g., quota exceeded, private browsing)
+  }
+}
+
+export function clearPhotosState(storage?: StorageArea): void {
+  const target = getPhotosSessionStorage(storage);
+  if (!target) return;
+
+  try {
+    target.removeItem(STORAGE_KEYS.PHOTOS_VIEW);
+    target.removeItem(STORAGE_KEYS.PHOTOS_SELECTED);
+    target.removeItem(STORAGE_KEYS.PHOTOS_ROTATIONS);
   } catch {
     // Ignore storage errors
   }

--- a/tests/photos-rotation.test.ts
+++ b/tests/photos-rotation.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearPhotosState,
+  loadPhotosRotations,
+  savePhotosRotations,
+} from "../lib/sidebar-persistence";
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+test("restores photo rotations only from the current tab", () => {
+  const firstTabStorage = new MemoryStorage();
+  const secondTabStorage = new MemoryStorage();
+
+  savePhotosRotations(
+    {
+      "photo-one": -90,
+      "photo-two": -180,
+    },
+    firstTabStorage,
+  );
+
+  assert.deepEqual(loadPhotosRotations(firstTabStorage), {
+    "photo-one": -90,
+    "photo-two": -180,
+  });
+  assert.deepEqual(loadPhotosRotations(secondTabStorage), {});
+});
+
+test("ignores malformed photo rotation entries", () => {
+  const tabStorage = new MemoryStorage();
+  tabStorage.setItem(
+    "photos-rotations",
+    JSON.stringify({
+      valid: -270,
+      "not-a-quarter-turn": 45,
+      "not-a-number": "90",
+    }),
+  );
+
+  assert.deepEqual(loadPhotosRotations(tabStorage), {
+    valid: -270,
+  });
+});
+
+test("clears photo rotations with the rest of Photos view state", () => {
+  const tabStorage = new MemoryStorage();
+  savePhotosRotations({ "photo-one": -90 }, tabStorage);
+
+  clearPhotosState(tabStorage);
+
+  assert.deepEqual(loadPhotosRotations(tabStorage), {});
+});


### PR DESCRIPTION
## What changed

- add Preview’s `RotateCcwSquare` action immediately to the right of the Photos favorite button
- rotate the active photo 90° counterclockwise per click while keeping portrait and landscape images fitted inside the viewer
- persist rotation independently per photo in tab-scoped `sessionStorage`
- restore saved rotation after navigation or reload and clear it with the rest of Photos view state when the app closes
- keep gallery-open and session-restored photos static, with sizing transitions enabled only by an explicit Rotate click
- add coverage for tab isolation, malformed stored values, and Photos state cleanup

## Why

Photos already supports viewing and favoriting images, but it lacked the rotation control available in Preview. Reusing the same icon and behavior makes the two image-viewing experiences consistent while preserving a user’s orientation within the current browser session.

## Validation

- `npm run check`
- 30 Node tests passed
- typecheck and production build completed successfully
- verified locally that opening a gallery photo has no entry animation
- verified that Rotate still animates and keeps the image contained
- verified that session-restored rotation appears immediately without a transition
- verified no browser console errors during the interaction