### PR TITLE
Default scrollbars to zero bottom margin

### DIFF
--- a/components/apps/messages/chat-header.tsx
+++ b/components/apps/messages/chat-header.tsx
@@ -222,7 +222,6 @@ function RecipientSearch({
             }}
             className="w-full rounded-md border border-input bg-background"
             isMobile={isMobileView}
-            bottomMargin="0"
           >
             <div>
               {displayPeople.map((person, index) => (

--- a/components/apps/messages/contact-drawer.tsx
+++ b/components/apps/messages/contact-drawer.tsx
@@ -96,7 +96,7 @@ export function ContactDrawer({
             </DrawerClose>
           </DrawerHeader>
 
-          <ScrollArea className="h-[calc(90vh-96px)]" bottomMargin="0" isMobile={true}>
+          <ScrollArea className="h-[calc(90vh-96px)]" isMobile={true}>
             <DrawerDescription className="sr-only">
               Contact information and details for {recipientNames}
             </DrawerDescription>

--- a/components/apps/messages/sidebar.tsx
+++ b/components/apps/messages/sidebar.tsx
@@ -319,7 +319,6 @@ export function Sidebar({
           }}
           isMobile={isMobileView}
           withVerticalMargins={false}
-          bottomMargin="0px"
         >
           <div className={`${isMobileView ? "w-full" : "w-[320px]"} px-2`}>
             <SearchBar value={searchTerm} onChange={onSearchChange} />

--- a/components/apps/music/content-views/albums-view.tsx
+++ b/components/apps/music/content-views/albums-view.tsx
@@ -11,7 +11,7 @@ interface AlbumsViewProps {
 
 export function AlbumsView({ albums, isMobileView }: AlbumsViewProps) {
   return (
-    <ScrollArea className="h-full" bottomMargin="0">
+    <ScrollArea className="h-full">
       <div className={cn("p-6", isMobileView && "p-4 pb-20")}>
         {!isMobileView && <h2 className="text-lg font-semibold mb-4">Albums</h2>}
         <div

--- a/components/apps/music/content-views/artists-view.tsx
+++ b/components/apps/music/content-views/artists-view.tsx
@@ -11,7 +11,7 @@ interface ArtistsViewProps {
 
 export function ArtistsView({ artists, isMobileView }: ArtistsViewProps) {
   return (
-    <ScrollArea className="h-full" bottomMargin="0">
+    <ScrollArea className="h-full">
       <div className={cn("p-6", isMobileView && "p-4 pb-20")}>
         <div>
           {!isMobileView && <h2 className="text-lg font-semibold mb-4">Artists</h2>}

--- a/components/apps/music/content-views/browse-view.tsx
+++ b/components/apps/music/content-views/browse-view.tsx
@@ -240,14 +240,14 @@ export function BrowseView({ isMobileView }: BrowseViewProps) {
 
   if (loading) {
     return (
-      <ScrollArea className="h-full" bottomMargin="0">
+      <ScrollArea className="h-full">
         <BrowseSkeleton isMobileView={isMobileView} />
       </ScrollArea>
     );
   }
 
   return (
-    <ScrollArea className="h-full" bottomMargin="0">
+    <ScrollArea className="h-full">
       <div className={cn("p-6", isMobileView && "p-4 pb-20")}>
         {/* Featured Carousel */}
         {topAlbums.length > 0 && (

--- a/components/apps/music/content-views/playlist-view.tsx
+++ b/components/apps/music/content-views/playlist-view.tsx
@@ -59,7 +59,7 @@ export function PlaylistView({ playlist, isMobileView }: PlaylistViewProps) {
   const totalDuration = playlist.tracks.reduce((sum, t) => sum + t.duration, 0);
 
   return (
-    <ScrollArea className="h-full" bottomMargin="0">
+    <ScrollArea className="h-full">
       <div className={cn("p-6", isMobileView && "p-4 pb-20")}>
         {/* Playlist Header */}
         <div

--- a/components/apps/music/content-views/songs-view.tsx
+++ b/components/apps/music/content-views/songs-view.tsx
@@ -27,7 +27,7 @@ export function SongsView({ songs, isMobileView }: SongsViewProps) {
   };
 
   return (
-    <ScrollArea className="h-full" bottomMargin="0">
+    <ScrollArea className="h-full">
       <div className={cn("p-6", isMobileView && "p-4 pb-20")}>
         <div>
           {/* Title only on desktop - mobile shows it in nav header */}

--- a/components/apps/music/sidebar.tsx
+++ b/components/apps/music/sidebar.tsx
@@ -35,7 +35,6 @@ export function Sidebar({
       <div className="flex-1 min-h-0 overflow-hidden">
         <ScrollArea
           className="h-full"
-          bottomMargin="0"
           onScrollCapture={(e) => {
             const target = e.target as HTMLElement;
             onScroll?.(target.scrollTop > 0);

--- a/components/apps/notes/presenters/notes-desktop-presenter.tsx
+++ b/components/apps/notes/presenters/notes-desktop-presenter.tsx
@@ -138,7 +138,6 @@ export function NotesDesktopPresenter({
             key={selectedNote?.id ?? "empty-note"}
             className="h-full"
             isMobile={false}
-            bottomMargin="0px"
           >
             {selectedNote ? (
               <div className="w-full min-h-full p-3">

--- a/components/apps/notes/sidebar-layout.tsx
+++ b/components/apps/notes/sidebar-layout.tsx
@@ -43,7 +43,7 @@ export default function SidebarLayout({ children, notes }: SidebarLayoutProps) {
         )}
         {(!isMobile || !showSidebar) && viewMode === "list" && (
           <div className="flex-grow h-dvh">
-            <ScrollArea className="h-full" isMobile={isMobile} bottomMargin="0px">
+            <ScrollArea className="h-full" isMobile={isMobile}>
               {children}
             </ScrollArea>
           </div>

--- a/components/apps/notes/sidebar.tsx
+++ b/components/apps/notes/sidebar.tsx
@@ -658,7 +658,6 @@ export default function Sidebar({
               }
             }}
             isMobile={isMobile}
-            bottomMargin="0px"
           >
             <div ref={scrollViewportRef} className="flex w-full flex-col">
               <SessionId setSessionId={setSessionId} />
@@ -716,7 +715,6 @@ export default function Sidebar({
               key={galleryDetailNote.id}
               className="h-full"
               isMobile={false}
-              bottomMargin="0px"
             >
               <div className="min-h-full w-full p-3">
                 <NoteDocument

--- a/components/apps/photos/sidebar.tsx
+++ b/components/apps/photos/sidebar.tsx
@@ -33,7 +33,6 @@ export function Sidebar({
       <div className="flex-1 min-h-0 overflow-hidden">
         <ScrollArea
           className="h-full"
-          bottomMargin="0"
           onScrollCapture={(e) => {
             const target = e.target as HTMLElement;
             onScroll?.(target.scrollTop > 0);

--- a/components/apps/settings/sidebar.tsx
+++ b/components/apps/settings/sidebar.tsx
@@ -116,7 +116,6 @@ export function Sidebar({
               }
             }}
             isMobile={isMobile}
-            bottomMargin="0px"
           >
             <div className="px-4 pt-2 pb-8 min-h-full">
               {/* Search bar */}
@@ -269,7 +268,6 @@ export function Sidebar({
             }
           }}
           isMobile={isMobile}
-          bottomMargin="0px"
         >
           <div className="flex flex-col w-full">
             <div className="w-[320px] px-2">

--- a/components/apps/weather/weather-app.tsx
+++ b/components/apps/weather/weather-app.tsx
@@ -1020,7 +1020,7 @@ export function WeatherApp({ isMobile = false, inShell = false }: WeatherAppProp
                   </div>
                 </div>
               </div>
-              <ScrollArea className="flex-1" bottomMargin="0" viewportClassName="px-1">
+              <ScrollArea className="flex-1" viewportClassName="px-1">
                 {trimmedSearchQuery ? (
                   <div className="px-2 pt-1 pb-3">
                     {searchLoading && (
@@ -1088,7 +1088,7 @@ export function WeatherApp({ isMobile = false, inShell = false }: WeatherAppProp
                 onMouseDown={windowFocus?.onDragStart}
               />
             )}
-            <ScrollArea className="h-full" bottomMargin="0">
+            <ScrollArea className="h-full">
               <div className="p-4 space-y-4">
                 {isMobileView && (
                   <div className="flex gap-4 overflow-x-auto pb-1">

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -6,11 +6,8 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 import { cn } from "@/lib/utils"
 
 /**
- * Custom ScrollArea component for the chat interface
- * Customized with:
- * - 64px padding on top and bottom of the scrollbar so its not hidden bethind chat header and message input
- * - Custom scrollbar styling to match the scrollbar design in globals.css
- * - 14px total width with 4px transparent border for a clean look
+ * Custom scroll area with the shared scrollbar styling from globals.css.
+ * Consumers with fixed overlays can opt into top or bottom scrollbar insets.
  */
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
@@ -71,7 +68,7 @@ const ScrollBar = React.forwardRef<
         "h-2.5 flex-col border-t border-t-transparent p-[1px]",
       className
     )}
-    style={bottomMargin ? { marginBottom: bottomMargin } : { marginBottom: '64px' }}
+    style={{ marginBottom: bottomMargin ?? "0px" }}
     {...props}
   >
     <ScrollAreaPrimitive.ScrollAreaThumb 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -266,9 +266,7 @@ Use the custom ScrollArea component with consistent styling:
 
 ```tsx
 <ScrollArea className="flex-1">
-  <div style={{ marginBottom: '64px' }}> {/* Space for fixed bottom elements */}
-    {content}
-  </div>
+  {content}
 </ScrollArea>
 ```
 
@@ -276,6 +274,11 @@ Scrollbar styling is handled globally:
 - Width: 10px (14px on hover)
 - Thumb: `bg-gray-500 dark:bg-gray-400`
 - Opacity animation on hover
+- Bottom margin: `0` by default
+
+Only pass `bottomMargin` when the scrollbar track must clear a fixed bottom
+overlay. The Messages conversation view does this with its dynamic composer
+height; ordinary app content should use the zero default.
 
 ## Responsive Patterns
 


### PR DESCRIPTION
## Summary

- Make the shared ScrollArea scrollbar track use no bottom margin by default
- Remove redundant explicit zero-margin props from Notes, Messages, Music, Photos, Settings, and Weather
- Keep the Messages conversation view as the sole explicit nonzero consumer, using its dynamic composer height
- Document the opt-in bottom-inset convention in the design system

## Root cause

The shared scrollbar carried a chat-specific 64px bottom margin as its global fallback. Notification Center inherited that shortened track accidentally, while nearly every other ScrollArea had to override the shared default with an explicit zero.

## User impact

Ordinary scrollbars now extend through their full available height. Views with fixed bottom overlays must opt into an inset explicitly, making the exceptional behavior visible at the call site.

This cleanup is intentionally separate from #272 so the shared component contract can be reviewed independently from the Notification Center overflow fix.

## Validation

- `npm run check`
- 38 tests passed
- TypeScript and production build passed
- Browser-tested Notes and Messages scrolling
- Verified the combined Notification Center fixes scroll to the bottom
- No browser console errors
