### PR TITLE
Render formatted Notes gallery previews

### DIFF
--- a/app/(desktop)/notes/styles/github-markdown.css
+++ b/app/(desktop)/notes/styles/github-markdown.css
@@ -214,3 +214,205 @@
   margin: 16px 0;
   border-radius: 4px;
 }
+
+/*
+ * Gallery previews preserve the note's Markdown hierarchy at card scale.
+ * Links and task controls are rendered as non-interactive spans so the
+ * containing card remains the single click target.
+ */
+.note-markdown-preview {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.note-markdown-preview > :first-child {
+  margin-top: 0;
+}
+
+.note-markdown-preview > :last-child {
+  margin-bottom: 0;
+}
+
+.note-markdown-preview h1,
+.note-markdown-preview h2,
+.note-markdown-preview h3,
+.note-markdown-preview h4,
+.note-markdown-preview h5,
+.note-markdown-preview h6 {
+  color: hsl(var(--foreground));
+  font-weight: 650;
+  line-height: 1.2;
+  margin: 0.65em 0 0.3em;
+}
+
+.note-markdown-preview h1 {
+  font-size: 1.45em;
+}
+
+.note-markdown-preview h2 {
+  font-size: 1.3em;
+}
+
+.note-markdown-preview h3 {
+  font-size: 1.15em;
+}
+
+.note-markdown-preview p {
+  margin: 0 0 0.55em;
+}
+
+.note-markdown-preview strong {
+  color: hsl(var(--foreground));
+  font-weight: 650;
+}
+
+.note-markdown-preview em {
+  font-style: italic;
+}
+
+.note-markdown-preview ul,
+.note-markdown-preview ol {
+  margin: 0 0 0.55em;
+  padding-left: 1.45em;
+}
+
+.note-markdown-preview ul {
+  list-style-type: disc;
+}
+
+.note-markdown-preview ul ul {
+  list-style-type: circle;
+}
+
+.note-markdown-preview ol {
+  list-style-type: decimal;
+}
+
+.note-markdown-preview li {
+  margin: 0.12em 0;
+}
+
+.note-markdown-preview ul.contains-task-list {
+  list-style-type: none;
+  padding-left: 0.1em;
+}
+
+.note-markdown-preview .task-list-item {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.45em;
+}
+
+.note-markdown-preview-checkbox {
+  border: 1px solid hsl(var(--muted-foreground));
+  border-radius: 999px;
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 1.05em;
+  justify-content: center;
+  line-height: 1;
+  margin-top: 0.14em;
+  width: 1.05em;
+}
+
+.note-markdown-preview-checkbox-checked {
+  align-items: center;
+  background: #e2a727;
+  border-color: #e2a727;
+  color: white;
+  font-size: 0.92em;
+}
+
+.dark .note-markdown-preview-checkbox-checked {
+  color: hsl(var(--background));
+}
+
+.note-markdown-preview-link {
+  color: #e2a727;
+  text-decoration: underline;
+  text-decoration-thickness: from-font;
+  text-underline-offset: 0.08em;
+}
+
+.note-markdown-preview blockquote {
+  border-left: 0.2em solid hsl(var(--muted-foreground) / 0.35);
+  color: hsl(var(--muted-foreground));
+  margin: 0 0 0.55em;
+  padding-left: 0.65em;
+}
+
+.note-markdown-preview code {
+  background: hsl(var(--muted));
+  border-radius: 0.22em;
+  color: hsl(var(--foreground));
+  font-size: 0.88em;
+  padding: 0.08em 0.25em;
+}
+
+.note-markdown-preview pre {
+  background: hsl(var(--muted));
+  border-radius: 0.35em;
+  margin: 0 0 0.55em;
+  overflow: hidden;
+  padding: 0.55em;
+  white-space: pre-wrap;
+}
+
+.note-markdown-preview pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.note-markdown-preview table {
+  border-collapse: collapse;
+  font-size: 0.88em;
+  margin: 0 0 0.55em;
+  width: 100%;
+}
+
+.note-markdown-preview th,
+.note-markdown-preview td {
+  border: 1px solid hsl(var(--muted-foreground) / 0.25);
+  padding: 0.2em 0.35em;
+  text-align: left;
+}
+
+.note-markdown-preview th {
+  color: hsl(var(--foreground));
+  font-weight: 650;
+}
+
+.note-markdown-preview hr {
+  border: 0;
+  border-top: 1px solid hsl(var(--muted-foreground) / 0.25);
+  margin: 0.65em 0;
+}
+
+.note-markdown-preview-image {
+  border-radius: 0.35em;
+  display: block;
+  height: auto;
+  margin: 0 0 0.55em;
+  max-height: 7em;
+  object-fit: cover;
+  width: 100%;
+}
+
+.note-markdown-preview-expanded {
+  line-height: 1.5;
+}
+
+.note-markdown-preview-expanded p,
+.note-markdown-preview-expanded ul,
+.note-markdown-preview-expanded ol,
+.note-markdown-preview-expanded blockquote,
+.note-markdown-preview-expanded pre,
+.note-markdown-preview-expanded table,
+.note-markdown-preview-expanded .note-markdown-preview-image {
+  margin-bottom: 0.8em;
+}
+
+.note-markdown-preview-expanded .note-markdown-preview-image {
+  max-height: none;
+  object-fit: contain;
+}

--- a/app/(desktop)/notes/styles/github-markdown.css
+++ b/app/(desktop)/notes/styles/github-markdown.css
@@ -398,6 +398,61 @@
   width: 100%;
 }
 
