### PR TITLE
Show Music play controls on touch

### DIFF
--- a/components/apps/music/content-views/home-view.tsx
+++ b/components/apps/music/content-views/home-view.tsx
@@ -13,6 +13,47 @@ interface HomeViewProps {
   isMobileView: boolean;
 }
 
+function ArtworkPlayButton({
+  isPlaying,
+  isMobileView,
+  label,
+  onClick,
+}: {
+  isPlaying: boolean;
+  isMobileView: boolean;
+  label: string;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`${isPlaying ? "Pause" : "Play"} ${label}`}
+      onClick={onClick}
+      className={cn(
+        "absolute inset-0 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-red-500",
+        isMobileView
+          ? "bg-transparent"
+          : "bg-black/0 can-hover:group-hover:bg-black/40 group-focus-within:bg-black/40"
+      )}
+    >
+      <span
+        className={cn(
+          "flex h-11 w-11 items-center justify-center rounded-full bg-black/65 text-white shadow-lg backdrop-blur-sm transition-[background-color,opacity]",
+          isMobileView
+            ? "opacity-100"
+            : "opacity-0 can-hover:group-hover:opacity-100 can-hover:hover:bg-black/75 group-focus-within:opacity-100"
+        )}
+      >
+        {isPlaying ? (
+          <Pause className="h-5 w-5" />
+        ) : (
+          <Play className="ml-0.5 h-5 w-5" />
+        )}
+      </span>
+    </button>
+  );
+}
+
 export function HomeView({
   playlists,
   songs,
@@ -31,7 +72,6 @@ export function HomeView({
     if (isPlayingThisPlaylist) {
       pause();
     } else {
-      onPlaylistSelect(playlist.id);
       const firstPlayable = playlist.tracks.find((t) => t.previewUrl);
       if (firstPlayable) {
         play(firstPlayable, playlist.tracks);
@@ -106,16 +146,12 @@ export function HomeView({
                     ) : (
                       <div className="w-full h-full bg-gradient-to-br from-zinc-700 to-zinc-800" />
                     )}
-                    <div
-                      className="absolute inset-0 bg-black/0 can-hover:group-hover:bg-black/40 transition-colors flex items-center justify-center"
+                    <ArtworkPlayButton
+                      isPlaying={!!isPlaying}
+                      isMobileView={isMobileView}
+                      label={playlist.name}
                       onClick={(e) => handlePlayPlaylist(playlist, e)}
-                    >
-                      {isPlaying ? (
-                        <Pause className="w-10 h-10 text-white opacity-0 can-hover:group-hover:opacity-100 transition-opacity" />
-                      ) : (
-                        <Play className="w-10 h-10 text-white opacity-0 can-hover:group-hover:opacity-100 transition-opacity" />
-                      )}
-                    </div>
+                    />
                   </div>
                   <p className="text-sm font-medium truncate">{playlist.name}</p>
                   <p className="text-xs text-muted-foreground">
@@ -154,13 +190,19 @@ export function HomeView({
                       unoptimized
                     />
                     {song.previewUrl && (
-                      <div className="absolute inset-0 bg-black/0 can-hover:group-hover:bg-black/40 transition-colors flex items-center justify-center">
-                        {isPlaying ? (
-                          <Pause className="w-10 h-10 text-white opacity-0 can-hover:group-hover:opacity-100 transition-opacity" />
-                        ) : (
-                          <Play className="w-10 h-10 text-white opacity-0 can-hover:group-hover:opacity-100 transition-opacity" />
-                        )}
-                      </div>
+                      <ArtworkPlayButton
+                        isPlaying={isPlaying}
+                        isMobileView={isMobileView}
+                        label={`${song.name} by ${song.artist}`}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          if (isPlaying) {
+                            pause();
+                          } else {
+                            play(song, songs);
+                          }
+                        }}
+                      />
                     )}
                   </div>
                   <p className="text-sm font-medium truncate">{song.name}</p>


### PR DESCRIPTION
## Today's delight

Music Home now uses real accessible Play/Pause buttons on playlist and song artwork. Pointer users keep the native hover reveal, while touch users get an always-visible 44×44 control. Activating a playlist control now plays in place instead of opening the playlist.

## Built result — desktop

![Desktop screenshot of Music play controls](https://github.com/user-attachments/assets/da7f3141-e548-4d0b-b061-87eebbde66c1)

At 1440×900, hovering song artwork revealed the control, activation changed Play to Pause, playback began, and the playback bar appeared.

## Built result — mobile

![Mobile screenshot of persistent Music play controls](https://github.com/user-attachments/assets/2544d829-5564-43d3-a3ec-633c7a272c8f)

At 390×844 in an iPhone 13 context with touch enabled and coarse-pointer/no-hover media queries, playlist and song controls remained visible, touch activation changed Play to Pause without leaving Home, and the MiniPlayer appeared.

## macOS inspiration

Apple’s current [Music User Guide for Mac](https://support.apple.com/en-gb/guide/music/mus36265ad9/mac) documents the native interaction directly: move the pointer over a song or album, then click Play. Desktop preserves that pointer reveal; mobile intentionally adapts the same action into a persistent touch target because hover is unavailable.

## Why this one

The controls were already functional, but their icons were forced to zero opacity on touch devices. This turns an invisible interaction into a clear one without adding data, dependencies, storage, keyboard behavior, or a new surface.

## Verification

- `npm run check`
- Desktop: 1440×900; hover reveal, Play → Pause, playback bar, focusable labels, zero console errors
- Mobile: iPhone 13 profile at 390×844; real touch events, `pointer: coarse`, `hover: none`, in-place playlist play, song Play → Pause, MiniPlayer, zero console errors
- 37 Node tests, typecheck, and production build passed; lint retained seven unrelated existing warnings and zero errors

## Scope

Micro: one existing Music file, 59 additions and 17 deletions. Open-PR audit found no overlap; recent work was concentrated in Photos, Notes, and iTerm.