### PR TITLE
Fix Photos header layout shift

### DIFF
--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -133,9 +133,7 @@ export function PhotosGrid({
           )}
           <div>
             <h1 className="text-lg font-semibold">{getViewTitle()}</h1>
-            {dateRange && (
-              <p className="text-xs text-muted-foreground">{dateRange}</p>
-            )}
+            <p className="min-h-4 text-xs text-muted-foreground">{dateRange}</p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- reserve space for the Photos date-range row from the first render
- keep the header and Years / Months / All Photos control stationary while photo data loads
- preserve the same header geometry for empty albums

## Root cause

The date-range paragraph was mounted only after photos loaded. Adding that 16px row increased the header from 53px to 69px and re-centered the filter control, producing an 8px downward jump.

## Impact

Opening Photos no longer causes the header filter to visibly settle after the initial data request. Switching between populated and empty albums also keeps the header stable.

## Verification

- `npm run check`
- browser-verified the header remains 69px tall and the filter remains at the same vertical position in populated and empty states