+/*
+ * The native mobile gallery treats each note as one continuous miniature
+ * document. Remove block whitespace at thumbnail scale, preserve readable
+ * leading, and draw list markers explicitly so they remain visible.
+ */
+.note-markdown-preview-compact h1,
+.note-markdown-preview-compact h2,
+.note-markdown-preview-compact h3,
+.note-markdown-preview-compact h4,
+.note-markdown-preview-compact h5,
+.note-markdown-preview-compact h6,
+.note-markdown-preview-compact p,
+.note-markdown-preview-compact ul,
+.note-markdown-preview-compact ol,
+.note-markdown-preview-compact blockquote,
+.note-markdown-preview-compact pre,
+.note-markdown-preview-compact table,
+.note-markdown-preview-compact .note-markdown-preview-image {
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.note-markdown-preview-compact ul,
+.note-markdown-preview-compact ol {
+  padding-left: 1.25em;
+}
+
+.note-markdown-preview-compact li {
+  margin: 0;
+}
+
+.note-markdown-preview-compact
+  ul:not(.contains-task-list)
+  > li {
+  list-style: none;
+  position: relative;
+}
+
+.note-markdown-preview-compact
+  ul:not(.contains-task-list)
+  > li::before {
+  color: hsl(var(--foreground));
+  content: "•";
+  font-size: 1.2em;
+  left: -1em;
+  line-height: 1;
+  position: absolute;
+  top: 0.08em;
+}
+
+.note-markdown-preview-compact ol > li::marker {
+  color: hsl(var(--foreground));
+  font-weight: 600;
+}
+
 .note-markdown-preview-expanded {
   line-height: 1.5;
 }

--- a/app/(desktop)/notes/styles/github-markdown.css
+++ b/app/(desktop)/notes/styles/github-markdown.css
@@ -429,6 +429,10 @@
   margin: 0;
 }
 
