### PR TITLE
Add realistic menu bar clock options

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ a macos sierra 10.12 themed desktop with:
 **settings** - system preferences
 - wi-fi and bluetooth panels
 - appearance (light/dark/system theme)
+- menu bar clock seconds option
 - airdrop and focus mode toggles
 - about this mac
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ a macos sierra 10.12 themed desktop with:
 **settings** - system preferences
 - wi-fi and bluetooth panels
 - appearance (light/dark/system theme)
-- menu bar clock seconds option
+- menu bar appearance and clock format options
 - airdrop and focus mode toggles
 - about this mac
 

--- a/components/apps/settings/content.tsx
+++ b/components/apps/settings/content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Settings, Paintbrush, Bluetooth, Wifi, Moon } from "lucide-react";
+import { Settings, Paintbrush, Bluetooth, Wifi, Moon, PanelTop } from "lucide-react";
 import { SettingsCategory, SettingsPanel } from "./settings-app";
 import { GeneralPanel } from "./panels/general";
 import { AboutPanel } from "./panels/about";
@@ -10,6 +10,7 @@ import { BluetoothPanel } from "./panels/bluetooth";
 import { WifiPanel } from "./panels/wifi";
 import { StoragePanel } from "./panels/storage";
 import { FocusPanel } from "./panels/focus";
+import { MenuBarPanel } from "./panels/menu-bar";
 import { cn } from "@/lib/utils";
 
 interface ContentProps {
@@ -56,6 +57,12 @@ const categoryInfo: Record<
     title: "Focus",
     description: "Choose when notifications and interruptions are allowed.",
     iconBg: "bg-violet-500",
+  },
+  "menu-bar": {
+    icon: <PanelTop className="w-8 h-8" />,
+    title: "Menu Bar",
+    description: "Choose how the clock appears in the menu bar.",
+    iconBg: "bg-gray-500",
   },
 };
 
@@ -104,6 +111,14 @@ export function Content({
         )}
       >
         <FocusPanel isMobile={isMobile} />
+      </div>
+    );
+  }
+
+  if (selectedCategory === "menu-bar") {
+    return (
+      <div className="flex-1 overflow-y-auto bg-background">
+        <MenuBarPanel />
       </div>
     );
   }

--- a/components/apps/settings/panels/appearance.tsx
+++ b/components/apps/settings/panels/appearance.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import Image from "next/image";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
+import { SettingsSwitch } from "../settings-switch";
 import { Check } from "lucide-react";
 import { useSystemSettings } from "@/lib/system-settings-context";
 import { OS_VERSIONS, getThumbnailPath } from "@/lib/os-versions";
