### PR TITLE
Fix notification center scrolling

### DIFF
--- a/components/desktop/notification-center.tsx
+++ b/components/desktop/notification-center.tsx
@@ -533,9 +533,12 @@ export function NotificationCenter({
   return (
     <div
       ref={menuRef}
-      className="absolute top-7 right-0 w-80 rounded-lg bg-white/95 dark:bg-zinc-800/95 backdrop-blur-xl shadow-2xl border border-muted-foreground/20 p-2 z-[70] max-h-[calc(100vh-3rem)]"
+      className="absolute top-7 right-0 z-[70] max-h-[calc(100vh-3rem)] w-80 overflow-hidden rounded-lg border border-muted-foreground/20 bg-white/95 p-2 shadow-2xl backdrop-blur-xl dark:bg-zinc-800/95"
     >
-      <ScrollArea className="h-full">
+      <ScrollArea
+        className="max-h-[calc(100vh-4rem-2px)]"
+        viewportClassName="max-h-[inherit]"
+      >
         {/* Date Header */}
         <div className="px-1 pt-1 pb-2">
           <p className="text-xs font-semibold uppercase text-muted-foreground">


### PR DESCRIPTION
## Summary

- Constrain Notification Center's custom scroll root to the panel's available height
- Apply the same maximum to the Radix viewport so card overflow becomes scrollable
- Keep the panel at its natural height when all content already fits

## Root cause

The outer panel had a maximum height, but the inner ScrollArea used `h-full` without a definite parent height. Its viewport expanded to the full card stack, leaving no internal overflow; the panel then clipped the bottom of that oversized viewport.

## User impact

All Notification Center cards, including Weather, are reachable by scrolling at normal and shorter desktop heights. Taller desktops still get the compact natural-height panel.

The branch is rebased onto `main` after #273, so the shared zero bottom-margin default also lets the Notification Center scrollbar track extend through its full available height.

## Validation

- `npm run check`
- 46 tests passed
- TypeScript and production build passed
- Browser interaction verified at the default viewport, 900×600, and 1440×1000
