### PR TITLE
Show Weather sunrise and sunset

### DIFF
--- a/components/apps/weather/weather-app.tsx
+++ b/components/apps/weather/weather-app.tsx
@@ -11,6 +11,8 @@ import {
   Droplets,
   Search,
   Sun,
+  Sunrise,
+  Sunset,
   Wind,
   X,
 } from "lucide-react";
@@ -59,6 +61,8 @@ interface OpenMeteoResponse {
     temperature_2m_max: number[];
     temperature_2m_min: number[];
     precipitation_probability_max: number[];
+    sunrise?: string[];
+    sunset?: string[];
   };
   hourly: {
     time: string[];
@@ -106,6 +110,8 @@ interface CityWeather {
   feelsLike: number;
   humidity: number;
   windMph: number;
+  sunrise: string;
+  sunset: string;
   hourly: HourForecast[];
   daily: DailyForecast[];
   updatedAt: Date;
@@ -131,6 +137,8 @@ function restoreWeatherDataFromCache(cache: WeatherDataCache): Record<string, Ci
       feelsLike: weather.feelsLike,
       humidity: weather.humidity,
       windMph: weather.windMph,
+      sunrise: weather.sunrise ?? "",
+      sunset: weather.sunset ?? "",
       hourly: weather.hourly,
       daily: weather.daily,
       updatedAt,
@@ -155,6 +163,8 @@ function serializeWeatherDataForCache(weatherByCity: Record<string, CityWeather>
       feelsLike: weather.feelsLike,
       humidity: weather.humidity,
       windMph: weather.windMph,
+      sunrise: weather.sunrise,
+      sunset: weather.sunset,
       hourly: weather.hourly,
       daily: weather.daily,
       updatedAt: weather.updatedAt.toISOString(),
@@ -307,6 +317,18 @@ function formatCityClock(iso: string): string {
   return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
 }
 
+function formatLocalSolarTime(iso: string): string {
+  const time = iso.split("T")[1];
+  if (!time) return "--";
+  const [hoursString, minutesString] = time.split(":");
+  const hours = Number(hoursString);
+  const minutes = Number(minutesString);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return "--";
+  const displayHour = hours % 12 || 12;
+  const period = hours >= 12 ? "PM" : "AM";
+  return `${displayHour}:${String(minutes).padStart(2, "0")} ${period}`;
+}
+
 function formatUpdatedTime(value: Date): string {
   return value.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
 }
@@ -367,6 +389,8 @@ async function fetchCityWeather(city: CityConfig): Promise<CityWeather> {
       "temperature_2m_max",
       "temperature_2m_min",
       "precipitation_probability_max",
+      "sunrise",
+      "sunset",
     ],
     hourlyFields: ["temperature_2m", "weather_code", "precipitation_probability"],
     forecastDays: 10,
@@ -438,6 +462,8 @@ async function fetchCityWeather(city: CityConfig): Promise<CityWeather> {
     feelsLike: data.current.apparent_temperature,
     humidity: data.current.relative_humidity_2m,
     windMph: data.current.wind_speed_10m,
+    sunrise: data.daily.sunrise?.[0] ?? "",
+    sunset: data.daily.sunset?.[0] ?? "",
     hourly,
     daily,
     updatedAt: new Date(),
@@ -1323,6 +1349,24 @@ export function WeatherApp({ isMobile = false, inShell = false }: WeatherAppProp
                           {selectedWeather
                             ? `${Math.round(selectedWeather.daily[0]?.precipitationChance ?? 0)}%`
                             : "--"}
+                        </p>
+                      </div>
+                      <div className={cn("rounded-xl p-3", innerCardClass)}>
+                        <div className={cn("flex items-center gap-1.5", mutedTextClass)}>
+                          <Sunrise size={14} />
+                          <span className="text-xs">Sunrise</span>
+                        </div>
+                        <p className="mt-1 text-2xl font-semibold">
+                          {selectedWeather ? formatLocalSolarTime(selectedWeather.sunrise) : "--"}
+                        </p>
+                      </div>
+                      <div className={cn("rounded-xl p-3", innerCardClass)}>
+                        <div className={cn("flex items-center gap-1.5", mutedTextClass)}>
+                          <Sunset size={14} />
+                          <span className="text-xs">Sunset</span>
+                        </div>
+                        <p className="mt-1 text-2xl font-semibold">
+                          {selectedWeather ? formatLocalSolarTime(selectedWeather.sunset) : "--"}
                         </p>
                       </div>
                     </div>

--- a/lib/sidebar-persistence.ts
+++ b/lib/sidebar-persistence.ts
@@ -571,6 +571,8 @@ export interface WeatherCachedCity {
   feelsLike: number;
   humidity: number;
   windMph: number;
+  sunrise?: string;
+  sunset?: string;
   hourly: WeatherCachedHourForecast[];
   daily: WeatherCachedDailyForecast[];
   updatedAt: string;
@@ -643,6 +645,8 @@ function isValidWeatherCacheEntry(value: unknown): value is WeatherCachedCity {
     isFiniteNumber(candidate.feelsLike) &&
     isFiniteNumber(candidate.humidity) &&
     isFiniteNumber(candidate.windMph) &&
+    (candidate.sunrise === undefined || typeof candidate.sunrise === "string") &&
+    (candidate.sunset === undefined || typeof candidate.sunset === "string") &&
     typeof candidate.updatedAt === "string" &&
     Array.isArray(candidate.hourly) &&
     candidate.hourly.every(isValidWeatherHour) &&


### PR DESCRIPTION
## Today's delight

Weather now shows live sunrise and sunset times for the selected city in the existing Conditions grid. The values come from the same Open-Meteo response as the rest of the forecast and remain compatible with previously cached weather data.

## Baseline and delta

- Before: Weather showed current conditions, hourly and 10-day forecasts, plus Humidity, Wind, Feels Like, and Max Rain tiles; selecting a city updated those values.
- Now: the Conditions grid also shows that city’s local Sunrise and Sunset times.
- Preserved: city selection, scene-preview controls, hourly and 10-day forecasts, cache/retry behavior, selection persistence, and Weather’s desktop-only mobile availability policy all replayed unchanged.

## Built result — desktop

![Desktop screenshot of Weather sunrise and sunset tiles](https://github.com/user-attachments/assets/eaaf8e36-598c-46e6-88fb-1c74f424cf63)

The 1440×900 production capture shows San Francisco’s live solar times beside the existing condition tiles. Selecting Seattle changed both times, and returning to San Francisco survived reload.

## Built result — mobile

![Mobile screenshot of Finder Applications with Weather intentionally absent](https://github.com/user-attachments/assets/4e5d64ee-1de6-4e93-9d46-3be28b007e5c)

Weather remains intentionally desktop-only. The iPhone capture shows the preserved mobile Finder Applications list with Weather absent; direct mobile visits to `/weather` still redirect to Notes.

## macOS inspiration

Apple’s current [Weather User Guide for Mac](https://support.apple.com/guide/weather-mac/view-weather-conditions-apdw93f0ea3e/mac) lists sunrise and sunset among Weather’s additional details. Open-Meteo’s [Forecast API documentation](https://open-meteo.com/en/docs) defines localized daily `sunrise` and `sunset` ISO-8601 fields. This implementation maps those two live values into the app’s existing native-style Conditions tile pattern.

## Why this one

Recent visible work is concentrated in Photos, Notes, and iTerm, and there were no open pull requests. This adds a useful real-data detail to a quieter existing app without changing its interaction model or mobile availability.

## Verification

- `npm run check` (38 tests, typecheck, production build; seven pre-existing lint warnings, zero errors)
- Desktop: 1440×900 production build; selected San Francisco → Seattle → San Francisco, verified both solar times update, selection persistence, existing forecast/preview controls, and zero console errors
- Mobile: iPhone 13-class 390×844 CSS viewport with real touch, `maxTouchPoints = 1`, `pointer: coarse`, and `hover: none`; verified `/weather` redirects, Weather remains absent from Finder Applications, and zero runtime/console errors

## Scope

Micro: 48 additions across two existing files. No overlap with recent Photos/Notes/iTerm work or open pull requests.