### PR TITLE
Center Photos viewer header

### DIFF
--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -434,7 +434,7 @@ export function PhotoViewer({
       {/* Header - matches PhotosGrid header style */}
       <div
         className={cn(
-          "px-4 py-3 flex items-center justify-between border-b dark:border-foreground/20 select-none",
+          "relative px-4 py-3 flex items-center justify-between border-b dark:border-foreground/20 select-none",
           isMobileView ? "bg-background" : "bg-muted/50"
         )}
         onMouseDown={inShell && !isMobileView ? windowFocus.onDragStart : undefined}
@@ -449,8 +449,8 @@ export function PhotoViewer({
         </button>
 
         {/* Date and counter */}
-        <div className="text-center">
-          <p className="text-sm font-medium">{formattedDate}</p>
+        <div className="pointer-events-none absolute left-1/2 top-1/2 w-max max-w-[calc(100%-9rem)] -translate-x-1/2 -translate-y-1/2 text-center">
+          <p className="truncate text-sm font-medium">{formattedDate}</p>
           <p className="text-xs text-muted-foreground">
             {currentIndex + 1} of {totalPhotos}
           </p>


### PR DESCRIPTION
## What changed

- Anchor the Photos viewer date and item counter to the true horizontal center of the header.
- Keep the back button and photo actions independently aligned at the edges.
- Bound and truncate long timestamps on very narrow screens so they cannot collide with the controls.

## Why

The previous `justify-between` layout centered the date between the left and right control groups. Because the viewer has more controls on the right, the date and item counter appeared left of the actual screen center.

## Impact

The header metadata now stays visually centered on both desktop and mobile, regardless of the number of controls on either side. Existing back, favorite, info, and rotate interactions remain unchanged.

## Verification

- `npm run check`
- Desktop: verified in a 1280×720 desktop surface; measured header-center deviation: `0px`
- Mobile: verified at 390×844; measured screen-center deviation: `0px`
- Mobile favorite control toggled successfully and was restored