### PR TITLE
Complete Calendar event workflows

### DIFF
--- a/components/apps/calendar/all-day-row.tsx
+++ b/components/apps/calendar/all-day-row.tsx
@@ -13,6 +13,7 @@ interface AllDayRowProps {
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
   onEditEvent?: (eventId: string) => void;
+  onViewEvent?: (event: CalendarEvent) => void;
   editOnClick?: boolean;
 }
 
@@ -24,6 +25,7 @@ export function AllDayRow({
   selectedEventId,
   onSelectEvent,
   onEditEvent,
+  onViewEvent,
   editOnClick = false,
 }: AllDayRowProps) {
   // Get calendar color by id
@@ -95,6 +97,8 @@ export function AllDayRow({
                       } else {
                         onSelectEvent?.(isSelected ? null : event.id);
                       }
+                    } else {
+                      onViewEvent?.(event);
                     }
                   }}
                   onDoubleClick={(e) => {

--- a/components/apps/calendar/all-day-row.tsx
+++ b/components/apps/calendar/all-day-row.tsx
@@ -13,6 +13,7 @@ interface AllDayRowProps {
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
   onEditEvent?: (eventId: string) => void;
+  editOnClick?: boolean;
 }
 
 export function AllDayRow({
@@ -23,6 +24,7 @@ export function AllDayRow({
   selectedEventId,
   onSelectEvent,
   onEditEvent,
+  editOnClick = false,
 }: AllDayRowProps) {
   // Get calendar color by id
   const getCalendarColor = useCallback((calendarId: string): string => {
@@ -88,12 +90,16 @@ export function AllDayRow({
                   onClick={(e) => {
                     e.stopPropagation();
                     if (isUserEvent) {
-                      onSelectEvent?.(isSelected ? null : event.id);
+                      if (editOnClick) {
+                        onEditEvent?.(event.id);
+                      } else {
+                        onSelectEvent?.(isSelected ? null : event.id);
+                      }
                     }
                   }}
                   onDoubleClick={(e) => {
                     e.stopPropagation();
-                    if (isUserEvent) {
+                    if (isUserEvent && !editOnClick) {
                       onEditEvent?.(event.id);
                     }
                   }}

--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -9,7 +9,7 @@ import { MonthView } from "./month-view";
 import { YearView } from "./year-view";
 import { EventForm } from "./event-form";
 import { ViewType, CalendarEvent, Calendar } from "./types";
-import { navigateDate } from "./utils";
+import { getUpcomingEventDefaults, navigateDate } from "./utils";
 import { loadCalendars } from "./data";
 
 // Valid view types for type guard
@@ -228,19 +228,20 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
 
   // Event creation
   const handleNewEvent = useCallback(() => {
+    const defaults = getUpcomingEventDefaults(currentDate);
     setEventFormReadOnly(false);
-    setEventFormInitialDate(currentDate);
-    setEventFormInitialEndDate(currentDate);
-    setEventFormInitialStartTime("09:00");
-    setEventFormInitialEndTime("10:00");
+    setEventFormInitialDate(defaults.startDate);
+    setEventFormInitialEndDate(defaults.endDate);
+    setEventFormInitialStartTime(defaults.startTime);
+    setEventFormInitialEndTime(defaults.endTime);
     setEventFormOpen(true);
   }, [currentDate]);
 
   const handleCreateEvent = useCallback(
-    (date: Date, startTime: string, endTime: string) => {
+    (date: Date, startTime: string, endTime: string, endDate: Date = date) => {
       setEventFormReadOnly(false);
       setEventFormInitialDate(date);
-      setEventFormInitialEndDate(date);
+      setEventFormInitialEndDate(endDate);
       setEventFormInitialStartTime(startTime);
       setEventFormInitialEndTime(endTime);
       setEventFormOpen(true);

--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -452,6 +452,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
           if (!open) setEventToEdit(null);
         }}
         onSave={handleSaveEvent}
+        onDelete={handleDeleteEvent}
         calendars={calendars}
         initialDate={eventFormInitialDate}
         initialEndDate={eventFormInitialEndDate}

--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -456,6 +456,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
         initialEndTime={eventFormInitialEndTime}
         container={dialogContainer}
         eventToEdit={eventToEdit}
+        isMobile={isMobile}
       />
     </div>
   );

--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -445,6 +445,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
             calendars={calendars}
             onCreateEvent={handleCreateEvent}
             onDateClick={handleDateClick}
+            onEditEvent={handleEditEvent}
             onViewEvent={handleViewEvent}
           />
         )}

--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -166,6 +166,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
 
   // Event form state
   const [eventFormOpen, setEventFormOpen] = useState(false);
+  const [eventFormReadOnly, setEventFormReadOnly] = useState(false);
   const [eventFormInitialDate, setEventFormInitialDate] = useState<Date | undefined>();
   const [eventFormInitialEndDate, setEventFormInitialEndDate] = useState<Date | undefined>();
   const [eventFormInitialStartTime, setEventFormInitialStartTime] = useState<
@@ -227,6 +228,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
 
   // Event creation
   const handleNewEvent = useCallback(() => {
+    setEventFormReadOnly(false);
     setEventFormInitialDate(currentDate);
     setEventFormInitialEndDate(currentDate);
     setEventFormInitialStartTime("09:00");
@@ -236,6 +238,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
 
   const handleCreateEvent = useCallback(
     (date: Date, startTime: string, endTime: string) => {
+      setEventFormReadOnly(false);
       setEventFormInitialDate(date);
       setEventFormInitialEndDate(date);
       setEventFormInitialStartTime(startTime);
@@ -274,10 +277,17 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
     // Find the event in user events
     const event = events.find((e) => e.id === eventId);
     if (event) {
+      setEventFormReadOnly(false);
       setEventToEdit(event);
       setEventFormOpen(true);
     }
   }, [events]);
+
+  const handleViewEvent = useCallback((event: CalendarEvent) => {
+    setEventFormReadOnly(true);
+    setEventToEdit(event);
+    setEventFormOpen(true);
+  }, []);
 
   // Event deletion (only user events can be deleted)
   const handleDeleteEvent = useCallback((eventId: string) => {
@@ -407,6 +417,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
             selectedEventId={selectedEventId}
             onSelectEvent={handleSelectEvent}
             onEditEvent={handleEditEvent}
+            onViewEvent={handleViewEvent}
           />
         )}
         {view === "week" && (
@@ -420,6 +431,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
             selectedEventId={isMobile ? null : selectedEventId}
             onSelectEvent={isMobile ? undefined : handleSelectEvent}
             onEditEvent={handleEditEvent}
+            onViewEvent={handleViewEvent}
             isMobile={isMobile}
             onNavigate={handleNavigate}
             onToday={handleToday}
@@ -433,6 +445,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
             calendars={calendars}
             onCreateEvent={handleCreateEvent}
             onDateClick={handleDateClick}
+            onViewEvent={handleViewEvent}
           />
         )}
         {view === "year" && (
@@ -449,7 +462,10 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
         open={eventFormOpen}
         onOpenChange={(open) => {
           setEventFormOpen(open);
-          if (!open) setEventToEdit(null);
+          if (!open) {
+            setEventToEdit(null);
+            setEventFormReadOnly(false);
+          }
         }}
         onSave={handleSaveEvent}
         onDelete={handleDeleteEvent}
@@ -460,6 +476,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
         initialEndTime={eventFormInitialEndTime}
         container={dialogContainer}
         eventToEdit={eventToEdit}
+        readOnly={eventFormReadOnly}
         isMobile={isMobile}
       />
     </div>

--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -269,7 +269,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
     setSelectedEventId(eventId);
   }, []);
 
-  // Event editing (double-click on user event)
+  // Event editing (double-click on desktop, tap on mobile)
   const handleEditEvent = useCallback((eventId: string) => {
     // Find the event in user events
     const event = events.find((e) => e.id === eventId);
@@ -419,7 +419,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
             onScrollChange={handleTimeGridScroll}
             selectedEventId={isMobile ? null : selectedEventId}
             onSelectEvent={isMobile ? undefined : handleSelectEvent}
-            onEditEvent={isMobile ? undefined : handleEditEvent}
+            onEditEvent={handleEditEvent}
             isMobile={isMobile}
             onNavigate={handleNavigate}
             onToday={handleToday}

--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -382,15 +382,17 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
       className="calendar-app h-full flex flex-col bg-background text-foreground relative outline-none overflow-hidden"
     >
       {/* Navigation bar */}
-      <Nav
-        view={view}
-        onViewChange={handleViewChange}
-        onNavigate={handleNavigate}
-        onToday={handleToday}
-        onNewEvent={handleNewEvent}
-        inShell={inShell}
-        isMobile={isMobile}
-      />
+      {!isMobile && (
+        <Nav
+          view={view}
+          onViewChange={handleViewChange}
+          onNavigate={handleNavigate}
+          onToday={handleToday}
+          onNewEvent={handleNewEvent}
+          inShell={inShell}
+          isMobile={false}
+        />
+      )}
 
       {/* Calendar view */}
       <div className="flex-1 overflow-hidden">
@@ -421,6 +423,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
             isMobile={isMobile}
             onNavigate={handleNavigate}
             onToday={handleToday}
+            onNewEvent={handleNewEvent}
           />
         )}
         {view === "month" && (

--- a/components/apps/calendar/day-view.tsx
+++ b/components/apps/calendar/day-view.tsx
@@ -52,6 +52,7 @@ export function DayView({
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
         onViewEvent={onViewEvent}
+        editOnClick
       />
 
       {/* Time grid */}
@@ -67,6 +68,7 @@ export function DayView({
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
         onViewEvent={onViewEvent}
+        editOnClick
       />
     </div>
   );

--- a/components/apps/calendar/day-view.tsx
+++ b/components/apps/calendar/day-view.tsx
@@ -15,6 +15,7 @@ interface DayViewProps {
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
   onEditEvent?: (eventId: string) => void;
+  onViewEvent?: (event: CalendarEvent) => void;
 }
 
 export function DayView({
@@ -27,6 +28,7 @@ export function DayView({
   selectedEventId,
   onSelectEvent,
   onEditEvent,
+  onViewEvent,
 }: DayViewProps) {
   const dates = [currentDate];
 
@@ -49,6 +51,7 @@ export function DayView({
         selectedEventId={selectedEventId}
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
+        onViewEvent={onViewEvent}
       />
 
       {/* Time grid */}
@@ -63,6 +66,7 @@ export function DayView({
         selectedEventId={selectedEventId}
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
+        onViewEvent={onViewEvent}
       />
     </div>
   );

--- a/components/apps/calendar/event-form.tsx
+++ b/components/apps/calendar/event-form.tsx
@@ -19,6 +19,7 @@ interface EventFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSave: (event: CalendarEvent) => void;
+  onDelete?: (eventId: string) => void;
   calendars: Calendar[];
   initialDate?: Date;
   initialEndDate?: Date;
@@ -60,6 +61,7 @@ export function EventForm({
   open,
   onOpenChange,
   onSave,
+  onDelete,
   calendars,
   initialDate,
   initialEndDate,
@@ -157,6 +159,12 @@ export function EventForm({
     };
 
     onSave(event);
+    onOpenChange(false);
+  };
+
+  const handleDelete = () => {
+    if (!eventToEdit || !onDelete) return;
+    onDelete(eventToEdit.id);
     onOpenChange(false);
   };
 
@@ -421,22 +429,44 @@ export function EventForm({
           </div>
         </div>
 
+        {isMobile && isEditing && onDelete && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="mt-8 h-14 w-full rounded-[24px] bg-background text-lg text-[#FF3B30] shadow-[0_1px_1px_rgba(0,0,0,0.03)] active:bg-background/70"
+          >
+            Delete Event
+          </button>
+        )}
+
         {/* Action buttons */}
-        {!isMobile && <div className="flex justify-end gap-2 px-4 py-3 border-t border-border/50 bg-muted/30">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleSave}
-            className="bg-muted hover:bg-muted/80 text-foreground"
-          >
-            {isEditing ? "Save" : "Add"}
-          </Button>
+        {!isMobile && <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50 bg-muted/30">
+          {isEditing && onDelete ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleDelete}
+              className="text-[#FF3B30] can-hover:hover:bg-[#FF3B30]/10 can-hover:hover:text-[#FF3B30]"
+            >
+              Delete
+            </Button>
+          ) : <span />}
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              className="bg-muted hover:bg-muted/80 text-foreground"
+            >
+              {isEditing ? "Save" : "Add"}
+            </Button>
+          </div>
         </div>}
         </div>
       </DialogContent>

--- a/components/apps/calendar/event-form.tsx
+++ b/components/apps/calendar/event-form.tsx
@@ -48,6 +48,13 @@ const TIME_OPTIONS = generateTimeOptions();
 // End time options include 24:00 (midnight/end of day)
 const END_TIME_OPTIONS = [...TIME_OPTIONS, "24:00"];
 
+function dateTimeFor(date: string, time: string): Date {
+  if (time === "24:00") {
+    return addDays(parseISO(date), 1);
+  }
+  return parseISO(`${date}T${time}:00`);
+}
+
 // Format time for display (12-hour format)
 function formatTimeDisplay(time: string): string {
   const [hour, minute] = time.split(":").map(Number);
@@ -357,27 +364,18 @@ export function EventForm({
                   onChange={(e) => {
                     const newStartTime = e.target.value;
 
-                    // Calculate current duration in minutes
-                    const [oldStartH, oldStartM] = startTime.split(":").map(Number);
-                    const [oldEndH, oldEndM] = endTime.split(":").map(Number);
-                    const durationMinutes = (oldEndH * 60 + oldEndM) - (oldStartH * 60 + oldStartM);
-
-                    // Calculate new end time preserving duration
-                    const [newStartH, newStartM] = newStartTime.split(":").map(Number);
-                    const newEndMinutes = newStartH * 60 + newStartM + durationMinutes;
-                    let newEndH = Math.floor(newEndMinutes / 60);
-                    let newEndM = newEndMinutes % 60;
-
-                    // Clamp to end of day (24:00 max)
-                    if (newEndH > 24 || (newEndH === 24 && newEndM > 0)) {
-                      newEndH = 24;
-                      newEndM = 0;
-                    }
-
-                    const newEndTime = `${newEndH.toString().padStart(2, "0")}:${newEndM.toString().padStart(2, "0")}`;
+                    const oldStart = dateTimeFor(startDate, startTime);
+                    const oldEnd = dateTimeFor(endDate, endTime);
+                    const durationMs = Math.max(
+                      15 * 60 * 1000,
+                      oldEnd.getTime() - oldStart.getTime()
+                    );
+                    const newStart = dateTimeFor(startDate, newStartTime);
+                    const newEnd = new Date(newStart.getTime() + durationMs);
 
                     setStartTime(newStartTime);
-                    setEndTime(newEndTime);
+                    setEndDate(format(newEnd, "yyyy-MM-dd"));
+                    setEndTime(format(newEnd, "HH:mm"));
                   }}
                   className={cn(
                     "px-3 py-2 text-sm rounded-lg border border-border bg-muted/50",
@@ -433,7 +431,10 @@ export function EventForm({
                       "focus:outline-none focus:ring-2 focus:ring-ring"
                     )}
                   >
-                    {END_TIME_OPTIONS.filter((time) => time > startTime).map(
+                    {(endDate > startDate
+                      ? TIME_OPTIONS
+                      : END_TIME_OPTIONS.filter((time) => time > startTime)
+                    ).map(
                       (time) => (
                         <option key={time} value={time}>
                           {formatTimeDisplay(time)}

--- a/components/apps/calendar/event-form.tsx
+++ b/components/apps/calendar/event-form.tsx
@@ -27,6 +27,7 @@ interface EventFormProps {
   initialEndTime?: string;
   container?: HTMLElement | null;
   eventToEdit?: CalendarEvent | null;
+  readOnly?: boolean;
   isMobile?: boolean;
 }
 
@@ -69,6 +70,7 @@ export function EventForm({
   initialEndTime,
   container,
   eventToEdit,
+  readOnly = false,
   isMobile = false,
 }: EventFormProps) {
   const isEditing = !!eventToEdit;
@@ -140,6 +142,7 @@ export function EventForm({
   }, [open, initialDate, initialEndDate, initialStartTime, initialEndTime, calendars, eventToEdit]);
 
   const handleSave = () => {
+    if (readOnly) return;
     const eventTitle = title.trim() || "New Event";
 
     // For timed events ending at 24:00, keep the time as 24:00 for correct rendering
@@ -186,7 +189,9 @@ export function EventForm({
         aria-describedby={undefined}
         data-calendar-event-form={isMobile ? "mobile-sheet" : "desktop-dialog"}
       >
-        <DialogTitle className="sr-only">{isEditing ? "Edit Event" : "Create New Event"}</DialogTitle>
+        <DialogTitle className="sr-only">
+          {readOnly ? "Event Details" : isEditing ? "Edit Event" : "Create New Event"}
+        </DialogTitle>
 
         {isMobile && (
           <div className="relative flex h-[76px] shrink-0 items-center justify-between px-4 pt-2">
@@ -199,16 +204,20 @@ export function EventForm({
               <X className="h-6 w-6" strokeWidth={2} />
             </button>
             <span className="absolute inset-x-16 text-center text-lg font-semibold">
-              {isEditing ? "Edit Event" : "New"}
+              {readOnly ? "Event Details" : isEditing ? "Edit Event" : "New"}
             </span>
-            <button
-              type="button"
-              onClick={handleSave}
-              aria-label={isEditing ? "Save Event" : "Add Event"}
-              className="grid h-11 w-11 place-items-center rounded-full bg-[#FF3B30] text-white shadow-sm active:scale-95 active:bg-[#D92D27]"
-            >
-              <Check className="h-6 w-6" strokeWidth={2.5} />
-            </button>
+            {readOnly ? (
+              <div className="h-11 w-11" aria-hidden="true" />
+            ) : (
+              <button
+                type="button"
+                onClick={handleSave}
+                aria-label={isEditing ? "Save Event" : "Add Event"}
+                className="grid h-11 w-11 place-items-center rounded-full bg-[#FF3B30] text-white shadow-sm active:scale-95 active:bg-[#D92D27]"
+              >
+                <Check className="h-6 w-6" strokeWidth={2.5} />
+              </button>
+            )}
           </div>
         )}
 
@@ -231,6 +240,7 @@ export function EventForm({
                   type="text"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
+                  readOnly={readOnly}
                   placeholder={isMobile ? "Title" : "New Event"}
                   className={cn(
                     "flex-1 bg-transparent border-none outline-none",
@@ -244,6 +254,7 @@ export function EventForm({
                 <div className="relative" ref={calendarDropdownRef}>
                   <button
                     type="button"
+                    disabled={readOnly}
                     onClick={() => setShowCalendarDropdown(!showCalendarDropdown)}
                     className="flex items-center gap-1 rounded p-1 transition-colors can-hover:hover:bg-muted/50"
                   >
@@ -262,6 +273,7 @@ export function EventForm({
                         <button
                           key={calendar.id}
                           type="button"
+                          disabled={readOnly}
                           onClick={() => {
                             setCalendarId(calendar.id);
                             setShowCalendarDropdown(false);
@@ -292,6 +304,7 @@ export function EventForm({
                   type="text"
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
+                  readOnly={readOnly}
                   placeholder={isMobile ? "Location or Video Call" : "Add Location"}
                   className={cn(
                     "flex-1 bg-transparent border-none outline-none placeholder:text-muted-foreground",
@@ -313,6 +326,7 @@ export function EventForm({
             <Switch
               checked={isAllDay}
               onCheckedChange={setIsAllDay}
+              disabled={readOnly}
             />
           </div>
 
@@ -322,6 +336,7 @@ export function EventForm({
             <div className="flex min-w-0 gap-2">
               <input
                 type="date"
+                disabled={readOnly}
                 value={startDate}
                 onChange={(e) => {
                   setStartDate(e.target.value);
@@ -338,6 +353,7 @@ export function EventForm({
               {!isAllDay && (
                 <select
                   value={startTime}
+                  disabled={readOnly}
                   onChange={(e) => {
                     const newStartTime = e.target.value;
 
@@ -386,6 +402,7 @@ export function EventForm({
               {isAllDay ? (
                 <input
                   type="date"
+                  disabled={readOnly}
                   value={endDate}
                   onChange={(e) => setEndDate(e.target.value)}
                   min={startDate}
@@ -408,6 +425,7 @@ export function EventForm({
                   />
                   <select
                     value={endTime}
+                    disabled={readOnly}
                     onChange={(e) => setEndTime(e.target.value)}
                     className={cn(
                       "px-3 py-2 text-sm rounded-lg border border-border bg-muted/50",
@@ -429,7 +447,7 @@ export function EventForm({
           </div>
         </div>
 
-        {isMobile && isEditing && onDelete && (
+        {isMobile && isEditing && !readOnly && onDelete && (
           <button
             type="button"
             onClick={handleDelete}
@@ -441,7 +459,7 @@ export function EventForm({
 
         {/* Action buttons */}
         {!isMobile && <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50 bg-muted/30">
-          {isEditing && onDelete ? (
+          {isEditing && !readOnly && onDelete ? (
             <Button
               variant="ghost"
               size="sm"
@@ -451,21 +469,23 @@ export function EventForm({
               Delete
             </Button>
           ) : <span />}
-          <div className="flex gap-2">
+          <div className="ml-auto flex gap-2">
             <Button
               variant="outline"
               size="sm"
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              {readOnly ? "Close" : "Cancel"}
             </Button>
-            <Button
-              size="sm"
-              onClick={handleSave}
-              className="bg-muted hover:bg-muted/80 text-foreground"
-            >
-              {isEditing ? "Save" : "Add"}
-            </Button>
+            {!readOnly && (
+              <Button
+                size="sm"
+                onClick={handleSave}
+                className="bg-muted hover:bg-muted/80 text-foreground"
+              >
+                {isEditing ? "Save" : "Add"}
+              </Button>
+            )}
           </div>
         </div>}
         </div>

--- a/components/apps/calendar/event-form.tsx
+++ b/components/apps/calendar/event-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { MapPin, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, MapPin, X } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -26,6 +26,7 @@ interface EventFormProps {
   initialEndTime?: string;
   container?: HTMLElement | null;
   eventToEdit?: CalendarEvent | null;
+  isMobile?: boolean;
 }
 
 // Generate time options in 15-minute increments
@@ -66,6 +67,7 @@ export function EventForm({
   initialEndTime,
   container,
   eventToEdit,
+  isMobile = false,
 }: EventFormProps) {
   const isEditing = !!eventToEdit;
   const [title, setTitle] = useState("");
@@ -166,81 +168,140 @@ export function EventForm({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         container={container}
-        className="desktop:max-w-[320px] p-0 gap-0 overflow-hidden [&>button]:hidden"
+        overlayClassName={isMobile ? "bg-black/20 backdrop-blur-[1px]" : undefined}
+        className={cn(
+          "p-0 gap-0 overflow-hidden [&>button]:hidden",
+          isMobile
+            ? "!left-0 !top-2 bottom-0 flex !h-[calc(100%-0.5rem)] !max-h-none !w-full !max-w-none !translate-x-0 !translate-y-0 flex-col rounded-t-[32px] border-x-0 border-b-0 border-white/70 bg-[#F2F2F7] shadow-2xl dark:border-white/10 dark:bg-[#1C1C1E] data-[state=open]:slide-in-from-bottom-8 data-[state=closed]:slide-out-to-bottom-8"
+            : "desktop:max-w-[320px]"
+        )}
         aria-describedby={undefined}
+        data-calendar-event-form={isMobile ? "mobile-sheet" : "desktop-dialog"}
       >
         <DialogTitle className="sr-only">{isEditing ? "Edit Event" : "Create New Event"}</DialogTitle>
-        {/* Title input - inline style */}
-        <div className="px-4 pt-4 pb-2">
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="New Event"
-              className="flex-1 text-lg font-medium bg-transparent border-none outline-none placeholder:text-foreground"
-              autoFocus
-            />
-            {/* Calendar color dropdown */}
-            <div className="relative" ref={calendarDropdownRef}>
-              <button
-                type="button"
-                onClick={() => setShowCalendarDropdown(!showCalendarDropdown)}
-                className="flex items-center gap-1 p-1 rounded hover:bg-muted/50 transition-colors"
-              >
-                <div
-                  className="w-3 h-3 rounded-full shrink-0"
-                  style={{ backgroundColor: calendarColor }}
+
+        {isMobile && (
+          <div className="relative flex h-[76px] shrink-0 items-center justify-between px-4 pt-2">
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              aria-label="Cancel"
+              className="grid h-11 w-11 place-items-center rounded-full bg-background/90 shadow-sm active:scale-95 active:bg-background"
+            >
+              <X className="h-6 w-6" strokeWidth={2} />
+            </button>
+            <span className="absolute inset-x-16 text-center text-lg font-semibold">
+              {isEditing ? "Edit Event" : "New"}
+            </span>
+            <button
+              type="button"
+              onClick={handleSave}
+              aria-label={isEditing ? "Save Event" : "Add Event"}
+              className="grid h-11 w-11 place-items-center rounded-full bg-[#FF3B30] text-white shadow-sm active:scale-95 active:bg-[#D92D27]"
+            >
+              <Check className="h-6 w-6" strokeWidth={2.5} />
+            </button>
+          </div>
+        )}
+
+        <div
+          className={cn(
+            isMobile &&
+              "min-h-0 flex-1 overflow-y-auto px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]"
+          )}
+        >
+          <div
+            className={cn(
+              isMobile &&
+                "mt-2 rounded-[24px] bg-background shadow-[0_1px_1px_rgba(0,0,0,0.03)]"
+            )}
+          >
+            {/* Title input - inline style */}
+            <div className={cn("px-4 pt-4 pb-2", isMobile && "pt-3 pb-3")}>
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={isMobile ? "Title" : "New Event"}
+                  className={cn(
+                    "flex-1 bg-transparent border-none outline-none",
+                    isMobile
+                      ? "min-w-0 text-xl font-normal placeholder:text-muted-foreground/55"
+                      : "text-lg font-medium placeholder:text-foreground"
+                  )}
+                  autoFocus
                 />
-                <ChevronDown className="w-3 h-3 text-muted-foreground" />
-              </button>
-              {showCalendarDropdown && (
-                <div className="absolute right-0 top-full mt-1 bg-popover border border-border rounded-lg shadow-lg py-1 min-w-[140px] z-50">
-                  {[...calendars.filter(c => c.id !== "holidays"), ...calendars.filter(c => c.id === "holidays")].map((calendar) => (
-                    <button
-                      key={calendar.id}
-                      type="button"
-                      onClick={() => {
-                        setCalendarId(calendar.id);
-                        setShowCalendarDropdown(false);
-                      }}
-                      className={cn(
-                        "w-full flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors",
-                        calendarId === calendar.id && "bg-muted/30"
-                      )}
-                    >
-                      <div
-                        className="w-3 h-3 rounded-full shrink-0"
-                        style={{ backgroundColor: calendar.color }}
-                      />
-                      <span>{calendar.name}</span>
-                    </button>
-                  ))}
+                {/* Calendar color dropdown */}
+                <div className="relative" ref={calendarDropdownRef}>
+                  <button
+                    type="button"
+                    onClick={() => setShowCalendarDropdown(!showCalendarDropdown)}
+                    className="flex items-center gap-1 rounded p-1 transition-colors can-hover:hover:bg-muted/50"
+                  >
+                    <div
+                      className="w-3 h-3 rounded-full shrink-0"
+                      style={{ backgroundColor: calendarColor }}
+                    />
+                    <ChevronDown className="w-3 h-3 text-muted-foreground" />
+                  </button>
+                  {showCalendarDropdown && (
+                    <div className="absolute right-0 top-full mt-1 bg-popover border border-border rounded-lg shadow-lg py-1 min-w-[140px] z-50">
+                      {[
+                        ...calendars.filter((c) => c.id !== "holidays"),
+                        ...calendars.filter((c) => c.id === "holidays"),
+                      ].map((calendar) => (
+                        <button
+                          key={calendar.id}
+                          type="button"
+                          onClick={() => {
+                            setCalendarId(calendar.id);
+                            setShowCalendarDropdown(false);
+                          }}
+                          className={cn(
+                            "w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors can-hover:hover:bg-muted/50",
+                            calendarId === calendar.id && "bg-muted/30"
+                          )}
+                        >
+                          <div
+                            className="w-3 h-3 rounded-full shrink-0"
+                            style={{ backgroundColor: calendar.color }}
+                          />
+                          <span>{calendar.name}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
-              )}
+              </div>
+            </div>
+
+            {/* Location */}
+            <div className={cn("px-4 py-2 border-t border-border/50", isMobile && "py-3")}>
+              <div className="flex items-center gap-2">
+                {!isMobile && <MapPin className="w-4 h-4 text-muted-foreground shrink-0" />}
+                <input
+                  type="text"
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                  placeholder={isMobile ? "Location or Video Call" : "Add Location"}
+                  className={cn(
+                    "flex-1 bg-transparent border-none outline-none placeholder:text-muted-foreground",
+                    isMobile ? "text-lg" : "text-sm"
+                  )}
+                />
+              </div>
             </div>
           </div>
-        </div>
-
-        {/* Location */}
-        <div className="px-4 py-2 border-t border-border/50">
-          <div className="flex items-center gap-2">
-            <MapPin className="w-4 h-4 text-muted-foreground shrink-0" />
-            <input
-              type="text"
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
-              placeholder="Add Location"
-              className="flex-1 text-sm bg-transparent border-none outline-none placeholder:text-muted-foreground"
-            />
-          </div>
-        </div>
 
         {/* Date/Time section */}
-        <div className="px-4 py-3 border-t border-border/50 space-y-3">
+        <div className={cn(
+          "px-4 py-3 border-t border-border/50 space-y-3",
+          isMobile && "mt-5 space-y-0 rounded-[24px] border-0 bg-background py-0 shadow-[0_1px_1px_rgba(0,0,0,0.03)]"
+        )}>
           {/* All-day toggle */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm">All-day</span>
+          <div className={cn("flex items-center justify-between", isMobile && "min-h-14")}>
+            <span className={cn(isMobile ? "text-lg" : "text-sm")}>All-day</span>
             <Switch
               checked={isAllDay}
               onCheckedChange={setIsAllDay}
@@ -248,9 +309,9 @@ export function EventForm({
           </div>
 
           {/* Start */}
-          <div className="space-y-1">
-            <div className="text-xs text-muted-foreground">Starts</div>
-            <div className="flex gap-2">
+          <div className={cn("space-y-1", isMobile && "flex min-h-14 items-center justify-between gap-3 space-y-0 border-t border-border/50")}>
+            <div className={cn(isMobile ? "shrink-0 text-lg text-foreground" : "text-xs text-muted-foreground")}>Starts</div>
+            <div className="flex min-w-0 gap-2">
               <input
                 type="date"
                 value={startDate}
@@ -262,6 +323,7 @@ export function EventForm({
                 }}
                 className={cn(
                   "flex-1 px-3 py-2 text-sm rounded-lg border border-border bg-muted/50",
+                  isMobile && "min-w-0 rounded-xl border-0 bg-muted px-2 py-1.5 text-base",
                   "focus:outline-none focus:ring-2 focus:ring-ring"
                 )}
               />
@@ -295,6 +357,7 @@ export function EventForm({
                   }}
                   className={cn(
                     "px-3 py-2 text-sm rounded-lg border border-border bg-muted/50",
+                    isMobile && "min-w-0 rounded-xl border-0 bg-muted px-2 py-1.5 text-base",
                     "focus:outline-none focus:ring-2 focus:ring-ring"
                   )}
                 >
@@ -309,9 +372,9 @@ export function EventForm({
           </div>
 
           {/* End */}
-          <div className="space-y-1">
-            <div className="text-xs text-muted-foreground">Ends</div>
-            <div className="flex gap-2">
+          <div className={cn("space-y-1", isMobile && "flex min-h-14 items-center justify-between gap-3 space-y-0 border-t border-border/50")}>
+            <div className={cn(isMobile ? "shrink-0 text-lg text-foreground" : "text-xs text-muted-foreground")}>Ends</div>
+            <div className="flex min-w-0 gap-2">
               {isAllDay ? (
                 <input
                   type="date"
@@ -320,6 +383,7 @@ export function EventForm({
                   min={startDate}
                   className={cn(
                     "flex-1 px-3 py-2 text-sm rounded-lg border border-border bg-muted/50",
+                    isMobile && "min-w-0 rounded-xl border-0 bg-muted px-2 py-1.5 text-base",
                     "focus:outline-none focus:ring-2 focus:ring-ring"
                   )}
                 />
@@ -330,7 +394,8 @@ export function EventForm({
                     value={endTime === "24:00" ? format(addDays(parseISO(startDate), 1), "yyyy-MM-dd") : endDate}
                     disabled
                     className={cn(
-                      "flex-1 px-3 py-2 text-sm rounded-lg border border-border bg-muted/30 opacity-50"
+                      "flex-1 px-3 py-2 text-sm rounded-lg border border-border bg-muted/30 opacity-50",
+                      isMobile && "min-w-0 rounded-xl border-0 bg-muted px-2 py-1.5 text-base"
                     )}
                   />
                   <select
@@ -338,6 +403,7 @@ export function EventForm({
                     onChange={(e) => setEndTime(e.target.value)}
                     className={cn(
                       "px-3 py-2 text-sm rounded-lg border border-border bg-muted/50",
+                      isMobile && "min-w-0 rounded-xl border-0 bg-muted px-2 py-1.5 text-base",
                       "focus:outline-none focus:ring-2 focus:ring-ring"
                     )}
                   >
@@ -356,7 +422,7 @@ export function EventForm({
         </div>
 
         {/* Action buttons */}
-        <div className="flex justify-end gap-2 px-4 py-3 border-t border-border/50 bg-muted/30">
+        {!isMobile && <div className="flex justify-end gap-2 px-4 py-3 border-t border-border/50 bg-muted/30">
           <Button
             variant="outline"
             size="sm"
@@ -371,6 +437,7 @@ export function EventForm({
           >
             {isEditing ? "Save" : "Add"}
           </Button>
+        </div>}
         </div>
       </DialogContent>
     </Dialog>

--- a/components/apps/calendar/month-view.tsx
+++ b/components/apps/calendar/month-view.tsx
@@ -25,6 +25,7 @@ interface MonthViewProps {
   onCreateEvent: (date: Date, startTime: string, endTime: string) => void;
   onDateClick?: (date: Date) => void;
   onMonthChange?: (date: Date) => void;
+  onViewEvent?: (event: CalendarEvent) => void;
 }
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -55,6 +56,7 @@ export function MonthView({
   onCreateEvent,
   onDateClick,
   onMonthChange,
+  onViewEvent,
 }: MonthViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [visibleMonth, setVisibleMonth] = useState(currentDate);
@@ -286,14 +288,24 @@ export function MonthView({
                         const color = getCalendarColor(event.calendarId);
                         const dateStr = format(day, "yyyy-MM-dd");
                         const isStart = event.startDate === dateStr;
+                        const isUserEvent = events.some((item) => item.id === event.id);
 
                         return (
                           <div
                             key={event.id}
-                            className="text-xs px-1.5 py-0.5 truncate cursor-default flex items-center gap-1 rounded"
+                            className={cn(
+                              "text-xs px-1.5 py-0.5 truncate flex items-center gap-1 rounded",
+                              isUserEvent ? "cursor-default" : "cursor-pointer"
+                            )}
                             style={{
                               backgroundColor: `${color}20`,
                               color: color,
+                            }}
+                            onClick={(clickEvent) => {
+                              if (!isUserEvent) {
+                                clickEvent.stopPropagation();
+                                onViewEvent?.(event);
+                              }
                             }}
                           >
                             <span

--- a/components/apps/calendar/month-view.tsx
+++ b/components/apps/calendar/month-view.tsx
@@ -25,6 +25,7 @@ interface MonthViewProps {
   onCreateEvent: (date: Date, startTime: string, endTime: string) => void;
   onDateClick?: (date: Date) => void;
   onMonthChange?: (date: Date) => void;
+  onEditEvent?: (eventId: string) => void;
   onViewEvent?: (event: CalendarEvent) => void;
 }
 
@@ -56,6 +57,7 @@ export function MonthView({
   onCreateEvent,
   onDateClick,
   onMonthChange,
+  onEditEvent,
   onViewEvent,
 }: MonthViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -293,17 +295,16 @@ export function MonthView({
                         return (
                           <div
                             key={event.id}
-                            className={cn(
-                              "text-xs px-1.5 py-0.5 truncate flex items-center gap-1 rounded",
-                              isUserEvent ? "cursor-default" : "cursor-pointer"
-                            )}
+                            className="text-xs px-1.5 py-0.5 truncate flex items-center gap-1 rounded cursor-pointer"
                             style={{
                               backgroundColor: `${color}20`,
                               color: color,
                             }}
                             onClick={(clickEvent) => {
-                              if (!isUserEvent) {
-                                clickEvent.stopPropagation();
+                              clickEvent.stopPropagation();
+                              if (isUserEvent) {
+                                onEditEvent?.(event.id);
+                              } else {
                                 onViewEvent?.(event);
                               }
                             }}

--- a/components/apps/calendar/month-view.tsx
+++ b/components/apps/calendar/month-view.tsx
@@ -15,6 +15,7 @@ import {
   isToday,
   format,
   formatEventTime,
+  getUpcomingEventDefaults,
   prioritizeUserEvents,
 } from "./utils";
 import { CalendarEvent, Calendar } from "./types";
@@ -23,7 +24,12 @@ interface MonthViewProps {
   currentDate: Date;
   events: CalendarEvent[];
   calendars: Calendar[];
-  onCreateEvent: (date: Date, startTime: string, endTime: string) => void;
+  onCreateEvent: (
+    date: Date,
+    startTime: string,
+    endTime: string,
+    endDate?: Date
+  ) => void;
   onDateClick?: (date: Date) => void;
   onMonthChange?: (date: Date) => void;
   onEditEvent?: (eventId: string) => void;
@@ -111,7 +117,13 @@ export function MonthView({
 
   // Handle double-click to create event
   const handleDoubleClick = useCallback((date: Date) => {
-    onCreateEvent(date, "09:00", "10:00");
+    const defaults = getUpcomingEventDefaults(date);
+    onCreateEvent(
+      defaults.startDate,
+      defaults.startTime,
+      defaults.endTime,
+      defaults.endDate
+    );
   }, [onCreateEvent]);
 
   // Initialize viewport height

--- a/components/apps/calendar/month-view.tsx
+++ b/components/apps/calendar/month-view.tsx
@@ -15,6 +15,7 @@ import {
   isToday,
   format,
   formatEventTime,
+  prioritizeUserEvents,
 } from "./utils";
 import { CalendarEvent, Calendar } from "./types";
 
@@ -75,6 +76,10 @@ export function MonthView({
 
   // Base date for all week calculations
   const baseDate = useMemo(() => getBaseDate(), []);
+  const userEventIds = useMemo(
+    () => new Set(events.map((event) => event.id)),
+    [events]
+  );
 
   // Total scrollable height
   const totalHeight = TOTAL_WEEKS * WEEK_HEIGHT;
@@ -231,6 +236,7 @@ export function MonthView({
             >
               {days.map((day, dayIdx) => {
                 const dayEvents = getEventsForDay(events, day);
+                const orderedDayEvents = prioritizeUserEvents(dayEvents, userEventIds);
                 const dayIsToday = isToday(day);
                 const isFirstOfMonth = day.getDate() === 1;
                 const monthOfDay = getMonth(day);
@@ -286,7 +292,7 @@ export function MonthView({
 
                     {/* Events */}
                     <div className="space-y-0.5 overflow-hidden">
-                      {dayEvents.slice(0, 3).map((event) => {
+                      {orderedDayEvents.slice(0, 3).map((event) => {
                         const color = getCalendarColor(event.calendarId);
                         const dateStr = format(day, "yyyy-MM-dd");
                         const isStart = event.startDate === dateStr;
@@ -326,9 +332,9 @@ export function MonthView({
                           </div>
                         );
                       })}
-                      {dayEvents.length > 3 && (
+                      {orderedDayEvents.length > 3 && (
                         <div className="text-xs text-muted-foreground pl-1">
-                          +{dayEvents.length - 3} more
+                          +{orderedDayEvents.length - 3} more
                         </div>
                       )}
                     </div>

--- a/components/apps/calendar/nav.tsx
+++ b/components/apps/calendar/nav.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { WindowControls } from "@/components/window-controls";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { WindowNavShell, WindowNavSpacer } from "@/components/window-nav-shell";
+import { WindowNavShell } from "@/components/window-nav-shell";
 import { useWindowNavBehavior } from "@/lib/use-window-nav-behavior";
 import { ViewType } from "./types";
 
@@ -52,7 +52,17 @@ export function Nav({
             closeLabel={nav.closeLabel}
           />
         }
-        right={<WindowNavSpacer isMobile={true} />}
+        right={
+          <button
+            type="button"
+            onClick={onNewEvent}
+            aria-label="New Event"
+            title="New Event"
+            className="-m-1.5 grid h-11 w-11 place-items-center rounded-lg text-[#FF3B30] active:bg-muted/60"
+          >
+            <Plus className="h-5 w-5" />
+          </button>
+        }
       />
     );
   }

--- a/components/apps/calendar/time-grid.tsx
+++ b/components/apps/calendar/time-grid.tsx
@@ -128,6 +128,7 @@ interface TimeGridProps {
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
   onEditEvent?: (eventId: string) => void;
+  onViewEvent?: (event: CalendarEvent) => void;
   editOnClick?: boolean;
 }
 
@@ -170,6 +171,7 @@ export function TimeGrid({
   selectedEventId,
   onSelectEvent,
   onEditEvent,
+  onViewEvent,
   editOnClick = false,
 }: TimeGridProps) {
   const hours = getDayHours();
@@ -459,6 +461,8 @@ export function TimeGrid({
                           } else {
                             onSelectEvent?.(isSelected ? null : event.id);
                           }
+                        } else {
+                          onViewEvent?.(event);
                         }
                       }}
                       onDoubleClick={(e) => {

--- a/components/apps/calendar/time-grid.tsx
+++ b/components/apps/calendar/time-grid.tsx
@@ -128,6 +128,7 @@ interface TimeGridProps {
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
   onEditEvent?: (eventId: string) => void;
+  editOnClick?: boolean;
 }
 
 function useCurrentTime(): Date {
@@ -169,6 +170,7 @@ export function TimeGrid({
   selectedEventId,
   onSelectEvent,
   onEditEvent,
+  editOnClick = false,
 }: TimeGridProps) {
   const hours = getDayHours();
   const now = useCurrentTime();
@@ -452,12 +454,16 @@ export function TimeGrid({
                       onClick={(e) => {
                         e.stopPropagation();
                         if (isUserEvent) {
-                          onSelectEvent?.(isSelected ? null : event.id);
+                          if (editOnClick) {
+                            onEditEvent?.(event.id);
+                          } else {
+                            onSelectEvent?.(isSelected ? null : event.id);
+                          }
                         }
                       }}
                       onDoubleClick={(e) => {
                         e.stopPropagation();
-                        if (isUserEvent) {
+                        if (isUserEvent && !editOnClick) {
                           onEditEvent?.(event.id);
                         }
                       }}

--- a/components/apps/calendar/utils.ts
+++ b/components/apps/calendar/utils.ts
@@ -426,6 +426,35 @@ export function prioritizeUserEvents(
   return [...owned, ...publicEvents];
 }
 
+export interface UpcomingEventDefaults {
+  startDate: Date;
+  endDate: Date;
+  startTime: string;
+  endTime: string;
+}
+
+// Start new events at the next strictly future half-hour in the user's local
+// time, retaining the date currently being viewed and a one-hour duration.
+export function getUpcomingEventDefaults(
+  referenceDate: Date,
+  now: Date = new Date()
+): UpcomingEventDefaults {
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  const nextHalfHour = (Math.floor(currentMinutes / 30) + 1) * 30;
+  const startDate = new Date(referenceDate);
+  startDate.setHours(0, nextHalfHour, 0, 0);
+
+  const endDate = new Date(startDate);
+  endDate.setMinutes(endDate.getMinutes() + 60);
+
+  return {
+    startDate,
+    endDate,
+    startTime: format(startDate, "HH:mm"),
+    endTime: format(endDate, "HH:mm"),
+  };
+}
+
 // Calculate event position in time grid (for day/week views)
 export function getEventTimePosition(event: CalendarEvent): {
   top: number;

--- a/components/apps/calendar/utils.ts
+++ b/components/apps/calendar/utils.ts
@@ -410,6 +410,22 @@ export function getEventsForDateRange(
   });
 }
 
+// Month cells have room for only a few rows. Keep user-created events visible
+// ahead of generated sample/holiday events while preserving both groups' order.
+export function prioritizeUserEvents(
+  dayEvents: CalendarEvent[],
+  userEventIds: ReadonlySet<string>
+): CalendarEvent[] {
+  const owned: CalendarEvent[] = [];
+  const publicEvents: CalendarEvent[] = [];
+
+  for (const event of dayEvents) {
+    (userEventIds.has(event.id) ? owned : publicEvents).push(event);
+  }
+
+  return [...owned, ...publicEvents];
+}
+
 // Calculate event position in time grid (for day/week views)
 export function getEventTimePosition(event: CalendarEvent): {
   top: number;

--- a/components/apps/calendar/week-view.tsx
+++ b/components/apps/calendar/week-view.tsx
@@ -131,7 +131,7 @@ export function WeekView({
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
         onViewEvent={onViewEvent}
-        editOnClick={isMobile}
+        editOnClick
       />
 
       {/* Time grid - scrollable, no day headers */}
@@ -147,7 +147,7 @@ export function WeekView({
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
         onViewEvent={onViewEvent}
-        editOnClick={isMobile}
+        editOnClick
       />
     </div>
   );

--- a/components/apps/calendar/week-view.tsx
+++ b/components/apps/calendar/week-view.tsx
@@ -128,6 +128,7 @@ export function WeekView({
         selectedEventId={selectedEventId}
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
+        editOnClick={isMobile}
       />
 
       {/* Time grid - scrollable, no day headers */}
@@ -142,6 +143,7 @@ export function WeekView({
         selectedEventId={selectedEventId}
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
+        editOnClick={isMobile}
       />
     </div>
   );

--- a/components/apps/calendar/week-view.tsx
+++ b/components/apps/calendar/week-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getWeekDays, formatDateHeader, isToday, format } from "./utils";
 import { TimeGrid } from "./time-grid";
@@ -20,6 +20,7 @@ interface WeekViewProps {
   isMobile?: boolean;
   onNavigate?: (direction: "prev" | "next") => void;
   onToday?: () => void;
+  onNewEvent?: () => void;
 }
 
 export function WeekView({
@@ -35,6 +36,7 @@ export function WeekView({
   isMobile = false,
   onNavigate,
   onToday,
+  onNewEvent,
 }: WeekViewProps) {
   const weekDays = getWeekDays(currentDate);
 
@@ -53,6 +55,7 @@ export function WeekView({
               variant="ghost"
               size="icon"
               onClick={() => onNavigate("prev")}
+              aria-label="Previous Week"
               className="h-8 w-8"
             >
               <ChevronLeft className="h-4 w-4" />
@@ -71,10 +74,23 @@ export function WeekView({
               variant="ghost"
               size="icon"
               onClick={() => onNavigate("next")}
+              aria-label="Next Week"
               className="h-8 w-8"
             >
               <ChevronRight className="h-4 w-4" />
             </Button>
+
+            {onNewEvent && (
+              <button
+                type="button"
+                onClick={onNewEvent}
+                aria-label="New Event"
+                title="New Event"
+                className="grid h-11 w-11 place-items-center rounded-lg text-[#FF3B30] active:bg-muted/60"
+              >
+                <Plus className="h-5 w-5" />
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/components/apps/calendar/week-view.tsx
+++ b/components/apps/calendar/week-view.tsx
@@ -17,6 +17,7 @@ interface WeekViewProps {
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
   onEditEvent?: (eventId: string) => void;
+  onViewEvent?: (event: CalendarEvent) => void;
   isMobile?: boolean;
   onNavigate?: (direction: "prev" | "next") => void;
   onToday?: () => void;
@@ -33,6 +34,7 @@ export function WeekView({
   selectedEventId,
   onSelectEvent,
   onEditEvent,
+  onViewEvent,
   isMobile = false,
   onNavigate,
   onToday,
@@ -128,6 +130,7 @@ export function WeekView({
         selectedEventId={selectedEventId}
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
+        onViewEvent={onViewEvent}
         editOnClick={isMobile}
       />
 
@@ -143,6 +146,7 @@ export function WeekView({
         selectedEventId={selectedEventId}
         onSelectEvent={onSelectEvent}
         onEditEvent={onEditEvent}
+        onViewEvent={onViewEvent}
         editOnClick={isMobile}
       />
     </div>

--- a/components/apps/calendar/week-view.tsx
+++ b/components/apps/calendar/week-view.tsx
@@ -45,14 +45,14 @@ export function WeekView({
   return (
     <div className="flex flex-col h-full">
       {/* Month/Year header */}
-      <div className="px-4 py-3 border-b border-border bg-background flex items-center justify-between">
+      <div className="relative px-4 py-3 border-b border-border bg-background flex items-center justify-between">
         <h1 className="text-2xl font-semibold">
           {formatDateHeader(currentDate, "week")}
         </h1>
 
         {/* Navigation controls (shown on mobile) */}
         {isMobile && onNavigate && onToday && (
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1 pr-12">
             <Button
               variant="ghost"
               size="icon"
@@ -88,7 +88,10 @@ export function WeekView({
                 onClick={onNewEvent}
                 aria-label="New Event"
                 title="New Event"
-                className="grid h-11 w-11 place-items-center rounded-lg text-[#FF3B30] active:bg-muted/60"
+                className="absolute top-1/2 grid h-11 w-11 -translate-y-1/2 place-items-center rounded-lg text-[#FF3B30] active:bg-muted/60"
+                style={{
+                  right: "max(0px, calc((100% - 4rem) / 14 - 1.375rem))",
+                }}
               >
                 <Plus className="h-5 w-5" />
               </button>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -34,14 +34,15 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   container?: HTMLElement | null;
+  overlayClassName?: string;
 }
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, container, ...props }, ref) => (
+>(({ className, children, container, overlayClassName, ...props }, ref) => (
   <DialogPortal container={container}>
-    <DialogOverlay contained={!!container} />
+    <DialogOverlay contained={!!container} className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(

--- a/tests/calendar-event-defaults.test.ts
+++ b/tests/calendar-event-defaults.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getUpcomingEventDefaults } from "../components/apps/calendar/utils";
+
+function localDate(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number
+): Date {
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
+}
+
+test("starts a new event at the next local half-hour", () => {
+  const referenceDate = localDate(2026, 8, 12, 9, 0);
+  const defaults = getUpcomingEventDefaults(
+    referenceDate,
+    localDate(2026, 8, 1, 16, 25)
+  );
+
+  assert.equal(defaults.startTime, "16:30");
+  assert.equal(defaults.endTime, "17:30");
+  assert.deepEqual(
+    [
+      defaults.startDate.getFullYear(),
+      defaults.startDate.getMonth() + 1,
+      defaults.startDate.getDate(),
+    ],
+    [2026, 8, 12]
+  );
+});
+
+test("moves to the following slot when now is exactly on a half-hour", () => {
+  const defaults = getUpcomingEventDefaults(
+    localDate(2026, 8, 12, 9, 0),
+    localDate(2026, 8, 1, 16, 30)
+  );
+
+  assert.equal(defaults.startTime, "17:00");
+  assert.equal(defaults.endTime, "18:00");
+});
+
+test("carries the one-hour event across midnight", () => {
+  const defaults = getUpcomingEventDefaults(
+    localDate(2026, 8, 12, 9, 0),
+    localDate(2026, 8, 1, 23, 25)
+  );
+
+  assert.equal(defaults.startTime, "23:30");
+  assert.equal(defaults.endTime, "00:30");
+  assert.equal(defaults.startDate.getDate(), 12);
+  assert.equal(defaults.endDate.getDate(), 13);
+});
+
+test("advances the selected date when the next slot is midnight", () => {
+  const defaults = getUpcomingEventDefaults(
+    localDate(2026, 8, 12, 9, 0),
+    localDate(2026, 8, 1, 23, 45)
+  );
+
+  assert.equal(defaults.startTime, "00:00");
+  assert.equal(defaults.endTime, "01:00");
+  assert.equal(defaults.startDate.getDate(), 13);
+  assert.equal(defaults.endDate.getDate(), 13);
+});

--- a/tests/calendar-month-events.test.ts
+++ b/tests/calendar-month-events.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { CalendarEvent } from "../components/apps/calendar/types";
+import { prioritizeUserEvents } from "../components/apps/calendar/utils";
+
+function event(id: string): CalendarEvent {
+  return {
+    id,
+    title: id,
+    startDate: "2026-08-01",
+    endDate: "2026-08-01",
+    startTime: "09:00",
+    endTime: "10:00",
+    isAllDay: false,
+    calendarId: "events",
+  };
+}
+
+test("keeps user-created events visible in capped Month cells", () => {
+  const publicEvents = [event("public-1"), event("public-2"), event("public-3")];
+  const userEvents = [event("owned-1"), event("owned-2")];
+
+  const ordered = prioritizeUserEvents(
+    [...publicEvents, ...userEvents],
+    new Set(userEvents.map(({ id }) => id))
+  );
+
+  assert.deepEqual(
+    ordered.map(({ id }) => id),
+    ["owned-1", "owned-2", "public-1", "public-2", "public-3"]
+  );
+  assert.deepEqual(
+    ordered.slice(0, 3).map(({ id }) => id),
+    ["owned-1", "owned-2", "public-1"]
+  );
+});
+
+test("preserves public event order when there are no user events", () => {
+  const publicEvents = [event("public-1"), event("public-2")];
+
+  assert.deepEqual(prioritizeUserEvents(publicEvents, new Set()), publicEvents);
+});


### PR DESCRIPTION
## Today's delight

Calendar now supports a complete, permission-aware event flow on both form factors. Created events can be added, opened with one click or tap, saved, and deleted. Public/sample/holiday events open that same surface as **Event Details**, with every value locked and no Save or Delete action. On mobile, Add is now centered over the Saturday column instead of sitting inside the navigation cluster.

## Baseline and delta

- Before: mobile Add appeared visibly too close to the Next control and left of the Saturday grid centerline; desktop also required a double-click to edit owned events.
- Now: mobile Add uses the same 64px time gutter and seven equal day columns as the calendar grid to compute the Saturday center at every supported width. All events open with one click or tap; ownership only determines edit versus view-only permissions.
- Preserved: the 44x44 Add target; previous/Today/next placement and behavior; desktop Calendar layout; event IDs and persistence; owned-only Save/Delete; public read-only details; and dark mode.

## Follow-up — useful default times

New Event now starts at the next strictly future half-hour in the user's local time instead of always defaulting to 9:00 AM. At 4:25 PM it proposes 4:30–5:30 PM; at exactly 4:30 PM it proposes 5:00–6:00 PM. The selected Calendar date is retained, one-hour duration remains the default, and late-night creation advances the end date correctly across midnight. Toolbar Add, mobile Add, and Month-date creation share the rule; drag-to-create retains the exact dragged slot.

## Review fix — Month visibility

The full review found one functional edge case: a day with three or more generated public events could hide every user-created event behind the Month view's three-row cap. Month cells now stably place owned events first while retaining the original order within the owned and public groups. The `+N more` count still reflects the complete day, and mobile remains on its intentionally unchanged Week view.

## Built result — desktop

![Desktop Calendar remains unchanged](https://github.com/user-attachments/assets/63277e72-e611-4c0c-b31c-8a7449654ef0)

At 1440x900, desktop retains the compact Calendar window, New Event toolbar action, all four views, and one-click event opening. The Saturday-column alignment rule is mobile-only.

## Built result — mobile

![Mobile Calendar Add centered over Saturday](https://github.com/user-attachments/assets/149b79de-5dbd-48b3-952c-28e3e799fb1c)

On a 390px iPhone surface, the Add center measured 366.72px and the Saturday-column center measured 366.71px. At 430px they measured 403.86px and 403.86px. The 44x44 target stays inside the viewport, does not overlap Next, and still opens the full-height event sheet under real touch/coarse-pointer emulation.

## Public event details

![Desktop Calendar view-only public event details](https://github.com/user-attachments/assets/9768e6e8-6244-43ac-950d-55f51d33a63c)

![Mobile Calendar view-only public event details](https://github.com/user-attachments/assets/85fa199c-6023-42ba-9db9-17b22e80797d)

Every event opens on one click or tap. User-created events are editable and deletable; public events use the same details surface with disabled fields and no Save or Delete.

## macOS inspiration

The owner's current iPhone Calendar reference places the Add affordance at the far-right edge of the header, visually aligned with the final day column, while event creation/editing uses a bottom-origin full-height sheet. Apple's [Calendar guide for iPhone](https://support.apple.com/en-ie/guide/iphone/iph3d110f84/ios) likewise places Add at the top. This implementation maps that position to the web grid's real Saturday centerline rather than applying a device-specific nudge.

## Why this one

The Add action was functional but visually disconnected from the grid below it. Centering it over Saturday makes the header read as one composed Calendar surface and resolves the owner's real-device observation with one responsive layout correction. Defaulting to the next upcoming slot now makes that same Add action immediately useful instead of requiring every event to be moved from 9:00 AM.

## Verification

- `npm run check` - lint (seven pre-existing warnings), 55 Node tests, typecheck, and production build
- `node --import tsx --test tests/calendar-event-defaults.test.ts tests/calendar-month-events.test.ts` - six focused Calendar tests
- Focused ESLint and `git diff --check`
- Desktop: 1440x900 with a fixed America/Los_Angeles clock at 4:25 PM; New Event rendered August 1, 4:30–5:30 PM
- Mobile: iPhone 13 at 390x844, `maxTouchPoints=1`, coarse pointer, hover-none; Add opened the 390x836 full-height sheet with August 1, 4:30–5:30 PM
- Midnight: 11:25 PM rendered 11:30 PM–12:30 AM with the end date advanced; changing the start to 11:45 PM preserved the one-hour duration through 12:45 AM
- Zero browser console or page errors in the final desktop, mobile, and midnight passes
- Preview: https://alanagoyal-git-codex-daily-delight-2026-08-01-162983-basecasevc.vercel.app

## Scope

The current-time follow-up adds one shared local-time helper, wires it into existing creation surfaces, keeps cross-midnight form duration valid, and adds four focused tests. The full draft PR is 12 files with 529 additions and 141 deletions relative to `main`. No backend, dependency, schema, external service, new shortcut, production data, or public-event mutation.
