### PR TITLE
Default mobile Photos to Library

### DIFF
--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -10,9 +10,11 @@ import { usePhotos } from "@/lib/photos/use-photos";
 import {
   loadPhotosRotations,
   loadPhotosSelectedId,
+  loadPhotosShowGrid,
   loadPhotosView,
   savePhotosRotations,
   savePhotosSelectedId,
+  savePhotosShowGrid,
   savePhotosView,
 } from "@/lib/sidebar-persistence";
 import type { PhotoRotations } from "@/lib/sidebar-persistence";
@@ -32,10 +34,10 @@ export default function App({ isDesktop = false }: AppProps) {
   const [isViewLoaded, setIsViewLoaded] = useState(false);
   const [timeFilter, setTimeFilter] = useState<TimeFilter>("all");
   const [isScrolled, setIsScrolled] = useState(false);
-  // Mobile opens directly into Photos content (Library by default). A persisted
-  // selected photo still restores the viewer instead of the sidebar.
+  // First-time mobile visitors open directly into Library. After that, preserve
+  // whether the current tab was showing the sidebar or Photos content.
   const [showGrid, setShowGrid] = useState(
-    () => !isDesktop || loadPhotosSelectedId() !== null,
+    () => loadPhotosSelectedId() !== null || loadPhotosShowGrid(),
   );
   const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(() => loadPhotosSelectedId());
   const [selectedInGridId, setSelectedInGridId] = useState<string | null>(null);
@@ -63,6 +65,12 @@ export default function App({ isDesktop = false }: AppProps) {
       savePhotosSelectedId(selectedPhotoId);
     }
   }, [selectedPhotoId, isViewLoaded]);