+.note-markdown-preview-compact > :not(:first-child) {
+  margin-top: 0.4em;
+}
+
 .note-markdown-preview-compact
   ul:not(.contains-task-list)
   > li {

--- a/components/apps/notes/nav.tsx
+++ b/components/apps/notes/nav.tsx
@@ -145,7 +145,7 @@ export function Nav({
     created: "Date Created",
     off: "Off",
   }[groupMode];
-  const usesGroupedBackground = !onGalleryBack;
+  const usesGroupedBackground = isMobile && !onGalleryBack;
 
   const applyPendingViewMode = useCallback(() => {
     const pendingViewMode = pendingViewModeRef.current;

--- a/components/apps/notes/nav.tsx
+++ b/components/apps/notes/nav.tsx
@@ -145,6 +145,7 @@ export function Nav({
     created: "Date Created",
     off: "Off",
   }[groupMode];
+  const isGalleryOverview = viewMode === "gallery" && !onGalleryBack;
 
   const applyPendingViewMode = useCallback(() => {
     const pendingViewMode = pendingViewModeRef.current;
@@ -182,6 +183,9 @@ export function Nav({
     <WindowNavShell
       isMobile={isMobile}
       isScrolled={isScrolled}
+      className={cn(
+        isGalleryOverview && "bg-[#F2F2F7] dark:bg-black",
+      )}
       onMouseDown={nav.onDragStart}
       left={
         <div className="flex items-center gap-1">

--- a/components/apps/notes/nav.tsx
+++ b/components/apps/notes/nav.tsx
@@ -145,7 +145,7 @@ export function Nav({
     created: "Date Created",
     off: "Off",
   }[groupMode];
-  const isGalleryOverview = viewMode === "gallery" && !onGalleryBack;
+  const usesGroupedBackground = !onGalleryBack;
 
   const applyPendingViewMode = useCallback(() => {
     const pendingViewMode = pendingViewModeRef.current;
@@ -184,7 +184,7 @@ export function Nav({
       isMobile={isMobile}
       isScrolled={isScrolled}
       className={cn(
-        isGalleryOverview && "bg-[#F2F2F7] dark:bg-black",
+        usesGroupedBackground && "bg-[#F2F2F7] dark:bg-black",
       )}
       onMouseDown={nav.onDragStart}
       left={

--- a/components/apps/notes/note-markdown-preview.tsx
+++ b/components/apps/notes/note-markdown-preview.tsx
@@ -8,18 +8,21 @@ import { cn } from "@/lib/utils";
 interface NoteMarkdownPreviewProps {
   content: string;
   className?: string;
+  compact?: boolean;
   expanded?: boolean;
 }
 
 export function NoteMarkdownPreview({
   content,
   className,
+  compact = false,
   expanded = false,
 }: NoteMarkdownPreviewProps) {
   return (
     <ReactMarkdown
       className={cn(
         "note-markdown-preview",
+        compact && "note-markdown-preview-compact",
         expanded && "note-markdown-preview-expanded",
         className,
       )}

--- a/components/apps/notes/note-markdown-preview.tsx
+++ b/components/apps/notes/note-markdown-preview.tsx
@@ -1,31 +1,109 @@
 "use client";
 
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "@/lib/utils";
+import { getBoundedMarkdownPreview } from "@/lib/notes/markdown-preview";
+
+const visibilityCallbacks = new WeakMap<Element, () => void>();
+let previewVisibilityObserver: IntersectionObserver | null = null;
+
+function observePreviewVisibility(
+  element: Element,
+  onVisible: () => void,
+): (() => void) | null {
+  if (typeof IntersectionObserver === "undefined") return null;
+
+  previewVisibilityObserver ??= new IntersectionObserver(
+    (entries, observer) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+
+        visibilityCallbacks.get(entry.target)?.();
+        visibilityCallbacks.delete(entry.target);
+        observer.unobserve(entry.target);
+      });
+    },
+    { rootMargin: "600px 0px" },
+  );
+
+  visibilityCallbacks.set(element, onVisible);
+  previewVisibilityObserver.observe(element);
+
+  return () => {
+    visibilityCallbacks.delete(element);
+    previewVisibilityObserver?.unobserve(element);
+  };
+}
 
 interface NoteMarkdownPreviewProps {
   content: string;
   className?: string;
   compact?: boolean;
   expanded?: boolean;
+  deferUntilVisible?: boolean;
+  maxCharacters?: number;
 }
 
-export function NoteMarkdownPreview({
+export const NoteMarkdownPreview = memo(function NoteMarkdownPreview({
   content,
   className,
   compact = false,
   expanded = false,
+  deferUntilVisible = false,
+  maxCharacters,
 }: NoteMarkdownPreviewProps) {
+  const placeholderRef = useRef<HTMLDivElement>(null);
+  const [isNearViewport, setIsNearViewport] = useState(false);
+  const shouldRender = !deferUntilVisible || isNearViewport;
+  const previewContent = useMemo(
+    () =>
+      maxCharacters === undefined
+        ? content
+        : getBoundedMarkdownPreview(content, maxCharacters),
+    [content, maxCharacters],
+  );
+  const previewClassName = cn(
+    "note-markdown-preview",
+    compact && "note-markdown-preview-compact",
+    expanded && "note-markdown-preview-expanded",
+    className,
+  );
+
+  useEffect(() => {
+    if (!deferUntilVisible || isNearViewport) return;
+
+    const placeholder = placeholderRef.current;
+    if (!placeholder) return;
+
+    const stopObserving = observePreviewVisibility(placeholder, () => {
+      setIsNearViewport(true);
+    });
+
+    if (!stopObserving) {
+      setIsNearViewport(true);
+      return;
+    }
+
+    return stopObserving;
+  }, [deferUntilVisible, isNearViewport]);
+
+  if (!shouldRender) {
+    return (
+      <div
+        ref={placeholderRef}
+        aria-hidden
+        className={previewClassName}
+        data-note-preview-pending
+      />
+    );
+  }
+
   return (
     <ReactMarkdown
-      className={cn(
-        "note-markdown-preview",
-        compact && "note-markdown-preview-compact",
-        expanded && "note-markdown-preview-expanded",
-        className,
-      )}
+      className={previewClassName}
       remarkPlugins={[remarkGfm]}
       components={{
         a: ({ children }) => (
@@ -56,7 +134,7 @@ export function NoteMarkdownPreview({
           ) : null,
       }}
     >
-      {content || "Start writing..."}
+      {previewContent || "Start writing..."}
     </ReactMarkdown>
   );
-}
+});

--- a/components/apps/notes/note-markdown-preview.tsx
+++ b/components/apps/notes/note-markdown-preview.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Image from "next/image";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { cn } from "@/lib/utils";
+
+interface NoteMarkdownPreviewProps {
+  content: string;
+  className?: string;
+  expanded?: boolean;
+}
+
+export function NoteMarkdownPreview({
+  content,
+  className,
+  expanded = false,
+}: NoteMarkdownPreviewProps) {
+  return (
+    <ReactMarkdown
+      className={cn(
+        "note-markdown-preview",
+        expanded && "note-markdown-preview-expanded",
+        className,
+      )}
+      remarkPlugins={[remarkGfm]}
+      components={{
+        a: ({ children }) => (
+          <span className="note-markdown-preview-link">{children}</span>
+        ),
+        input: ({ checked, type }) =>
+          type === "checkbox" ? (
+            <span
+              aria-hidden
+              className={cn(
+                "note-markdown-preview-checkbox",
+                checked && "note-markdown-preview-checkbox-checked",
+              )}
+            >
+              {checked ? "✓" : null}
+            </span>
+          ) : null,
+        img: ({ alt, src }) =>
+          typeof src === "string" && src ? (
+            <Image
+              src={src}
+              alt={alt || "Note image"}
+              width={1200}
+              height={800}
+              className="note-markdown-preview-image"
+              unoptimized
+            />
+          ) : null,
+      }}
+    >
+      {content || "Start writing..."}
+    </ReactMarkdown>
+  );
+}

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -407,7 +407,8 @@ function GalleryCard({
     >
       <div
         className={cn(
-          "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-white text-left shadow-sm dark:bg-[#1C1C1E]",
+          "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 text-left shadow-sm",
+          isMobile ? "bg-white dark:bg-[#1C1C1E]" : "bg-background",
           isMobile
             ? "rounded-lg px-1.5 pt-1.5"
             : "rounded-xl px-4 py-3",

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -417,7 +417,7 @@ function GalleryCard({
           className={cn(
             "min-h-0 w-full flex-1 overflow-hidden text-muted-foreground",
             isMobile
-              ? "text-[5.5px] leading-[7px]"
+              ? "mt-0.5 text-[5.5px] leading-[7px]"
               : "mt-2 text-xs leading-[1.35]",
           )}
         />

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -13,6 +13,7 @@ import { NoteItem } from "./note-item";
 import { NoteMarkdownPreview } from "./note-markdown-preview";
 import { Note, NotesViewMode } from "@/lib/notes/types";
 import { getDisplayCreatedAt } from "@/lib/notes/display-created-at";
+import { NOTE_MARKDOWN_PREVIEW_MAX_CHARACTERS } from "@/lib/notes/markdown-preview";
 import {
   canStartMobileNoteLongPress,
   didMobileNoteLongPressMove,
@@ -93,7 +94,7 @@ function MobileGalleryNoteActions({
   onPinToggle: (slug: string) => void;
   onDelete: (note: Note) => Promise<void>;
 }) {
-  const previewRef = useRef<HTMLButtonElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
   const actionsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -166,6 +167,14 @@ function MobileGalleryNoteActions({
     onOpenNote(note);
   };
 
+  const handlePreviewKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+  ) => {
+    if (event.repeat || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
+    handleOpenNote();
+  };
+
   const handleDelete = () => {
     onOpenChange(false);
     void onDelete(note);
@@ -192,13 +201,17 @@ function MobileGalleryNoteActions({
             Preview the note, then pin, unpin, or delete it.
           </DialogPrimitive.Description>
 
-          <button
+          <div
             ref={previewRef}
-            type="button"
-            aria-label={`Open ${note.title}`}
-            onClick={handleOpenNote}
-            className="flex h-[min(52dvh,32rem)] w-full flex-col overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl outline-none will-change-transform"
+            className="relative flex h-[min(52dvh,32rem)] w-full flex-col overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl will-change-transform"
           >
+            <button
+              type="button"
+              aria-label={`Open ${note.title}`}
+              onClick={handleOpenNote}
+              onKeyDown={handlePreviewKeyDown}
+              className="absolute inset-0 z-10 cursor-default rounded-[28px] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#E2A727]"
+            />
             <h2 className="shrink-0 text-2xl font-bold leading-tight">
               {note.emoji} {note.title}
             </h2>
@@ -207,7 +220,7 @@ function MobileGalleryNoteActions({
               expanded
               className="mt-8 min-h-0 w-full flex-1 overflow-hidden text-[17px] leading-6 text-foreground"
             />
-          </button>
+          </div>
 
           <div
             ref={actionsRef}
@@ -366,6 +379,12 @@ function GalleryCard({
   };
 
   const handleCardKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (!event.repeat && (event.key === "Enter" || event.key === " ")) {
+      event.preventDefault();
+      onNoteSelect(note);
+      return;
+    }
+
     if (!isMobile || !isContextMenuKeyboardShortcut(event.key, event.shiftKey)) {
       return;
     }
@@ -386,16 +405,9 @@ function GalleryCard({
       onPointerUp={isMobile ? handlePointerEnd : undefined}
       onPointerCancel={isMobile ? handlePointerEnd : undefined}
     >
-      <button
-        ref={cardButtonRef}
-        type="button"
-        data-note-slug={note.slug}
-        onClick={handleCardClick}
-        onKeyDown={handleCardKeyDown}
-        aria-haspopup={isMobile ? "dialog" : undefined}
-        aria-expanded={isMobile ? isContextMenuOpen : undefined}
+      <div
         className={cn(
-          "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-white text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727] dark:bg-[#1C1C1E]",
+          "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-white text-left shadow-sm dark:bg-[#1C1C1E]",
           isMobile
             ? "rounded-lg px-1.5 pt-1.5"
             : "rounded-xl px-4 py-3",
@@ -414,6 +426,8 @@ function GalleryCard({
         <NoteMarkdownPreview
           content={note.content}
           compact={isMobile}
+          deferUntilVisible
+          maxCharacters={NOTE_MARKDOWN_PREVIEW_MAX_CHARACTERS}
           className={cn(
             "min-h-0 w-full flex-1 overflow-hidden text-muted-foreground",
             isMobile
@@ -421,7 +435,22 @@ function GalleryCard({
               : "mt-2 text-xs leading-[1.35]",
           )}
         />
-      </button>
+      </div>
+
+      <button
+        ref={cardButtonRef}
+        type="button"
+        data-note-slug={note.slug}
+        onClick={handleCardClick}
+        onKeyDown={handleCardKeyDown}
+        aria-label={`Open ${note.title}`}
+        aria-haspopup={isMobile ? "dialog" : undefined}
+        aria-expanded={isMobile ? isContextMenuOpen : undefined}
+        className={cn(
+          "absolute inset-x-0 top-0 z-10 aspect-[4/3] w-full cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
+          isMobile ? "rounded-lg" : "rounded-xl",
+        )}
+      />
 
       {isPinned && (
         <button
@@ -429,7 +458,7 @@ function GalleryCard({
           aria-label={`Unpin ${note.title}`}
           onClick={handleQuickPinClick}
           className={cn(
-            "absolute flex items-center justify-center bg-muted text-muted-foreground shadow-sm transition-colors can-hover:hover:bg-muted-foreground/15 can-hover:hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
+            "absolute z-20 flex items-center justify-center bg-muted text-muted-foreground shadow-sm transition-colors can-hover:hover:bg-muted-foreground/15 can-hover:hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
             isMobile
               ? "right-1.5 top-1.5 h-6 w-6 rounded-md"
               : "right-3 top-3 h-7 w-7 rounded-lg",

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -395,9 +395,9 @@ function GalleryCard({
         aria-haspopup={isMobile ? "dialog" : undefined}
         aria-expanded={isMobile ? isContextMenuOpen : undefined}
         className={cn(
-          "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-background text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727]",
+          "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-white text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727] dark:bg-[#1C1C1E]",
           isMobile
-            ? "rounded-lg px-2 py-1.5"
+            ? "rounded-lg px-1.5 py-1.5"
             : "rounded-xl px-4 py-3",
         )}
       >
@@ -405,7 +405,7 @@ function GalleryCard({
           className={cn(
             "line-clamp-2 font-semibold",
             isMobile
-              ? "pr-5 text-[9px] leading-[11px]"
+              ? "pr-5 text-[7px] leading-2"
               : "pr-7 text-sm leading-5",
           )}
         >
@@ -416,7 +416,7 @@ function GalleryCard({
           className={cn(
             "min-h-0 w-full flex-1 overflow-hidden text-muted-foreground",
             isMobile
-              ? "mt-1 text-[7px] leading-[1.25]"
+              ? "mt-0.5 text-[5px] leading-[5.5px]"
               : "mt-2 text-xs leading-[1.35]",
           )}
         />

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -397,7 +397,7 @@ function GalleryCard({
         className={cn(
           "flex aspect-[4/3] w-full flex-col overflow-hidden border border-muted-foreground/25 bg-white text-left shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E2A727] dark:bg-[#1C1C1E]",
           isMobile
-            ? "rounded-lg px-1.5 py-1.5"
+            ? "rounded-lg px-1.5 pt-1.5"
             : "rounded-xl px-4 py-3",
         )}
       >
@@ -413,10 +413,11 @@ function GalleryCard({
         </h4>
         <NoteMarkdownPreview
           content={note.content}
+          compact={isMobile}
           className={cn(
             "min-h-0 w-full flex-1 overflow-hidden text-muted-foreground",
             isMobile
-              ? "mt-0.5 text-[5px] leading-[5.5px]"
+              ? "text-[5.5px] leading-[7px]"
               : "mt-2 text-xs leading-[1.35]",
           )}
         />

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -10,9 +10,9 @@ import { useRouter } from "next/navigation";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Pin, PinOff, Trash2 } from "lucide-react";
 import { NoteItem } from "./note-item";
+import { NoteMarkdownPreview } from "./note-markdown-preview";
 import { Note, NotesViewMode } from "@/lib/notes/types";
 import { getDisplayCreatedAt } from "@/lib/notes/display-created-at";
-import { getNotePreviewText } from "@/lib/notes/note-utils";
 import {
   canStartMobileNoteLongPress,
   didMobileNoteLongPressMove,
@@ -197,14 +197,16 @@ function MobileGalleryNoteActions({
             type="button"
             aria-label={`Open ${note.title}`}
             onClick={handleOpenNote}
-            className="block h-[min(52dvh,32rem)] w-full overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl outline-none will-change-transform"
+            className="flex h-[min(52dvh,32rem)] w-full flex-col overflow-hidden rounded-[28px] border border-muted-foreground/15 bg-background p-6 text-left shadow-2xl outline-none will-change-transform"
           >
-            <h2 className="text-2xl font-bold leading-tight">
+            <h2 className="shrink-0 text-2xl font-bold leading-tight">
               {note.emoji} {note.title}
             </h2>
-            <p className="mt-8 whitespace-pre-wrap text-[17px] leading-6 text-foreground">
-              {getNotePreviewText(note.content)}
-            </p>
+            <NoteMarkdownPreview
+              content={note.content}
+              expanded
+              className="mt-8 min-h-0 w-full flex-1 overflow-hidden text-[17px] leading-6 text-foreground"
+            />
           </button>
 
           <div
@@ -409,16 +411,15 @@ function GalleryCard({
         >
           {note.emoji} {note.title}
         </h4>
-        <p
+        <NoteMarkdownPreview
+          content={note.content}
           className={cn(
-            "whitespace-pre-wrap text-muted-foreground",
+            "min-h-0 w-full flex-1 overflow-hidden text-muted-foreground",
             isMobile
-              ? "mt-1 line-clamp-[6] text-[7px] leading-[1.25]"
-              : "mt-2 line-clamp-[7] text-xs leading-[1.35]",
+              ? "mt-1 text-[7px] leading-[1.25]"
+              : "mt-2 text-xs leading-[1.35]",
           )}
-        >
-          {getNotePreviewText(note.content)}
-        </p>
+        />
       </button>
 
       {isPinned && (

--- a/components/apps/notes/sidebar.tsx
+++ b/components/apps/notes/sidebar.tsx
@@ -680,16 +680,22 @@ export default function Sidebar({
                   !isMobile && viewMode === "gallery" && "px-5 pb-5",
                 )}
               >
-                <SearchBar
-                  notes={notes}
-                  onSearchResults={setLocalSearchResults}
-                  sessionId={sessionId}
-                  inputRef={searchInputRef}
-                  searchQuery={searchQuery}
-                  setSearchQuery={setSearchQuery}
-                  setHighlightedIndex={setHighlightedIndex}
-                  clearSearch={clearSearch}
-                />
+                <div
+                  className={cn(
+                    isMobile && viewMode === "gallery" && "-mx-2",
+                  )}
+                >
+                  <SearchBar
+                    notes={notes}
+                    onSearchResults={setLocalSearchResults}
+                    sessionId={sessionId}
+                    inputRef={searchInputRef}
+                    searchQuery={searchQuery}
+                    setSearchQuery={setSearchQuery}
+                    setHighlightedIndex={setHighlightedIndex}
+                    clearSearch={clearSearch}
+                  />
+                </div>
                 <SidebarContent
                   groupedNotes={groupedNotes}
                   selectedNoteSlug={selectedNoteSlug}

--- a/components/apps/notes/sidebar.tsx
+++ b/components/apps/notes/sidebar.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import { usePathname } from "next/navigation";
 import SessionId from "./session-id";
-import { Pin } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { SidebarContent } from "./sidebar-content";
 import { SearchBar } from "./search";
@@ -42,11 +41,7 @@ import {
 import NoteDocument from "./note";
 
 const labels = {
-  pinned: (
-    <>
-      <Pin className="inline-block w-4 h-4 mr-1" /> Pinned
-    </>
-  ),
+  pinned: "Pinned",
   notes: "Notes",
   today: "Today",
   yesterday: "Yesterday",

--- a/components/apps/notes/sidebar.tsx
+++ b/components/apps/notes/sidebar.tsx
@@ -611,17 +611,26 @@ export default function Sidebar({
     !isMobile &&
     viewMode === "gallery" &&
     Boolean(galleryDetailNote && onGalleryBack);
+  const isGalleryOverview =
+    viewMode === "gallery" && !isGalleryDetailOpen;
 
   return (
     <div
       className={cn(
         "flex h-full flex-col",
         isMobile
-          ? "w-full max-w-full bg-background"
+          ? cn(
+              "w-full max-w-full",
+              isGalleryOverview
+                ? "bg-[#F2F2F7] dark:bg-black"
+                : "bg-background",
+            )
           : viewMode === "gallery"
             ? cn(
                 "min-w-0 flex-1",
-                isGalleryDetailOpen ? "bg-background" : "bg-muted",
+                isGalleryDetailOpen
+                  ? "bg-background"
+                  : "bg-[#F2F2F7] dark:bg-black",
               )
             : "w-[320px] border-r border-muted-foreground/20 bg-muted",
       )}

--- a/components/apps/notes/sidebar.tsx
+++ b/components/apps/notes/sidebar.tsx
@@ -615,11 +615,9 @@ export default function Sidebar({
           : viewMode === "gallery"
             ? cn(
                 "min-w-0 flex-1",
-                isGalleryDetailOpen
-                  ? "bg-background"
-                  : "bg-[#F2F2F7] dark:bg-black",
+                isGalleryDetailOpen ? "bg-background" : "bg-muted",
               )
-            : "w-[320px] border-r border-muted-foreground/20 bg-[#F2F2F7] dark:bg-black",
+            : "w-[320px] border-r border-muted-foreground/20 bg-muted",
       )}
     >
       <Nav

--- a/components/apps/notes/sidebar.tsx
+++ b/components/apps/notes/sidebar.tsx
@@ -606,20 +606,12 @@ export default function Sidebar({
     !isMobile &&
     viewMode === "gallery" &&
     Boolean(galleryDetailNote && onGalleryBack);
-  const isGalleryOverview =
-    viewMode === "gallery" && !isGalleryDetailOpen;
-
   return (
     <div
       className={cn(
         "flex h-full flex-col",
         isMobile
-          ? cn(
-              "w-full max-w-full",
-              isGalleryOverview
-                ? "bg-[#F2F2F7] dark:bg-black"
-                : "bg-background",
-            )
+          ? "w-full max-w-full bg-[#F2F2F7] dark:bg-black"
           : viewMode === "gallery"
             ? cn(
                 "min-w-0 flex-1",
@@ -627,7 +619,7 @@ export default function Sidebar({
                   ? "bg-background"
                   : "bg-[#F2F2F7] dark:bg-black",
               )
-            : "w-[320px] border-r border-muted-foreground/20 bg-muted",
+            : "w-[320px] border-r border-muted-foreground/20 bg-[#F2F2F7] dark:bg-black",
       )}
     >
       <Nav

--- a/lib/notes/markdown-preview.ts
+++ b/lib/notes/markdown-preview.ts
@@ -1,0 +1,34 @@
+export const NOTE_MARKDOWN_PREVIEW_MAX_CHARACTERS = 1_200;
+
+export function getBoundedMarkdownPreview(
+  content: string,
+  maxCharacters = NOTE_MARKDOWN_PREVIEW_MAX_CHARACTERS,
+): string {
+  const characterLimit = Math.max(0, Math.floor(maxCharacters));
+  if (content.length <= characterLimit) return content;
+  if (characterLimit === 0) return "";
+
+  let endIndex = characterLimit;
+  const lastIncludedCodeUnit = content.charCodeAt(endIndex - 1);
+  const firstExcludedCodeUnit = content.charCodeAt(endIndex);
+
+  // Avoid splitting an emoji or other supplementary Unicode character.
+  if (
+    lastIncludedCodeUnit >= 0xd800 &&
+    lastIncludedCodeUnit <= 0xdbff &&
+    firstExcludedCodeUnit >= 0xdc00 &&
+    firstExcludedCodeUnit <= 0xdfff
+  ) {
+    endIndex -= 1;
+  }
+
+  const boundedContent = content.slice(0, endIndex);
+  const lastLineBreak = boundedContent.lastIndexOf("\n");
+  const minimumUsefulBoundary = Math.floor(endIndex * 0.7);
+
+  if (lastLineBreak >= minimumUsefulBoundary) {
+    return boundedContent.slice(0, lastLineBreak).trimEnd();
+  }
+
+  return boundedContent.trimEnd();
+}

--- a/tests/markdown-preview.test.ts
+++ b/tests/markdown-preview.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NoteMarkdownPreview } from "../components/apps/notes/note-markdown-preview";
+import {
+  NOTE_MARKDOWN_PREVIEW_MAX_CHARACTERS,
+  getBoundedMarkdownPreview,
+} from "../lib/notes/markdown-preview";
+
+test("preserves Markdown that already fits in the preview limit", () => {
+  const content = "## Heading\n\n- one\n- two";
+
+  assert.equal(getBoundedMarkdownPreview(content), content);
+});
+
+test("bounds long Markdown at a nearby complete line", () => {
+  const content = `${"a".repeat(90)}\n${"b".repeat(40)}`;
+
+  assert.equal(getBoundedMarkdownPreview(content, 100), "a".repeat(90));
+});
+
+test("uses the hard limit when no useful line boundary exists", () => {
+  const content = "a".repeat(NOTE_MARKDOWN_PREVIEW_MAX_CHARACTERS + 100);
+
+  assert.equal(
+    getBoundedMarkdownPreview(content).length,
+    NOTE_MARKDOWN_PREVIEW_MAX_CHARACTERS,
+  );
+});
+
+test("does not split supplementary Unicode characters", () => {
+  assert.equal(getBoundedMarkdownPreview("abc😀def", 4), "abc");
+});
+
+test("supports an empty preview limit", () => {
+  assert.equal(getBoundedMarkdownPreview("content", 0), "");
+});
+
+test("defers Markdown parsing until a preview reaches the viewport", () => {
+  const markup = renderToStaticMarkup(
+    createElement(NoteMarkdownPreview, {
+      content: "# Deferred heading",
+      deferUntilVisible: true,
+      maxCharacters: NOTE_MARKDOWN_PREVIEW_MAX_CHARACTERS,
+    }),
+  );
+
+  assert.match(markup, /data-note-preview-pending/);
+  assert.doesNotMatch(markup, /Deferred heading/);
+});
+
+test("renders links and task controls as non-interactive preview content", () => {
+  const markup = renderToStaticMarkup(
+    createElement(NoteMarkdownPreview, {
+      content: "- [x] [Completed](https://example.com)",
+    }),
+  );
+
+  assert.doesNotMatch(markup, /<a(?:\s|>)/);
+  assert.doesNotMatch(markup, /<input(?:\s|>)/);
+  assert.match(markup, /note-markdown-preview-link/);
+  assert.match(markup, /note-markdown-preview-checkbox-checked/);
+});


### PR DESCRIPTION
## What changed

- Render Notes gallery cards with a compact, non-interactive GFM Markdown preview.
- Preserve headings, emphasis, lists, task items, links, quotes, code, tables, and images at card scale.
- Scale mobile thumbnail typography to match the native three-column Notes gallery.
- Give compact previews their own mobile typography: visible custom list markers, readable 7px leading, and a subtle rhythm between body blocks.
- Add a 2px title-to-body gap and approximately 2.2–2.5px between top-level paragraphs, headings, and lists.
- Remove the mobile card’s bottom padding so preview content can use the full thumbnail height instead of being clipped early.
- Use the same grouped overview surfaces in list and gallery: `#F2F2F7` in light mode and true black in dark mode, including the sticky navigation headers.
- Keep the shared search field styling consistent in both modes: white in light mode and `#353533` in dark mode.
- Render the shared “Pinned” section heading as plain text across mobile gallery, desktop gallery, and desktop list views.
- Keep the mobile search field at the same position and size when switching between list and gallery, without changing the gallery grid inset.
- Use the same formatted preview in the expanded mobile note-actions card.
- Keep links and task controls non-interactive inside the card so the card remains the single valid click target.

## Why

Gallery previews previously passed note content through `getNotePreviewText()`, which stripped Markdown markers and collapsed every newline. Notes with meaningful structure therefore appeared as dense plaintext instead of reflecting their actual formatting.

The initial formatted-preview implementation also rendered mobile thumbnail text too large for the native three-column layout. The first density adjustment made list markers too small, packed lines too tightly, and still reserved space at the bottom of the card. Compact previews now use explicit markers, readable leading, and small but visible paragraph spacing while allowing the document to reach the bottom edge.

The native Notes “Pinned” section uses a text-only heading. Our shared label added a pin icon to every layout, so removing it at the source corrects both mobile and desktop without affecting individual note pin controls.

The mobile gallery’s wider content inset was also being applied to the shared search wrapper, causing the search field to jump inward when changing view modes. The search field now compensates for that gallery-only content inset. List and gallery overview surfaces now share the same theme colors, while opened note documents retain their separate reading background.

## Impact

Gallery previews now reflect the underlying note structure, preserve visible bullets, and retain more of each note at a readable thumbnail scale. Titles and body sections are visually distinct without reintroducing excessive whitespace. List and gallery backgrounds, search styling, section headings, and search placement now remain consistent across light and dark modes.

## Verification

- `npm run check`
  - lint: 0 errors (7 pre-existing warnings)
  - tests: 30 passed
  - typecheck: passed
  - production build: passed (39 pages generated)
- Browser visual QA at an actual 393 × 852 mobile viewport
- Confirmed mobile search geometry is identical in list and gallery: `x: 16`, `y: 56`, `width: 361`, `height: 30`
- Confirmed search fills remain white in light mode and `rgb(53, 53, 51)` in dark mode across both views
- Confirmed list and gallery surfaces and sticky headers resolve to `rgb(242, 242, 247)` in light mode and `rgb(0, 0, 0)` in dark mode
- Confirmed matching list backgrounds on mobile and desktop while desktop note documents retain their reading surface
- Confirmed a computed 2px title-to-body gap and 2.2–2.5px top-level block spacing
- Confirmed compact cards render explicit bullet markers at the computed mobile size
- Confirmed mobile cards have zero bottom padding and 7px preview line-height
- Confirmed “Pinned” contains no icon in mobile gallery, desktop gallery, and desktop list views
- Confirmed no nested interactive descendants and no browser console errors