@@ -301,20 +302,14 @@ export function AppearancePanel({ isMobile = false, scrollToOSVersion, onScrollC
         <div className="rounded-xl bg-background">
           <div className="flex items-center justify-between p-4">
             <span className="text-base">Automatic</span>
-            <button
-              onClick={() => handleThemeChange(isAutomatic ? "light" : "system")}
-              className={cn(
-                "w-12 h-7 rounded-full transition-colors relative",
-                isAutomatic ? "bg-green-500" : "bg-gray-300"
-              )}
-            >
-              <div
-                className={cn(
-                  "absolute top-0.5 w-6 h-6 rounded-full bg-white shadow transition-transform",
-                  isAutomatic ? "translate-x-5" : "translate-x-0.5"
-                )}
-              />
-            </button>
+            <SettingsSwitch
+              aria-label="Automatic appearance"
+              checked={isAutomatic}
+              onCheckedChange={(checked) =>
+                handleThemeChange(checked ? "system" : "light")
+              }
+              isMobile
+            />
           </div>
         </div>
 

--- a/components/apps/settings/panels/bluetooth.tsx
+++ b/components/apps/settings/panels/bluetooth.tsx
@@ -3,6 +3,7 @@
 import { Bluetooth, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSystemSettings } from "@/lib/system-settings-context";
+import { SettingsSwitch } from "../settings-switch";
 
 // Device type for different icons
 type DeviceType = "keyboard" | "trackpad" | "airpods" | "airpods-max" | "headphones";
@@ -127,20 +128,12 @@ export function BluetoothPanel({ isMobile = false }: BluetoothPanelProps) {
           {/* Bluetooth toggle */}
           <div className="flex items-center justify-between pt-4 mt-4 border-t border-border/50">
             <span className="text-base">Bluetooth</span>
-            <button
-              onClick={() => setBluetoothEnabled(!bluetoothEnabled)}
-              className={cn(
-                "w-12 h-7 rounded-full transition-colors relative",
-                bluetoothEnabled ? "bg-green-500" : "bg-gray-300"
-              )}
-            >
-              <div
-                className={cn(
-                  "absolute top-0.5 w-6 h-6 rounded-full bg-white shadow transition-transform",
-                  bluetoothEnabled ? "translate-x-5" : "translate-x-0.5"
-                )}
-              />
-            </button>
+            <SettingsSwitch
+              aria-label="Bluetooth"
+              checked={bluetoothEnabled}
+              onCheckedChange={setBluetoothEnabled}
+              isMobile
+            />
           </div>
         </div>
 
@@ -194,20 +187,11 @@ export function BluetoothPanel({ isMobile = false }: BluetoothPanelProps) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between">
             <span className="text-xs font-medium">Bluetooth</span>
-            <button
-              onClick={() => setBluetoothEnabled(!bluetoothEnabled)}
-              className={cn(
-                "w-10 h-6 rounded-full transition-colors relative shrink-0",
-                bluetoothEnabled ? "bg-blue-500" : "bg-gray-300"
-              )}
-            >
-              <div
-                className={cn(
-                  "absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform",
-                  bluetoothEnabled ? "translate-x-4" : "translate-x-0.5"
-                )}
-              />
-            </button>
+            <SettingsSwitch
+              aria-label="Bluetooth"
+              checked={bluetoothEnabled}
+              onCheckedChange={setBluetoothEnabled}
+            />
           </div>
           <p className="text-xs text-muted-foreground mt-1">
             Connect to accessories you can use for activities such as streaming music, typing, and gaming.{" "}

--- a/components/apps/settings/panels/menu-bar.tsx
+++ b/components/apps/settings/panels/menu-bar.tsx
@@ -3,10 +3,8 @@
 import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Clock3, PanelTop } from "lucide-react";
-import { Switch } from "@/components/ui/switch";
 import { useSystemSettings } from "@/lib/system-settings-context";
-
-const blueSwitch = "data-[state=checked]:bg-[#0A7CFF]";
+import { SettingsSwitch } from "../settings-switch";
 
 function SwitchRow({
   label,
@@ -22,12 +20,11 @@ function SwitchRow({
   return (
     <div className="flex min-h-11 items-center justify-between gap-4 px-4 py-2.5">
       <span className={disabled ? "text-muted-foreground" : undefined}>{label}</span>
-      <Switch
+      <SettingsSwitch
         aria-label={label}
         checked={checked}
         disabled={disabled}
         onCheckedChange={onCheckedChange}
-        className={blueSwitch}
       />
     </div>
   );
@@ -174,11 +171,10 @@ export function MenuBarPanel() {
               </p>
             </div>
           </div>
-          <Switch
+          <SettingsSwitch
             aria-label="Show menu bar background"
             checked={menuBarBackground}
             onCheckedChange={setMenuBarBackground}
-            className={blueSwitch}
           />
         </div>
       </div>

--- a/components/apps/settings/panels/menu-bar.tsx
+++ b/components/apps/settings/panels/menu-bar.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { useSystemSettings } from "@/lib/system-settings-context";
+
+export function MenuBarPanel() {
+  const { clockShowSeconds, setClockShowSeconds } = useSystemSettings();
+
+  return (
+    <div className="mx-auto w-full max-w-2xl p-6">
+      <div className="mb-5 text-center">
+        <h1 className="text-base font-semibold">Menu Bar</h1>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Choose how the clock appears in the menu bar.
+        </p>
+      </div>
+
+      <section aria-labelledby="clock-options-heading">
+        <h2
+          id="clock-options-heading"
+          className="mb-2 px-1 text-xs font-medium text-muted-foreground"
+        >
+          Clock Options
+        </h2>
+        <div className="rounded-xl bg-muted/60">
+          <div className="flex items-center gap-4 px-4 py-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium">
+                Display the time with seconds
+              </p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Show the time as hours, minutes, and seconds.
+              </p>
+            </div>
+            <Switch
+              aria-label="Display the time with seconds"
+              checked={clockShowSeconds}
+              onCheckedChange={setClockShowSeconds}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/apps/settings/panels/menu-bar.tsx
+++ b/components/apps/settings/panels/menu-bar.tsx
@@ -1,45 +1,217 @@
 "use client";
 
+import { useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Clock3, PanelTop } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { useSystemSettings } from "@/lib/system-settings-context";
 
-export function MenuBarPanel() {
-  const { clockShowSeconds, setClockShowSeconds } = useSystemSettings();
+const blueSwitch = "data-[state=checked]:bg-[#0A7CFF]";
+
+function SwitchRow({
+  label,
+  checked,
+  onCheckedChange,
+  disabled = false,
+}: {
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex min-h-11 items-center justify-between gap-4 px-4 py-2.5">
+      <span className={disabled ? "text-muted-foreground" : undefined}>{label}</span>
+      <Switch
+        aria-label={label}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onCheckedChange}
+        className={blueSwitch}
+      />
+    </div>
+  );
+}
+
+function ClockOptionsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const {
+    clockShowDate,
+    setClockShowDate,
+    clockShowDayOfWeek,
+    setClockShowDayOfWeek,
+    clockStyle,
+    setClockStyle,
+    clockShowAmPm,
+    setClockShowAmPm,
+    clockFlashSeparators,
+    setClockFlashSeparators,
+    clockShowSeconds,
+    setClockShowSeconds,
+  } = useSystemSettings();
+  const isDigital = clockStyle === "digital";
 
   return (
-    <div className="mx-auto w-full max-w-2xl p-6">
-      <div className="mb-5 text-center">
-        <h1 className="text-base font-semibold">Menu Bar</h1>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Choose how the clock appears in the menu bar.
-        </p>
-      </div>
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[95] bg-black/30 backdrop-blur-[1px]" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[96] w-[min(560px,calc(100vw-32px))] max-h-[calc(100vh-48px)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-[28px] border border-black/10 bg-background shadow-2xl focus:outline-none">
+          <div className="px-7 pb-5 pt-6">
+            <Dialog.Title className="text-lg font-semibold">Clock Options</Dialog.Title>
+            <Dialog.Description className="sr-only">
+              Choose how the date and time appear in the menu bar.
+            </Dialog.Description>
 
-      <section aria-labelledby="clock-options-heading">
-        <h2
-          id="clock-options-heading"
-          className="mb-2 px-1 text-xs font-medium text-muted-foreground"
-        >
-          Clock Options
-        </h2>
-        <div className="rounded-xl bg-muted/60">
-          <div className="flex items-center gap-4 px-4 py-3">
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-medium">
-                Display the time with seconds
-              </p>
-              <p className="mt-0.5 text-xs text-muted-foreground">
-                Show the time as hours, minutes, and seconds.
+            <section className="mt-5" aria-labelledby="clock-date-heading">
+              <h2 id="clock-date-heading" className="mb-2 text-sm font-semibold">
+                Date
+              </h2>
+              <div className="divide-y divide-border/50 rounded-xl bg-muted/60 text-sm">
+                <SwitchRow
+                  label="Show date"
+                  checked={clockShowDate}
+                  onCheckedChange={setClockShowDate}
+                />
+                <SwitchRow
+                  label="Show the day of the week"
+                  checked={clockShowDayOfWeek}
+                  onCheckedChange={setClockShowDayOfWeek}
+                />
+              </div>
+            </section>
+
+            <section className="mt-6" aria-labelledby="clock-time-heading">
+              <h2 id="clock-time-heading" className="mb-2 text-sm font-semibold">
+                Time
+              </h2>
+              <div className="divide-y divide-border/50 rounded-xl bg-muted/60 text-sm">
+                <fieldset className="flex min-h-11 items-center justify-between gap-4 px-4 py-2.5">
+                  <legend className="sr-only">Clock style</legend>
+                  <span>Style</span>
+                  <div className="flex items-center gap-5">
+                    {(["digital", "analog"] as const).map((style) => (
+                      <label key={style} className="flex items-center gap-2 capitalize">
+                        <input
+                          type="radio"
+                          name="clock-style"
+                          value={style}
+                          checked={clockStyle === style}
+                          onChange={() => setClockStyle(style)}
+                          className="h-4 w-4 accent-[#0A7CFF]"
+                        />
+                        {style}
+                      </label>
+                    ))}
+                  </div>
+                </fieldset>
+                <SwitchRow
+                  label="Show AM/PM"
+                  checked={clockShowAmPm}
+                  onCheckedChange={setClockShowAmPm}
+                  disabled={!isDigital}
+                />
+                <SwitchRow
+                  label="Flash the time separators"
+                  checked={clockFlashSeparators}
+                  onCheckedChange={setClockFlashSeparators}
+                  disabled={!isDigital}
+                />
+                <SwitchRow
+                  label="Display the time with seconds"
+                  checked={clockShowSeconds}
+                  onCheckedChange={setClockShowSeconds}
+                  disabled={!isDigital}
+                />
+              </div>
+            </section>
+          </div>
+
+          <div className="flex justify-end border-t border-border/60 px-7 py-4">
+            <Dialog.Close asChild>
+              <button className="rounded-lg bg-[#0A7CFF] px-5 py-1.5 text-sm font-medium text-white can-hover:hover:bg-[#006EE6]">
+                Done
+              </button>
+            </Dialog.Close>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+export function MenuBarPanel() {
+  const [clockOptionsOpen, setClockOptionsOpen] = useState(false);
+  const {
+    menuBarBackground,
+    setMenuBarBackground,
+    clockStyle,
+    clockShowDate,
+    clockShowDayOfWeek,
+  } = useSystemSettings();
+  const clockSummary = [
+    clockStyle === "digital" ? "Digital" : "Analog",
+    clockShowDate ? "date" : null,
+    clockShowDayOfWeek ? "weekday" : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-7 p-6">
+      <div className="rounded-xl bg-muted/60 text-sm">
+        <div className="flex items-center justify-between gap-4 px-4 py-3">
+          <div className="flex items-center gap-3">
+            <PanelTop className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <p className="font-medium">Show menu bar background</p>
+              <p className="text-xs text-muted-foreground">
+                Increase contrast behind menu bar items.
               </p>
             </div>
-            <Switch
-              aria-label="Display the time with seconds"
-              checked={clockShowSeconds}
-              onCheckedChange={setClockShowSeconds}
-            />
+          </div>
+          <Switch
+            aria-label="Show menu bar background"
+            checked={menuBarBackground}
+            onCheckedChange={setMenuBarBackground}
+            className={blueSwitch}
+          />
+        </div>
+      </div>
+
+      <section aria-labelledby="menu-bar-controls-heading">
+        <h2 id="menu-bar-controls-heading" className="mb-3 text-sm font-semibold">
+          Menu Bar Controls
+        </h2>
+        <div className="mb-3 rounded-xl bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
+          System controls can be configured to appear in the menu bar.
+        </div>
+        <div className="rounded-xl bg-muted/60">
+          <div className="flex items-center justify-between gap-4 px-4 py-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-400 text-white shadow-sm">
+                <Clock3 className="h-5 w-5" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Clock</p>
+                <p className="truncate text-xs text-muted-foreground">{clockSummary}</p>
+              </div>
+            </div>
+            <button
+              onClick={() => setClockOptionsOpen(true)}
+              className="shrink-0 rounded-lg bg-muted px-3 py-1.5 text-sm can-hover:hover:bg-muted/80"
+            >
+              Clock Options&hellip;
+            </button>
           </div>
         </div>
       </section>
+
+      <ClockOptionsDialog open={clockOptionsOpen} onOpenChange={setClockOptionsOpen} />
     </div>
   );
 }

--- a/components/apps/settings/panels/wifi.tsx
+++ b/components/apps/settings/panels/wifi.tsx
@@ -3,6 +3,7 @@
 import { Wifi, Lock, MoreHorizontal, Check, Smartphone } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSystemSettings } from "@/lib/system-settings-context";
+import { SettingsSwitch } from "../settings-switch";
 
 // Wi-Fi signal strength icon component
 function WifiSignal({ className }: { className?: string }) {
@@ -43,20 +44,11 @@ export function WifiPanel({}: WifiPanelProps) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between">
             <span className="text-xs font-medium">Wi-Fi</span>
-            <button
-              onClick={() => setWifiEnabled(!wifiEnabled)}
-              className={cn(
-                "w-10 h-6 rounded-full transition-colors relative shrink-0",
-                wifiEnabled ? "bg-blue-500" : "bg-gray-300"
-              )}
-            >
-              <div
-                className={cn(
-                  "absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform",
-                  wifiEnabled ? "translate-x-4" : "translate-x-0.5"
-                )}
-              />
-            </button>
+            <SettingsSwitch
+              aria-label="Wi-Fi"
+              checked={wifiEnabled}
+              onCheckedChange={setWifiEnabled}
+            />
           </div>
           <p className="text-xs text-muted-foreground mt-1">
             Set up Wi-Fi to wirelessly connect your Mac to the internet. Turn on Wi-Fi, then choose a network to join.{" "}

--- a/components/apps/settings/settings-app.tsx
+++ b/components/apps/settings/settings-app.tsx
@@ -6,7 +6,7 @@ import { Sidebar } from "./sidebar";
 import { Content } from "./content";
 import { loadSettingsState, saveSettingsState } from "@/lib/sidebar-persistence";
 
-export type SettingsCategory = "general" | "appearance" | "wifi" | "bluetooth" | "focus";
+export type SettingsCategory = "general" | "appearance" | "wifi" | "bluetooth" | "focus" | "menu-bar";
 export type SettingsPanel = "about" | "personal-info" | "storage" | null;
 
 interface HistoryEntry {
@@ -134,6 +134,7 @@ export function SettingsApp({ isMobile = false, inShell = false, initialPanel, i
       if (selectedCategory === "wifi") return "Wi-Fi";
       if (selectedCategory === "bluetooth") return "Bluetooth";
       if (selectedCategory === "focus") return "Focus";
+      if (selectedCategory === "menu-bar") return "Menu Bar";
     }
     return undefined;
   };

--- a/components/apps/settings/settings-switch.tsx
+++ b/components/apps/settings/settings-switch.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+
+type SettingsSwitchProps = ComponentProps<typeof Switch> & {
+  isMobile?: boolean;
+};
+
+export function SettingsSwitch({
+  className,
+  isMobile = false,
+  ...props
+}: SettingsSwitchProps) {
+  return (
+    <Switch
+      className={cn(
+        isMobile
+          ? "h-7 w-12 data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-gray-300 [&>span]:h-6 [&>span]:w-6 [&>span]:bg-white data-[state=checked]:[&>span]:translate-x-5"
+          : "h-6 w-10 data-[state=checked]:bg-blue-500 data-[state=unchecked]:bg-gray-300 [&>span]:h-5 [&>span]:w-5 [&>span]:bg-white",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/apps/settings/sidebar.tsx
+++ b/components/apps/settings/sidebar.tsx
@@ -49,19 +49,19 @@ const categories: { id: SettingsCategory; name: string; icon: React.ReactNode; i
     keywords: ["light", "dark", "auto", "theme", "mode"],
   },
   {
-    id: "focus",
-    name: "Focus",
-    icon: <Moon className="w-5 h-5 fill-current text-white" />,
-    iconBg: "bg-gradient-to-b from-violet-400 to-indigo-600",
-    keywords: ["focus", "do not disturb", "sleep", "reduce interruptions", "notifications"],
-  },
-  {
     id: "menu-bar",
     name: "Menu Bar",
     icon: <PanelTop className="w-5 h-5 text-white" />,
     iconBg: "bg-gray-500",
     keywords: ["menu bar", "clock", "time", "date", "seconds"],
     desktopOnly: true,
+  },
+  {
+    id: "focus",
+    name: "Focus",
+    icon: <Moon className="w-5 h-5 fill-current text-white" />,
+    iconBg: "bg-gradient-to-b from-violet-400 to-indigo-600",
+    keywords: ["focus", "do not disturb", "sleep", "reduce interruptions", "notifications"],
   },
 ];
 

--- a/components/apps/settings/sidebar.tsx
+++ b/components/apps/settings/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { Settings, Paintbrush, Search, X, ChevronRight, Plane, Wifi, Bluetooth, Radio, Link2, Battery, Moon } from "lucide-react";
+import { Settings, Paintbrush, Search, X, ChevronRight, Plane, Wifi, Bluetooth, Radio, Link2, Battery, Moon, PanelTop } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettingsCategory, SettingsPanel } from "./settings-app";
 import { SidebarNav } from "./sidebar-nav";
@@ -54,6 +54,14 @@ const categories: { id: SettingsCategory; name: string; icon: React.ReactNode; i
     icon: <Moon className="w-5 h-5 fill-current text-white" />,
     iconBg: "bg-gradient-to-b from-violet-400 to-indigo-600",
     keywords: ["focus", "do not disturb", "sleep", "reduce interruptions", "notifications"],
+  },
+  {
+    id: "menu-bar",
+    name: "Menu Bar",
+    icon: <PanelTop className="w-5 h-5 text-white" />,
+    iconBg: "bg-gray-500",
+    keywords: ["menu bar", "clock", "time", "date", "seconds"],
+    desktopOnly: true,
   },
 ];
 

--- a/components/apps/settings/sidebar.tsx
+++ b/components/apps/settings/sidebar.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { Settings, Paintbrush, Search, X, ChevronRight, Plane, Wifi, Bluetooth, Radio, Link2, Battery, Moon, PanelTop } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { SettingsSwitch } from "./settings-switch";
 import { SettingsCategory, SettingsPanel } from "./settings-app";
 import { SidebarNav } from "./sidebar-nav";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -198,18 +199,12 @@ export function Sidebar({
                         </span>
                         <span className="flex-1 text-left text-base">{item.name}</span>
                         {item.type === "toggle" && (
-                          <button
-                            onClick={() => setAirplaneMode(!airplaneMode)}
-                            className={cn(
-                              "w-12 h-7 rounded-full relative transition-colors",
-                              airplaneMode ? "bg-green-500" : "bg-gray-300"
-                            )}
-                          >
-                            <div className={cn(
-                              "absolute top-0.5 w-6 h-6 rounded-full bg-white shadow transition-transform",
-                              airplaneMode ? "translate-x-5" : "translate-x-0.5"
-                            )} />
-                          </button>
+                          <SettingsSwitch
+                            aria-label="Airplane Mode"
+                            checked={airplaneMode}
+                            onCheckedChange={setAirplaneMode}
+                            isMobile
+                          />
                         )}
                         {item.type === "value" && (
                           <span className="text-muted-foreground text-base">{item.value}</span>

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -18,6 +18,10 @@ import { AboutDialog } from "./about-dialog";
 import { FocusMenu, FOCUS_STATUS_CONFIG } from "./focus-menu";
 import { useFileMenuActions } from "@/lib/file-menu-context";
 import { useSystemSettings } from "@/lib/system-settings-context";
+import {
+  getDelayUntilNextClockRefresh,
+  getMenuBarClockRefreshMs,
+} from "@/lib/menu-bar-clock";
 import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 import type { FinderViewMode } from "@/components/apps/finder/view-mode";
 
@@ -139,7 +143,11 @@ export function MenuBar({
         .join("")
         .trim();
 
-      if (clockFlashSeparators && Math.floor(now.getMilliseconds() / 500) % 2) {
+      if (
+        clockStyle === "digital" &&
+        clockFlashSeparators &&
+        Math.floor(now.getMilliseconds() / 500) % 2
+      ) {
         time = time.replaceAll(":", " ");
       }
 
@@ -150,17 +158,29 @@ export function MenuBar({
     };
 
     updateTime();
-    const interval = setInterval(
-      updateTime,
-      clockFlashSeparators ? 500 : clockShowSeconds ? 1000 : 30000
-    );
-    return () => clearInterval(interval);
+    const refreshMs = getMenuBarClockRefreshMs({
+      clockStyle,
+      flashSeparators: clockFlashSeparators,
+      showSeconds: clockShowSeconds,
+    });
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const scheduleNextUpdate = () => {
+      timeout = setTimeout(() => {
+        updateTime();
+        scheduleNextUpdate();
+      }, getDelayUntilNextClockRefresh(Date.now(), refreshMs));
+    };
+
+    scheduleNextUpdate();
+    return () => clearTimeout(timeout);
   }, [
     clockFlashSeparators,
     clockShowAmPm,
     clockShowDate,
     clockShowDayOfWeek,
     clockShowSeconds,
+    clockStyle,
   ]);
 
   // Helper to quit the focused app (quits all windows for multi-window apps)
@@ -199,10 +219,9 @@ export function MenuBar({
   return (
     <div
       className={cn(
-        "fixed top-0 left-0 right-0 h-7 backdrop-blur-md border-b border-white/10 flex items-center justify-between px-4 z-[70] select-none",
-        menuBarBackground
-          ? "bg-white/55 dark:bg-black/55"
-          : "bg-white/20 dark:bg-black/20"
+        "fixed top-0 left-0 right-0 h-7 flex items-center justify-between px-4 z-[70] select-none",
+        menuBarBackground &&
+          "border-b border-white/10 bg-white/55 backdrop-blur-md dark:bg-black/55"
       )}
     >
       <div className="flex items-center gap-4">

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -61,7 +61,7 @@ export function MenuBar({
   onFinderStatusBarVisibleChange,
 }: MenuBarProps) {
   const fileMenuActions = useFileMenuActions();
-  const { focusMode } = useSystemSettings();
+  const { focusMode, clockShowSeconds } = useSystemSettings();
   const { getFocusedAppId, closeApp, state, setMenuOpen } = useWindowManager();
   const [currentTime, setCurrentTime] = useState<string>("");
   const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
@@ -99,14 +99,15 @@ export function MenuBar({
       const time = now.toLocaleTimeString("en-US", {
         hour: "numeric",
         minute: "2-digit",
+        second: clockShowSeconds ? "2-digit" : undefined,
       });
       setCurrentTime(`${weekday} ${month} ${day} ${time}`);
     };
 
     updateTime();
-    const interval = setInterval(updateTime, 60000);
+    const interval = setInterval(updateTime, clockShowSeconds ? 1000 : 60000);
     return () => clearInterval(interval);
-  }, []);
+  }, [clockShowSeconds]);
 
   // Helper to quit the focused app (quits all windows for multi-window apps)
   // Storage is cleared automatically by closeApp → clearAppState

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -25,6 +25,21 @@ type OpenMenu = "apple" | "appMenu" | "fileMenu" | "finderViewMenu" | "battery" 
 
 const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
 
+function AnalogClock({ date }: { date: Date }) {
+  const minuteAngle = date.getMinutes() * 6;
+  const hourAngle = (date.getHours() % 12) * 30 + date.getMinutes() * 0.5;
+
+  return (
+    <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4">
+      <circle cx="10" cy="10" r="8" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M10 3.5v1M10 15.5v1M3.5 10h1M15.5 10h1" stroke="currentColor" strokeWidth="1" />
+      <path d="M10 10V6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" transform={`rotate(${hourAngle} 10 10)`} />
+      <path d="M10 10V4.5" stroke="currentColor" strokeWidth="1" strokeLinecap="round" transform={`rotate(${minuteAngle} 10 10)`} />
+      <circle cx="10" cy="10" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
 interface MenuBarProps {
   onOpenSettings?: () => void;
   onOpenWifiSettings?: () => void;
@@ -61,9 +76,20 @@ export function MenuBar({
   onFinderStatusBarVisibleChange,
 }: MenuBarProps) {
   const fileMenuActions = useFileMenuActions();
-  const { focusMode, clockShowSeconds } = useSystemSettings();
+  const {
+    focusMode,
+    menuBarBackground,
+    clockShowDate,
+    clockShowDayOfWeek,
+    clockStyle,
+    clockShowAmPm,
+    clockFlashSeparators,
+    clockShowSeconds,
+  } = useSystemSettings();
   const { getFocusedAppId, closeApp, state, setMenuOpen } = useWindowManager();
   const [currentTime, setCurrentTime] = useState<string>("");
+  const [currentDate, setCurrentDate] = useState<Date | null>(null);
+  const [datePrefix, setDatePrefix] = useState<string>("");
   const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
   const [aboutDialogOpen, setAboutDialogOpen] = useState(false);
   const [lowPowerMode, setLowPowerMode] = useState(false);
@@ -93,21 +119,49 @@ export function MenuBar({
   useEffect(() => {
     const updateTime = () => {
       const now = new Date();
-      const weekday = now.toLocaleDateString("en-US", { weekday: "short" });
-      const month = now.toLocaleDateString("en-US", { month: "short" });
-      const day = now.getDate();
-      const time = now.toLocaleTimeString("en-US", {
+      const dateParts = [
+        clockShowDayOfWeek
+          ? now.toLocaleDateString("en-US", { weekday: "short" })
+          : null,
+        clockShowDate
+          ? now.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+          : null,
+      ].filter(Boolean);
+      const timeParts = new Intl.DateTimeFormat("en-US", {
         hour: "numeric",
         minute: "2-digit",
         second: clockShowSeconds ? "2-digit" : undefined,
-      });
-      setCurrentTime(`${weekday} ${month} ${day} ${time}`);
+        hour12: true,
+      }).formatToParts(now);
+      let time = timeParts
+        .filter((part) => clockShowAmPm || part.type !== "dayPeriod")
+        .map((part) => part.value)
+        .join("")
+        .trim();
+
+      if (clockFlashSeparators && Math.floor(now.getMilliseconds() / 500) % 2) {
+        time = time.replaceAll(":", " ");
+      }
+
+      const prefix = dateParts.join(" ");
+      setCurrentDate(now);
+      setDatePrefix(prefix);
+      setCurrentTime(prefix ? `${prefix} ${time}` : time);
     };
 
     updateTime();
-    const interval = setInterval(updateTime, clockShowSeconds ? 1000 : 60000);
+    const interval = setInterval(
+      updateTime,
+      clockFlashSeparators ? 500 : clockShowSeconds ? 1000 : 30000
+    );
     return () => clearInterval(interval);
-  }, [clockShowSeconds]);
+  }, [
+    clockFlashSeparators,
+    clockShowAmPm,
+    clockShowDate,
+    clockShowDayOfWeek,
+    clockShowSeconds,
+  ]);
 
   // Helper to quit the focused app (quits all windows for multi-window apps)
   // Storage is cleared automatically by closeApp → clearAppState
@@ -143,7 +197,14 @@ export function MenuBar({
   const closeMenu = useCallback(() => setOpenMenu(null), []);
 
   return (
-    <div className="fixed top-0 left-0 right-0 h-7 bg-white/20 dark:bg-black/20 backdrop-blur-md border-b border-white/10 flex items-center justify-between px-4 z-[70] select-none">
+    <div
+      className={cn(
+        "fixed top-0 left-0 right-0 h-7 backdrop-blur-md border-b border-white/10 flex items-center justify-between px-4 z-[70] select-none",
+        menuBarBackground
+          ? "bg-white/55 dark:bg-black/55"
+          : "bg-white/20 dark:bg-black/20"
+      )}
+    >
       <div className="flex items-center gap-4">
         <button
           onClick={() => toggleMenu("apple")}
@@ -264,15 +325,24 @@ export function MenuBar({
         {/* Date/Time */}
         <button
           onClick={() => toggleMenu("notificationCenter")}
+          aria-label={currentDate ? currentDate.toLocaleString("en-US") : "Date and time"}
+          data-testid="menu-bar-clock"
           className={cn(
-            "text-sm px-2 py-0.5 rounded transition-colors ml-1",
+            "flex items-center gap-1.5 text-sm px-2 py-0.5 rounded transition-colors ml-1",
             openMenu === "notificationCenter"
               ? "bg-white/30 dark:bg-white/20"
               : "can-hover:hover:bg-white/10",
             "text-black dark:text-white"
           )}
         >
-          {currentTime}
+          {clockStyle === "analog" && currentDate ? (
+            <>
+              {datePrefix && <span>{datePrefix}</span>}
+              <AnalogClock date={currentDate} />
+            </>
+          ) : (
+            currentTime
+          )}
         </button>
       </div>
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -351,6 +351,15 @@ For app-level mobile views, keep base surfaces consistent with semantic tokens:
 
 ## Common Patterns
 
+### Settings Switches
+
+Use `SettingsSwitch` (`components/apps/settings/settings-switch.tsx`) for
+standalone toggles in System Settings instead of hand-building the track and
+thumb. The desktop variant is the shared 40×24 blue macOS control; pass
+`isMobile` for the existing 48×28 green touch presentation. Controls where the
+entire row is itself the switch, such as Focus modes, may keep the switch visual
+non-interactive inside the row to avoid nesting buttons.
+
 ### Desktop Notifications
 
 Top-right banners use `DesktopNotificationBanner` for incoming Messages notifications. Keep promotional or long-lived content in Notification Center instead of showing it as a desktop banner.

--- a/lib/menu-bar-clock.ts
+++ b/lib/menu-bar-clock.ts
@@ -1,0 +1,23 @@
+import type { ClockStyle } from "@/lib/system-settings-context";
+
+interface ClockRefreshOptions {
+  clockStyle: ClockStyle;
+  flashSeparators: boolean;
+  showSeconds: boolean;
+}
+
+export function getMenuBarClockRefreshMs({
+  clockStyle,
+  flashSeparators,
+  showSeconds,
+}: ClockRefreshOptions): number {
+  if (clockStyle === "analog") return 60_000;
+  if (flashSeparators) return 500;
+  if (showSeconds) return 1_000;
+  return 60_000;
+}
+
+export function getDelayUntilNextClockRefresh(nowMs: number, refreshMs: number): number {
+  const elapsedInPeriod = nowMs % refreshMs;
+  return elapsedInPeriod === 0 ? refreshMs : refreshMs - elapsedInPeriod;
+}

--- a/lib/sidebar-persistence.ts
+++ b/lib/sidebar-persistence.ts
@@ -309,7 +309,7 @@ export function clearPhotosState(storage?: StorageArea): void {
 
 // Note: SettingsCategory and SettingsPanel types are defined in settings-app.tsx.
 // These arrays must match those types.
-const SETTINGS_CATEGORIES = ["general", "appearance", "wifi", "bluetooth", "focus"] as const;
+const SETTINGS_CATEGORIES = ["general", "appearance", "wifi", "bluetooth", "focus", "menu-bar"] as const;
 const SETTINGS_PANELS = ["about", "personal-info", "storage"] as const;
 
 type SettingsCategory = (typeof SETTINGS_CATEGORIES)[number];

--- a/lib/system-settings-context.tsx
+++ b/lib/system-settings-context.tsx
@@ -22,6 +22,8 @@ interface SystemSettingsContextValue {
   setFocusMode: (mode: FocusMode) => void;
   focusEndsAt: number | null;
   scheduleFocusEnd: (timestamp: number) => void;
+  clockShowSeconds: boolean;
+  setClockShowSeconds: (show: boolean) => void;
   osVersionId: string;
   setOSVersionId: (id: string) => void;
   currentOS: OSVersion;
@@ -35,6 +37,7 @@ const BLUETOOTH_KEY = "settings-bluetooth-enabled";
 const AIRDROP_KEY = "system-airdrop";
 const FOCUS_KEY = "system-focus";
 const FOCUS_ENDS_AT_KEY = "desktop-focus-ends-at";
+const CLOCK_SHOW_SECONDS_KEY = "menu-bar-clock-show-seconds";
 const OS_VERSION_KEY = "system-os-version";
 
 // Helper to load settings from localStorage synchronously
@@ -47,6 +50,7 @@ function getInitialSettings() {
       airdropMode: "contacts" as AirdropMode,
       focusMode: "off" as FocusMode,
       focusEndsAt: null,
+      clockShowSeconds: false,
       osVersionId: DEFAULT_OS_VERSION_ID,
     };
   }
@@ -57,6 +61,7 @@ function getInitialSettings() {
   const storedAirdrop = localStorage.getItem(AIRDROP_KEY);
   const storedFocus = localStorage.getItem(FOCUS_KEY);
   const storedFocusEndsAt = localStorage.getItem(FOCUS_ENDS_AT_KEY);
+  const storedClockShowSeconds = localStorage.getItem(CLOCK_SHOW_SECONDS_KEY);
   const storedOSVersion = localStorage.getItem(OS_VERSION_KEY);
   const parsedFocusEndsAt = storedFocusEndsAt
     ? Number(storedFocusEndsAt)
@@ -72,6 +77,7 @@ function getInitialSettings() {
       parsedFocusEndsAt !== null && Number.isFinite(parsedFocusEndsAt)
         ? parsedFocusEndsAt
         : null,
+    clockShowSeconds: storedClockShowSeconds === "true",
     osVersionId: storedOSVersion || DEFAULT_OS_VERSION_ID,
   };
 }
@@ -93,6 +99,9 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
   const [focusMode, setFocusModeState] = useState<FocusMode>(initial.focusMode);
   const [focusEndsAt, setFocusEndsAtState] = useState<number | null>(
     initial.focusEndsAt
+  );
+  const [clockShowSeconds, setClockShowSecondsState] = useState(
+    initial.clockShowSeconds
   );
   const [osVersionId, setOSVersionIdState] = useState<string>(initial.osVersionId);
 
@@ -201,10 +210,17 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
     }
   }, []);
 
+  const setClockShowSeconds = useCallback((show: boolean) => {
+    setClockShowSecondsState(show);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(CLOCK_SHOW_SECONDS_KEY, String(show));
+    }
+  }, []);
+
   const currentOS = useMemo(() => getOSVersion(osVersionId), [osVersionId]);
 
   return (
-    <SystemSettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, wifiEnabled, setWifiEnabled, bluetoothEnabled, setBluetoothEnabled, airdropMode, setAirdropMode, focusMode, setFocusMode, focusEndsAt, scheduleFocusEnd, osVersionId, setOSVersionId, currentOS }}>
+    <SystemSettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, wifiEnabled, setWifiEnabled, bluetoothEnabled, setBluetoothEnabled, airdropMode, setAirdropMode, focusMode, setFocusMode, focusEndsAt, scheduleFocusEnd, clockShowSeconds, setClockShowSeconds, osVersionId, setOSVersionId, currentOS }}>
       {children}
       {/* Brightness overlay - dims everything below system overlays */}
       {brightness < 100 && (
@@ -241,6 +257,8 @@ const defaultSettings: SystemSettingsContextValue = {
   setFocusMode: () => {},
   focusEndsAt: null,
   scheduleFocusEnd: () => {},
+  clockShowSeconds: false,
+  setClockShowSeconds: () => {},
   osVersionId: DEFAULT_OS_VERSION_ID,
   setOSVersionId: () => {},
   currentOS: getOSVersion(DEFAULT_OS_VERSION_ID),

--- a/lib/system-settings-context.tsx
+++ b/lib/system-settings-context.tsx
@@ -6,6 +6,7 @@ import { OSVersion, getOSVersion, DEFAULT_OS_VERSION_ID } from "@/lib/os-version
 
 export type AirdropMode = "contacts" | "everyone";
 export type FocusMode = "off" | "doNotDisturb" | "sleep" | "reduceInterruptions";
+export type ClockStyle = "digital" | "analog";
 
 interface SystemSettingsContextValue {
   brightness: number;
@@ -22,6 +23,18 @@ interface SystemSettingsContextValue {
   setFocusMode: (mode: FocusMode) => void;
   focusEndsAt: number | null;
   scheduleFocusEnd: (timestamp: number) => void;
+  menuBarBackground: boolean;
+  setMenuBarBackground: (show: boolean) => void;
+  clockShowDate: boolean;
+  setClockShowDate: (show: boolean) => void;
+  clockShowDayOfWeek: boolean;
+  setClockShowDayOfWeek: (show: boolean) => void;
+  clockStyle: ClockStyle;
+  setClockStyle: (style: ClockStyle) => void;
+  clockShowAmPm: boolean;
+  setClockShowAmPm: (show: boolean) => void;
+  clockFlashSeparators: boolean;
+  setClockFlashSeparators: (flash: boolean) => void;
   clockShowSeconds: boolean;
   setClockShowSeconds: (show: boolean) => void;
   osVersionId: string;
@@ -37,6 +50,12 @@ const BLUETOOTH_KEY = "settings-bluetooth-enabled";
 const AIRDROP_KEY = "system-airdrop";
 const FOCUS_KEY = "system-focus";
 const FOCUS_ENDS_AT_KEY = "desktop-focus-ends-at";
+const MENU_BAR_BACKGROUND_KEY = "menu-bar-show-background";
+const CLOCK_SHOW_DATE_KEY = "menu-bar-clock-show-date";
+const CLOCK_SHOW_DAY_KEY = "menu-bar-clock-show-day";
+const CLOCK_STYLE_KEY = "menu-bar-clock-style";
+const CLOCK_SHOW_AM_PM_KEY = "menu-bar-clock-show-am-pm";
+const CLOCK_FLASH_SEPARATORS_KEY = "menu-bar-clock-flash-separators";
 const CLOCK_SHOW_SECONDS_KEY = "menu-bar-clock-show-seconds";
 const OS_VERSION_KEY = "system-os-version";
 
@@ -50,6 +69,12 @@ function getInitialSettings() {
       airdropMode: "contacts" as AirdropMode,
       focusMode: "off" as FocusMode,
       focusEndsAt: null,
+      menuBarBackground: false,
+      clockShowDate: true,
+      clockShowDayOfWeek: true,
+      clockStyle: "digital" as ClockStyle,
+      clockShowAmPm: true,
+      clockFlashSeparators: false,
       clockShowSeconds: false,
       osVersionId: DEFAULT_OS_VERSION_ID,
     };
@@ -61,6 +86,7 @@ function getInitialSettings() {
   const storedAirdrop = localStorage.getItem(AIRDROP_KEY);
   const storedFocus = localStorage.getItem(FOCUS_KEY);
   const storedFocusEndsAt = localStorage.getItem(FOCUS_ENDS_AT_KEY);
+  const storedClockStyle = localStorage.getItem(CLOCK_STYLE_KEY);
   const storedClockShowSeconds = localStorage.getItem(CLOCK_SHOW_SECONDS_KEY);
   const storedOSVersion = localStorage.getItem(OS_VERSION_KEY);
   const parsedFocusEndsAt = storedFocusEndsAt
@@ -77,6 +103,12 @@ function getInitialSettings() {
       parsedFocusEndsAt !== null && Number.isFinite(parsedFocusEndsAt)
         ? parsedFocusEndsAt
         : null,
+    menuBarBackground: localStorage.getItem(MENU_BAR_BACKGROUND_KEY) === "true",
+    clockShowDate: localStorage.getItem(CLOCK_SHOW_DATE_KEY) !== "false",
+    clockShowDayOfWeek: localStorage.getItem(CLOCK_SHOW_DAY_KEY) !== "false",
+    clockStyle: (storedClockStyle === "analog" ? "analog" : "digital") as ClockStyle,
+    clockShowAmPm: localStorage.getItem(CLOCK_SHOW_AM_PM_KEY) !== "false",
+    clockFlashSeparators: localStorage.getItem(CLOCK_FLASH_SEPARATORS_KEY) === "true",
     clockShowSeconds: storedClockShowSeconds === "true",
     osVersionId: storedOSVersion || DEFAULT_OS_VERSION_ID,
   };
@@ -99,6 +131,20 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
   const [focusMode, setFocusModeState] = useState<FocusMode>(initial.focusMode);
   const [focusEndsAt, setFocusEndsAtState] = useState<number | null>(
     initial.focusEndsAt
+  );
+  const [menuBarBackground, setMenuBarBackgroundState] = useState(
+    initial.menuBarBackground
+  );
+  const [clockShowDate, setClockShowDateState] = useState(initial.clockShowDate);
+  const [clockShowDayOfWeek, setClockShowDayOfWeekState] = useState(
+    initial.clockShowDayOfWeek
+  );
+  const [clockStyle, setClockStyleState] = useState<ClockStyle>(initial.clockStyle);
+  const [clockShowAmPm, setClockShowAmPmState] = useState(
+    initial.clockShowAmPm
+  );
+  const [clockFlashSeparators, setClockFlashSeparatorsState] = useState(
+    initial.clockFlashSeparators
   );
   const [clockShowSeconds, setClockShowSecondsState] = useState(
     initial.clockShowSeconds
@@ -217,10 +263,40 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
     }
   }, []);
 
+  const setMenuBarBackground = useCallback((show: boolean) => {
+    setMenuBarBackgroundState(show);
+    localStorage.setItem(MENU_BAR_BACKGROUND_KEY, String(show));
+  }, []);
+
+  const setClockShowDate = useCallback((show: boolean) => {
+    setClockShowDateState(show);
+    localStorage.setItem(CLOCK_SHOW_DATE_KEY, String(show));
+  }, []);
+
+  const setClockShowDayOfWeek = useCallback((show: boolean) => {
+    setClockShowDayOfWeekState(show);
+    localStorage.setItem(CLOCK_SHOW_DAY_KEY, String(show));
+  }, []);
+
+  const setClockStyle = useCallback((style: ClockStyle) => {
+    setClockStyleState(style);
+    localStorage.setItem(CLOCK_STYLE_KEY, style);
+  }, []);
+
+  const setClockShowAmPm = useCallback((show: boolean) => {
+    setClockShowAmPmState(show);
+    localStorage.setItem(CLOCK_SHOW_AM_PM_KEY, String(show));
+  }, []);
+
+  const setClockFlashSeparators = useCallback((flash: boolean) => {
+    setClockFlashSeparatorsState(flash);
+    localStorage.setItem(CLOCK_FLASH_SEPARATORS_KEY, String(flash));
+  }, []);
+
   const currentOS = useMemo(() => getOSVersion(osVersionId), [osVersionId]);
 
   return (
-    <SystemSettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, wifiEnabled, setWifiEnabled, bluetoothEnabled, setBluetoothEnabled, airdropMode, setAirdropMode, focusMode, setFocusMode, focusEndsAt, scheduleFocusEnd, clockShowSeconds, setClockShowSeconds, osVersionId, setOSVersionId, currentOS }}>
+    <SystemSettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, wifiEnabled, setWifiEnabled, bluetoothEnabled, setBluetoothEnabled, airdropMode, setAirdropMode, focusMode, setFocusMode, focusEndsAt, scheduleFocusEnd, menuBarBackground, setMenuBarBackground, clockShowDate, setClockShowDate, clockShowDayOfWeek, setClockShowDayOfWeek, clockStyle, setClockStyle, clockShowAmPm, setClockShowAmPm, clockFlashSeparators, setClockFlashSeparators, clockShowSeconds, setClockShowSeconds, osVersionId, setOSVersionId, currentOS }}>
       {children}
       {/* Brightness overlay - dims everything below system overlays */}
       {brightness < 100 && (
@@ -257,6 +333,18 @@ const defaultSettings: SystemSettingsContextValue = {
   setFocusMode: () => {},
   focusEndsAt: null,
   scheduleFocusEnd: () => {},
+  menuBarBackground: false,
+  setMenuBarBackground: () => {},
+  clockShowDate: true,
+  setClockShowDate: () => {},
+  clockShowDayOfWeek: true,
+  setClockShowDayOfWeek: () => {},
+  clockStyle: "digital",
+  setClockStyle: () => {},
+  clockShowAmPm: true,
+  setClockShowAmPm: () => {},
+  clockFlashSeparators: false,
+  setClockFlashSeparators: () => {},
   clockShowSeconds: false,
   setClockShowSeconds: () => {},
   osVersionId: DEFAULT_OS_VERSION_ID,

--- a/tests/menu-bar-clock.test.ts
+++ b/tests/menu-bar-clock.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getDelayUntilNextClockRefresh,
+  getMenuBarClockRefreshMs,
+} from "../lib/menu-bar-clock";
+
+test("digital clock refresh cadence follows its visible precision", () => {
+  assert.equal(
+    getMenuBarClockRefreshMs({
+      clockStyle: "digital",
+      flashSeparators: false,
+      showSeconds: false,
+    }),
+    60_000
+  );
+  assert.equal(
+    getMenuBarClockRefreshMs({
+      clockStyle: "digital",
+      flashSeparators: false,
+      showSeconds: true,
+    }),
+    1_000
+  );
+  assert.equal(
+    getMenuBarClockRefreshMs({
+      clockStyle: "digital",
+      flashSeparators: true,
+      showSeconds: true,
+    }),
+    500
+  );
+});
+
+test("analog clock ignores stored digital-only refresh preferences", () => {
+  assert.equal(
+    getMenuBarClockRefreshMs({
+      clockStyle: "analog",
+      flashSeparators: true,
+      showSeconds: true,
+    }),
+    60_000
+  );
+});
+
+test("clock refresh delay aligns updates to the next display boundary", () => {
+  const twentyNineSecondsPastMinute = Date.UTC(2026, 6, 31, 12, 0, 29, 250);
+
+  assert.equal(
+    getDelayUntilNextClockRefresh(twentyNineSecondsPastMinute, 60_000),
+    30_750
+  );
+  assert.equal(getDelayUntilNextClockRefresh(twentyNineSecondsPastMinute, 1_000), 750);
+  assert.equal(getDelayUntilNextClockRefresh(twentyNineSecondsPastMinute, 500), 250);
+  assert.equal(getDelayUntilNextClockRefresh(Date.UTC(2026, 6, 31, 12), 60_000), 60_000);
+});


### PR DESCRIPTION
## Today's delight

System Settings now mirrors the native Menu Bar hierarchy instead of presenting one isolated clock toggle: a focused Menu Bar page opens a macOS-style **Clock Options…** sheet, and every control shown has real behavior.

The menu bar can now show or hide its background, date, weekday, AM/PM, seconds, and flashing separators, or switch to a live analog clock. Existing defaults remain unchanged.

## Baseline and delta

- **Before:** the branch exposed only an inline “Display the time with seconds” switch.
- **Now:** a native-style main Menu Bar page, Clock Options sheet, independently functional date and weekday controls, digital/analog style, AM/PM, flashing separators, seconds, and menu bar background.
- **Matched order:** the implemented desktop categories follow their relative order in the owner-provided System Settings reference: Wi-Fi → Bluetooth → General → Appearance → Menu Bar → Focus.
- **Shared control:** Menu Bar now uses the same Settings-specific switch component as Wi-Fi, Bluetooth, mobile Appearance, and mobile Airplane Mode instead of a smaller generic variant.
- **Preserved:** existing preference compatibility, the clock’s Notification Center action, Settings navigation/search behavior, and the mobile Settings experience.

## Built result — desktop

![Clock Options using the shared desktop Settings switches](https://github.com/user-attachments/assets/5f329869-703d-471e-ab7b-fc2f1bc78be0)

1440×900 desktop verification. Clock Options and the main Menu Bar page use the same 40×24 blue switch as Wi-Fi and Bluetooth; the white thumb remains correct in dark mode.

## Built result — mobile

![Mobile Appearance using the shared touch Settings switch](https://github.com/user-attachments/assets/6d341850-0f22-4d73-9d80-85bbcea8257e)

iPhone 13 verification at 390×664 CSS pixels / 1170×1992 physical pixels with touch and coarse-pointer emulation. The shared component preserves the intentional 48×28 green touch presentation, and Menu Bar remains desktop-only.

## macOS inspiration

The implementation follows the owner-provided live System Settings references for both the Menu Bar page and Clock Options sheet. It preserves their hierarchy, labels, grouped rows, switches, radio controls, dimmed sheet backdrop, Done action, and the relative order of every implemented sidebar category.

Controls that cannot be represented honestly on the web—voice announcements and unrelated system menu-control inventory—are intentionally omitted instead of rendered as dead UI. Apple’s current guide similarly documents date, weekday, seconds, and analog/digital clock presentation: [Change Control Center settings on Mac](https://support.apple.com/guide/mac-help/change-control-center-settings-mchl50f94f8f/mac).

## Why this one

This is a direct fidelity follow-up to the first clock-seconds pass. The native references exposed a compact, coherent set of adjacent clock preferences that all map cleanly to real web behavior and make the Settings surface feel substantially more authentic.

## Verification

- `npm run check` with the repository’s configured environment
  - ESLint: 0 errors (7 pre-existing warnings)
  - Node tests: 46 passed
  - TypeScript: passed
  - Next.js production build: passed
- Desktop at 1440×900: Menu Bar, Clock Options, and Wi-Fi switches all measured 40×24; date and Wi-Fi toggles changed and restored their state; the switch thumb remained white in dark mode
- iPhone 13 touch/coarse-pointer verification: Automatic measured 48×28, changed and restored through a real touch tap, and the desktop-only Menu Bar category stayed absent
- Zero browser console or page errors on both surfaces

## Scope

Larger follow-up: 13 files, 502 additions, 85 deletions relative to `main`. The change remains one coherent feature, adds no dependencies or assets, includes no secrets or production data, and does not overlap the other open work reviewed for this run.