+
+  useEffect(() => {
+    if (isViewLoaded) {
+      savePhotosShowGrid(showGrid);
+    }
+  }, [showGrid, isViewLoaded]);
 
   useEffect(() => {
     if (isViewLoaded) {

--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -25,13 +25,12 @@ interface AppProps {
 export default function App({ isDesktop = false }: AppProps) {
   // Fetch photos from Supabase
   const { photos, collections, loading, error, toggleFavorite } = usePhotos();
+  const isMobileView = !isDesktop;
 
   // Load persisted view state (runs after hydration since page waits for isHydrated)
   const [activeView, setActiveView] = useState<PhotosView>(() => loadPhotosView() as PhotosView);
   const [isViewLoaded, setIsViewLoaded] = useState(false);
   const [timeFilter, setTimeFilter] = useState<TimeFilter>("all");
-  const [isMobileView, setIsMobileView] = useState(false);
-  const [isLayoutInitialized, setIsLayoutInitialized] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   // Mobile opens directly into Photos content (Library by default). A persisted
   // selected photo still restores the viewer instead of the sidebar.
@@ -45,12 +44,6 @@ export default function App({ isDesktop = false }: AppProps) {
   );
 
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // Mobile layout is determined by shell context, not viewport width
-  useEffect(() => {
-    setIsMobileView(!isDesktop);
-    setIsLayoutInitialized(true);
-  }, [isDesktop]);
 
   // Mark view as loaded after first render
   useEffect(() => {
@@ -149,10 +142,6 @@ export default function App({ isDesktop = false }: AppProps) {
       setSelectedPhotoId(filteredPhotos[selectedPhotoIndex + 1].id);
     }
   }, [selectedPhotoIndex, filteredPhotos]);
-
-  if (!isLayoutInitialized) {
-    return <div className="h-full bg-background" />;
-  }
 
   // Mobile: show either sidebar or grid
   // Desktop: show both side by side

--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -130,6 +130,8 @@ export default function App({ isDesktop = false }: AppProps) {
         .filter((collection) => selectedPhoto.collections.includes(collection.id))
         .map((collection) => collection.name)
     : [];
+  const isRestoringSelectedPhoto =
+    selectedPhotoId !== null && loading && !selectedPhoto;
 
   const handlePreviousPhoto = useCallback(() => {
     if (selectedPhotoIndex > 0) {
@@ -185,7 +187,9 @@ export default function App({ isDesktop = false }: AppProps) {
           {/* Photos Grid - always mounted to preserve scroll */}
           <div
             className={`flex-1 min-h-0 overflow-hidden ${
-              showPhotosGrid && !selectedPhoto ? "block" : "hidden"
+              showPhotosGrid && !selectedPhoto && !isRestoringSelectedPhoto
+                ? "block"
+                : "hidden"
             }`}
           >
             <PhotosGrid
@@ -205,6 +209,14 @@ export default function App({ isDesktop = false }: AppProps) {
               onGridSelect={handleGridSelect}
             />
           </div>
+
+          {showPhotosGrid && isRestoringSelectedPhoto && (
+            <div
+              role="status"
+              aria-label="Loading selected photo"
+              className="flex-1 min-h-0 bg-background"
+            />
+          )}
 
           {/* Photo Viewer */}
           {selectedPhoto && showPhotosGrid && (

--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -33,8 +33,11 @@ export default function App({ isDesktop = false }: AppProps) {
   const [isMobileView, setIsMobileView] = useState(false);
   const [isLayoutInitialized, setIsLayoutInitialized] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
-  // If there's a selected photo, show the grid (needed for mobile to display viewer)
-  const [showGrid, setShowGrid] = useState(() => loadPhotosSelectedId() !== null);
+  // Mobile opens directly into Photos content (Library by default). A persisted
+  // selected photo still restores the viewer instead of the sidebar.
+  const [showGrid, setShowGrid] = useState(
+    () => !isDesktop || loadPhotosSelectedId() !== null,
+  );
   const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(() => loadPhotosSelectedId());
   const [selectedInGridId, setSelectedInGridId] = useState<string | null>(null);
   const [photoRotations, setPhotoRotations] = useState<PhotoRotations>(() =>

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -434,7 +434,7 @@ export function PhotoViewer({
       {/* Header - matches PhotosGrid header style */}
       <div
         className={cn(
-          "px-4 py-3 flex items-center justify-between border-b dark:border-foreground/20 select-none",
+          "relative px-4 py-3 flex items-center justify-between border-b dark:border-foreground/20 select-none",
           isMobileView ? "h-[69px] bg-background" : "bg-muted/50"
         )}
         onMouseDown={inShell && !isMobileView ? windowFocus.onDragStart : undefined}
@@ -456,8 +456,8 @@ export function PhotoViewer({
         </button>
 
         {/* Date and counter */}
-        <div className="text-center">
-          <p className="text-sm font-medium">{formattedDate}</p>
+        <div className="pointer-events-none absolute left-1/2 top-1/2 w-max max-w-[calc(100%-9rem)] -translate-x-1/2 -translate-y-1/2 text-center">
+          <p className="truncate text-sm font-medium">{formattedDate}</p>
           <p className="text-xs text-muted-foreground">
             {currentIndex + 1} of {totalPhotos}
           </p>

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -443,9 +443,16 @@ export function PhotoViewer({
         <button
           onClick={onBack}
           onMouseDown={(e) => e.stopPropagation()}
+          aria-label="Back to photo grid"
           className="flex items-center -ml-2"
         >
-          <ChevronLeft className="w-5 h-5 text-foreground" />
+          <ChevronLeft
+            className={cn(
+              isMobileView
+                ? "h-7 w-7 text-muted-foreground"
+                : "h-5 w-5 text-foreground",
+            )}
+          />
         </button>
 
         {/* Date and counter */}

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -435,7 +435,7 @@ export function PhotoViewer({
       <div
         className={cn(
           "px-4 py-3 flex items-center justify-between border-b dark:border-foreground/20 select-none",
-          isMobileView ? "bg-background" : "bg-muted/50"
+          isMobileView ? "h-[69px] bg-background" : "bg-muted/50"
         )}
         onMouseDown={inShell && !isMobileView ? windowFocus.onDragStart : undefined}
       >

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -126,9 +126,11 @@ export function PhotosGrid({
           {isMobileView && (
             <button
               onClick={onBack}
-              className="flex items-center text-[#0A84FF] hover:text-[#0A84FF]/80 -ml-2"
+              onMouseDown={(e) => e.stopPropagation()}
+              aria-label="Back to Photos albums"
+              className="-ml-2 flex items-center text-muted-foreground"
             >
-              <ChevronLeft className="w-6 h-6" />
+              <ChevronLeft className="h-7 w-7" />
             </button>
           )}
           <div>

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -135,7 +135,7 @@ export function PhotosGrid({
             <h1 className="text-lg font-semibold">{getViewTitle()}</h1>
             {isMobileView ? (
               <p className="min-h-4 text-xs text-muted-foreground">
-                {dateRange}
+                {photos.length} {photos.length === 1 ? "item" : "items"}
               </p>
             ) : (
               dateRange && (

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -118,7 +118,7 @@ export function PhotosGrid({
       <div
         className={cn(
           "px-4 py-3 flex items-center justify-between border-b dark:border-foreground/20 select-none",
-          isMobileView ? "bg-background" : "bg-muted/50"
+          isMobileView ? "h-[69px] bg-background" : "bg-muted/50"
         )}
         onMouseDown={inShell && !isMobileView ? windowFocus.onDragStart : undefined}
       >

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -136,7 +136,13 @@ export function PhotosGrid({
           <div>
             <h1 className="text-lg font-semibold">{getViewTitle()}</h1>
             {isMobileView ? (
-              <p className="min-h-4 text-xs text-muted-foreground">
+              <p
+                className={cn(
+                  "min-h-4 text-xs text-muted-foreground",
+                  (loading || error) && "invisible",
+                )}
+                aria-live="polite"
+              >
                 {photos.length} {photos.length === 1 ? "item" : "items"}
               </p>
             ) : (

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -133,8 +133,14 @@ export function PhotosGrid({
           )}
           <div>
             <h1 className="text-lg font-semibold">{getViewTitle()}</h1>
-            {dateRange && (
-              <p className="text-xs text-muted-foreground">{dateRange}</p>
+            {isMobileView ? (
+              <p className="min-h-4 text-xs text-muted-foreground">
+                {dateRange}
+              </p>
+            ) : (
+              dateRange && (
+                <p className="text-xs text-muted-foreground">{dateRange}</p>
+              )
             )}
           </div>
         </div>

--- a/lib/sidebar-persistence.ts
+++ b/lib/sidebar-persistence.ts
@@ -34,6 +34,7 @@ const STORAGE_KEYS = {
   FINDER_SIDEBAR: "finder-sidebar",
   FINDER_PATH: "finder-path",
   PHOTOS_VIEW: "photos-view",
+  PHOTOS_SHOW_GRID: "photos-show-grid",
   PHOTOS_SELECTED: "photos-selected-id",
   PHOTOS_ROTATIONS: "photos-rotations",
   SETTINGS_STATE: "settings-state",
@@ -187,6 +188,31 @@ export function savePhotosView(view: string): void {
   }
 }
 
+export function loadPhotosShowGrid(storage?: StorageArea): boolean {
+  const target = getPhotosSessionStorage(storage);
+  if (!target) return true;
+
+  try {
+    return target.getItem(STORAGE_KEYS.PHOTOS_SHOW_GRID) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function savePhotosShowGrid(
+  showGrid: boolean,
+  storage?: StorageArea,
+): void {
+  const target = getPhotosSessionStorage(storage);
+  if (!target) return;
+
+  try {
+    target.setItem(STORAGE_KEYS.PHOTOS_SHOW_GRID, String(showGrid));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
 export function loadPhotosSelectedId(): string | null {
   if (typeof window === "undefined") return null;
   try {
@@ -269,6 +295,7 @@ export function clearPhotosState(storage?: StorageArea): void {
 
   try {
     target.removeItem(STORAGE_KEYS.PHOTOS_VIEW);
+    target.removeItem(STORAGE_KEYS.PHOTOS_SHOW_GRID);
     target.removeItem(STORAGE_KEYS.PHOTOS_SELECTED);
     target.removeItem(STORAGE_KEYS.PHOTOS_ROTATIONS);
   } catch {

--- a/tests/photos-rotation.test.ts
+++ b/tests/photos-rotation.test.ts
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   clearPhotosState,
   loadPhotosRotations,
+  loadPhotosShowGrid,
   savePhotosRotations,
+  savePhotosShowGrid,
 } from "../lib/sidebar-persistence";
 
 class MemoryStorage {
@@ -58,11 +60,23 @@ test("ignores malformed photo rotation entries", () => {
   });
 });
 
+test("opens Photos content by default and restores the mobile menu on refresh", () => {
+  const tabStorage = new MemoryStorage();
+
+  assert.equal(loadPhotosShowGrid(tabStorage), true);
+
+  savePhotosShowGrid(false, tabStorage);
+
+  assert.equal(loadPhotosShowGrid(tabStorage), false);
+});
+
 test("clears photo rotations with the rest of Photos view state", () => {
   const tabStorage = new MemoryStorage();
   savePhotosRotations({ "photo-one": -90 }, tabStorage);
+  savePhotosShowGrid(false, tabStorage);
 
   clearPhotosState(tabStorage);
 
   assert.deepEqual(loadPhotosRotations(tabStorage), {});
+  assert.equal(loadPhotosShowGrid(tabStorage), true);
 });


### PR DESCRIPTION
## What changed

- Default a first-time mobile visit to `/photos` to the Library grid.
- Persist whether the current tab is showing the Photos menu or photo content, so refresh preserves the user’s current surface instead of forcing Library.
- Resolve mobile layout synchronously from the shell context so the correct header renders on first paint.
- Show the filtered mobile item count (`0 items`, `1 item`, etc.) beneath the view title only after photos finish loading, avoiding a false zero-count flash.
- Use the same larger 28px muted-gray Back chevron in both the mobile grid and photo viewer.
- Lock both mobile headers to the same 69px height so the Back chevron remains at identical screen coordinates when opening or closing a photo.
- Center the photo date and counter relative to the full viewer width rather than the uneven left and right controls.
- Keep the grid hidden while a persisted selected photo is restored, preventing a Library or Favorites flash during refresh.
- Preserve the existing desktop split view and Back navigation to the Photos menu and albums.

## Why

Mobile Photos previously initialized its navigation flag from only the persisted selected-photo ID. With no selected photo, it opened the menu even for a first-time visitor, despite Library already being the default collection. Simply defaulting that flag to the grid then made every refresh reopen Library, including when the user had intentionally returned to the menu.

The selected photo ID also restores before the asynchronous photo records arrive. During that gap, the app treated the missing record as a reason to render the grid, causing a brief Library or Favorites flash before the viewer appeared.

Persisting the mobile menu/content surface separately gives first-time visitors the intended Library default while preserving navigation on refresh. A neutral restoration state prevents the grid flash, and shared header geometry keeps the mobile controls stable and the viewer title truly screen-centered.

## Validation

- `npm run check`
  - ESLint (no errors; existing warnings only)
  - 38 Node tests
  - TypeScript typecheck
  - Next.js production build
- Deployed preview verification
  - Selected-photo refresh enters the neutral restoration state without exposing the Library grid.
  - Viewer date and counter measure at the exact horizontal center of the header.
  - No browser console warnings or errors.