### PR TITLE
Center Photos headers without dates

### DIFF
--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -133,7 +133,9 @@ export function PhotosGrid({
           )}
           <div>
             <h1 className="text-lg font-semibold">{getViewTitle()}</h1>
-            <p className="min-h-4 text-xs text-muted-foreground">{dateRange}</p>
+            {dateRange && (
+              <p className="text-xs text-muted-foreground">{dateRange}</p>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- Render the Photos header date row only when a date range exists.
- Keep the back arrow aligned with the actual title/date content.

## Why

The header always reserved space for a date row, even when the date range was empty. In Favorites, that invisible row shifted the visible title above the vertically centered back arrow.

## Impact

Favorites and other no-date album headers now center their title with the back arrow. Headers with dates continue to center the title and date together as a group.

## Validation

- `npm run check`
- 37 tests passed
- TypeScript check passed
- Production build passed