### PR TITLE
Add TextEdit Find and document commands

### DIFF
--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -10,11 +10,16 @@ import { APPS } from "@/lib/app-config";
 import {
   HOME_DIR,
   LOCAL_FINDER_FILES,
+  getAllLocalFinderFiles,
+  getLocalFinderFiles,
   getLocalTextFileContent,
   PROJECTS_DIR,
 } from "@/lib/file-route-utils";
 import { getFinderVisibleApps } from "@/lib/app-availability";
-import { getFileModifiedDate } from "@/lib/file-storage";
+import {
+  getFileModifiedDate,
+  TEXTEDIT_DOCUMENTS_CHANGED_EVENT,
+} from "@/lib/file-storage";
 import { loadFinderPath, saveFinderPath } from "@/lib/sidebar-persistence";
 import { getPreviewMetadataFromPath } from "@/lib/preview-utils";
 import {
@@ -261,6 +266,7 @@ export function FinderApp({
   }, [onViewModeChange]);
   const [showViewDropdown, setShowViewDropdown] = useState(false);
   const [githubRecentFiles, setGithubRecentFiles] = useState<GitHubRecentFile[]>([]);
+  const [textEditDocumentsVersion, setTextEditDocumentsVersion] = useState(0);
 
   const [searchActive, setSearchActive] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
@@ -386,7 +392,7 @@ export function FinderApp({
 
       // Static file system
       if (LOCAL_FINDER_FILES[path]) {
-        setFiles(LOCAL_FINDER_FILES[path]);
+        setFiles(getLocalFinderFiles(path));
       } else {
         setFiles([]);
       }
@@ -401,6 +407,16 @@ export function FinderApp({
   useEffect(() => {
     loadFiles(currentPath);
   }, [currentPath, loadFiles]);
+
+  useEffect(() => {
+    const handleTextEditDocumentsChanged = () => {
+      setTextEditDocumentsVersion((version) => version + 1);
+      void loadFiles(currentPathRef.current);
+    };
+
+    window.addEventListener(TEXTEDIT_DOCUMENTS_CHANGED_EVENT, handleTextEditDocumentsChanged);
+    return () => window.removeEventListener(TEXTEDIT_DOCUMENTS_CHANGED_EVENT, handleTextEditDocumentsChanged);
+  }, [loadFiles]);
 
   // Desktop windows sync path back into window metadata; standalone/mobile Finder keeps the legacy session path.
   useEffect(() => {
@@ -517,7 +533,7 @@ export function FinderApp({
   useEffect(() => {
     const entries: EntryInput[] = [];
 
-    for (const items of Object.values(LOCAL_FINDER_FILES)) {
+    for (const items of Object.values(getAllLocalFinderFiles())) {
       for (const item of items) {
         const section: SidebarItem = item.path.includes("/Desktop")
           ? "desktop"
@@ -561,7 +577,7 @@ export function FinderApp({
 
     searchEngine.buildIndex(entries);
     setSearchIndexSize(searchEngine.version);
-  }, [searchEngine, finderVisibleApps]);
+  }, [searchEngine, finderVisibleApps, textEditDocumentsVersion]);
 
   useEffect(() => {
     if (!searchActive || searchPrefetchStartedRef.current) return;

--- a/components/apps/textedit/textedit-window.tsx
+++ b/components/apps/textedit/textedit-window.tsx
@@ -30,6 +30,7 @@ interface TextEditWindowProps {
   zIndex: number;
   isFocused: boolean;
   isMaximized: boolean;
+  isDirty: boolean;
   onFocus: () => void;
   onClose: () => void;
   onMinimize: () => void;
@@ -48,6 +49,7 @@ export function TextEditWindow({
   zIndex,
   isFocused,
   isMaximized,
+  isDirty,
   onFocus,
   onClose,
   onMinimize,
@@ -222,7 +224,12 @@ export function TextEditWindow({
             closeLabel="Close window"
           />
           <div className="flex-1 min-w-0 px-2 text-center">
-            <span className="block truncate text-zinc-500 dark:text-zinc-400 text-sm">{fileName}</span>
+            <span
+              data-testid="textedit-document-title"
+              className="block truncate text-sm text-zinc-500 dark:text-zinc-400"
+            >
+              {fileName}{isDirty ? " — Edited" : ""}
+            </span>
           </div>
           <div className="w-[68px] shrink-0" />
         </div>
@@ -317,6 +324,7 @@ export function TextEditWindow({
         <div className="flex-1 min-h-0">
           <textarea
             ref={textareaRef}
+            aria-label={`Document contents for ${fileName}`}
             value={content}
             onChange={(e) => onContentChange(e.target.value)}
             className="w-full h-full bg-transparent resize-none outline-none font-mono text-sm leading-relaxed p-4 overflow-auto text-zinc-900 dark:text-white"

--- a/components/apps/textedit/textedit-window.tsx
+++ b/components/apps/textedit/textedit-window.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, ChevronUp, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { WindowControls } from "@/components/window-controls";
 import {
@@ -13,6 +14,12 @@ import {
   EDGE_SIZE,
 } from "@/lib/use-window-behavior";
 import { MAXIMIZED_Z_INDEX, useWindowManager } from "@/lib/window-context";
+import {
+  findTextMatches,
+  replaceAllTextMatches,
+  replaceTextMatch,
+  TEXTEDIT_OPEN_FIND_EVENT,
+} from "@/lib/textedit-find";
 
 interface TextEditWindowProps {
   windowId: string; // Unique window identifier for multi-window support
@@ -49,11 +56,78 @@ export function TextEditWindow({
   onResize,
   onContentChange,
 }: TextEditWindowProps) {
-  // windowId is used for identification in multi-window scenarios
-  void windowId;
   const windowRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const findInputRef = useRef<HTMLInputElement>(null);
   const fileName = filePath?.split("/").pop() || "Untitled";
   const { isMenuOpenRef } = useWindowManager();
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [replaceOpen, setReplaceOpen] = useState(false);
+  const [replacement, setReplacement] = useState("");
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const matches = useMemo(() => findTextMatches(content, findQuery), [content, findQuery]);
+
+  useEffect(() => {
+    if (matches.length === 0) {
+      setCurrentMatchIndex(0);
+      return;
+    }
+
+    setCurrentMatchIndex((index) => Math.min(index, matches.length - 1));
+  }, [matches.length]);
+
+  useEffect(() => {
+    const handleOpenFind = (event: Event) => {
+      const { detail } = event as CustomEvent<{ windowId?: string }>;
+      if (detail.windowId !== windowId) return;
+
+      setFindOpen(true);
+      requestAnimationFrame(() => {
+        findInputRef.current?.focus();
+        findInputRef.current?.select();
+      });
+    };
+
+    window.addEventListener(TEXTEDIT_OPEN_FIND_EVENT, handleOpenFind);
+    return () => window.removeEventListener(TEXTEDIT_OPEN_FIND_EVENT, handleOpenFind);
+  }, [windowId]);
+
+  const selectMatch = useCallback((index: number) => {
+    const match = matches[index];
+    if (!match) return;
+
+    setCurrentMatchIndex(index);
+    textareaRef.current?.focus();
+    textareaRef.current?.setSelectionRange(match.start, match.end);
+  }, [matches]);
+
+  const moveMatch = (direction: -1 | 1) => {
+    if (matches.length === 0) return;
+    const nextIndex = (currentMatchIndex + direction + matches.length) % matches.length;
+    selectMatch(nextIndex);
+  };
+
+  const handleReplace = () => {
+    const match = matches[currentMatchIndex];
+    if (!match) return;
+
+    onContentChange(replaceTextMatch(content, match, replacement));
+    requestAnimationFrame(() => findInputRef.current?.focus());
+  };
+
+  const handleReplaceAll = () => {
+    if (matches.length === 0) return;
+
+    onContentChange(replaceAllTextMatches(content, matches, replacement));
+    requestAnimationFrame(() => findInputRef.current?.focus());
+  };
+
+  const closeFind = () => {
+    setFindOpen(false);
+    setReplaceOpen(false);
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  };
 
   const { isInteracting, handleDragStart, handleResizeStart } = useWindowBehavior({
     position,
@@ -153,9 +227,96 @@ export function TextEditWindow({
           <div className="w-[68px] shrink-0" />
         </div>
 
+        {findOpen && (
+          <div
+            data-testid="textedit-find-bar"
+            className="border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <Search aria-hidden="true" className="h-4 w-4 shrink-0 text-zinc-400" />
+              <input
+                ref={findInputRef}
+                value={findQuery}
+                onChange={(event) => {
+                  setFindQuery(event.target.value);
+                  setCurrentMatchIndex(0);
+                }}
+                aria-label="Find text"
+                placeholder="Find"
+                className="h-7 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-2 text-xs outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-600 dark:bg-zinc-900"
+              />
+              <span aria-live="polite" className="w-[72px] shrink-0 text-right text-[11px] text-zinc-500 dark:text-zinc-400">
+                {!findQuery
+                  ? ""
+                  : matches.length === 0
+                    ? "No matches"
+                    : `${currentMatchIndex + 1} of ${matches.length}`}
+              </span>
+              <button
+                onClick={() => moveMatch(-1)}
+                disabled={matches.length === 0}
+                aria-label="Previous match"
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md can-hover:hover:bg-zinc-200 disabled:opacity-35 dark:can-hover:hover:bg-zinc-700"
+              >
+                <ChevronUp aria-hidden="true" className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => moveMatch(1)}
+                disabled={matches.length === 0}
+                aria-label="Next match"
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md can-hover:hover:bg-zinc-200 disabled:opacity-35 dark:can-hover:hover:bg-zinc-700"
+              >
+                <ChevronDown aria-hidden="true" className="h-4 w-4" />
+              </button>
+              <label className="flex shrink-0 items-center gap-1.5 text-xs">
+                <input
+                  type="checkbox"
+                  checked={replaceOpen}
+                  onChange={(event) => setReplaceOpen(event.target.checked)}
+                  className="h-3.5 w-3.5 accent-blue-500"
+                />
+                Replace
+              </label>
+              <button
+                onClick={closeFind}
+                className="h-7 shrink-0 rounded-md px-2 text-xs font-medium can-hover:hover:bg-zinc-200 dark:can-hover:hover:bg-zinc-700"
+              >
+                Done
+              </button>
+            </div>
+
+            {replaceOpen && (
+              <div className="mt-2 flex min-w-0 items-center gap-2 pl-6">
+                <input
+                  value={replacement}
+                  onChange={(event) => setReplacement(event.target.value)}
+                  aria-label="Replacement text"
+                  placeholder="Replace with"
+                  className="h-7 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-2 text-xs outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-600 dark:bg-zinc-900"
+                />
+                <button
+                  onClick={handleReplace}
+                  disabled={matches.length === 0}
+                  className="h-7 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-xs can-hover:hover:bg-zinc-100 disabled:opacity-35 dark:border-zinc-600 dark:bg-zinc-900 dark:can-hover:hover:bg-zinc-700"
+                >
+                  Replace
+                </button>
+                <button
+                  onClick={handleReplaceAll}
+                  disabled={matches.length === 0}
+                  className="h-7 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-xs can-hover:hover:bg-zinc-100 disabled:opacity-35 dark:border-zinc-600 dark:bg-zinc-900 dark:can-hover:hover:bg-zinc-700"
+                >
+                  All
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Content */}
         <div className="flex-1 min-h-0">
           <textarea
+            ref={textareaRef}
             value={content}
             onChange={(e) => onContentChange(e.target.value)}
             className="w-full h-full bg-transparent resize-none outline-none font-mono text-sm leading-relaxed p-4 overflow-auto text-zinc-900 dark:text-white"

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -20,6 +20,7 @@ import {
   getDocumentAppFinderTarget,
   PROJECTS_DIR,
   getLocalTextFileContent,
+  getKnownTextEditDocumentPaths,
   isSupportedTextEditPath,
 } from "@/lib/file-route-utils";
 import { DOCK_HEIGHT, MENU_BAR_HEIGHT } from "@/lib/use-window-behavior";
@@ -29,7 +30,18 @@ import { ShutdownOverlay } from "./shutdown-overlay";
 import { RestartOverlay } from "./restart-overlay";
 import { getWallpaperPath } from "@/lib/os-versions";
 import type { SettingsPanel, SettingsCategory } from "@/components/apps/settings/settings-app";
-import { getTextEditContent, saveTextEditContent, cacheTextEditContent } from "@/lib/file-storage";
+import {
+  cacheTextEditContent,
+  createTextEditDocument,
+  getTextEditContent,
+  renameTextEditDocument,
+  saveTextEditContent,
+} from "@/lib/file-storage";
+import {
+  getDuplicateTextEditPath,
+  getRenamedTextEditPath,
+  getUntitledTextEditPath,
+} from "@/lib/textedit-documents";
 import { loadNotesSelectedSlug, saveMessagesConversation } from "@/lib/sidebar-persistence";
 import { getNotesSelectedSlugMemory } from "@/lib/notes/selection-state";
 import { setUrl } from "@/lib/set-url";
@@ -201,23 +213,8 @@ function DesktopContent({
     getWindowsByApp,
   } = useWindowManager();
   const { focusMode, currentOS } = useSystemSettings();
-  const { touchRecent } = useRecents();
+  const { addRecent, renameRecent, touchRecent } = useRecents();
 
-  // Debounce touchRecent to avoid excessive re-renders
-  const touchTimers = useRef<Record<string, NodeJS.Timeout>>({});
-  const debouncedTouchRecent = useCallback((path: string) => {
-    if (touchTimers.current[path]) clearTimeout(touchTimers.current[path]);
-    touchTimers.current[path] = setTimeout(() => {
-      touchRecent(path);
-      delete touchTimers.current[path];
-    }, 500);
-  }, [touchRecent]);
-
-  // Cleanup timers on unmount
-  useEffect(() => {
-    const timers = touchTimers.current;
-    return () => Object.values(timers).forEach(clearTimeout);
-  }, []);
   const [mode, setMode] = useState<DesktopMode>("active");
   const [settingsPanel, setSettingsPanel] = useState<SettingsPanel | undefined>(undefined);
   const [settingsCategory, setSettingsCategory] = useState<SettingsCategory | undefined>(undefined);
@@ -354,7 +351,7 @@ function DesktopContent({
 
   // Memoize the check for existing window to avoid effect re-runs
   const existingTextEditWindow = initialTextEditFile
-    ? textEditWindows.find((w) => w.instanceId === initialTextEditFile)
+    ? textEditWindows.find((w) => w.metadata?.filePath === initialTextEditFile)
     : null;
   const existingWindowId = existingTextEditWindow?.id;
 
@@ -491,6 +488,14 @@ function DesktopContent({
   // Handler for opening text files in TextEdit
   const handleOpenTextFile = useCallback(
     (filePath: string, content: string) => {
+      const existingWindow = textEditWindows.find(
+        (windowState) => windowState.metadata?.filePath === filePath
+      );
+      if (existingWindow) {
+        focusMultiWindow(existingWindow.id);
+        return;
+      }
+
       // Check for cached (edited) content first - preserve user edits
       const cachedContent = getTextEditContent(filePath);
       const contentToUse = cachedContent !== undefined ? cachedContent : content;
@@ -503,7 +508,7 @@ function DesktopContent({
       // Open multi-window (will focus existing if same file already open)
       openMultiWindow("textedit", filePath, { filePath, content: contentToUse });
     },
-    [openMultiWindow]
+    [focusMultiWindow, openMultiWindow, textEditWindows]
   );
 
   // Handler for opening preview files (images and PDFs) in Preview
@@ -555,6 +560,69 @@ function DesktopContent({
       getDocumentPickerFinderWindowPlacement()
     );
   }, [openDedicatedFinderWindow]);
+
+  const handleTextEditNew = useCallback(() => {
+    const filePath = getUntitledTextEditPath(getKnownTextEditDocumentPaths());
+    createTextEditDocument(filePath, "");
+    addRecent({ path: filePath, name: filePath.split("/").pop() ?? filePath, type: "file" });
+    openMultiWindow("textedit", filePath, { filePath, content: "", isDirty: false });
+  }, [addRecent, openMultiWindow]);
+
+  const handleTextEditOpen = useCallback(() => {
+    openDocumentAppPicker("textedit");
+  }, [openDocumentAppPicker]);
+
+  const handleTextEditClose = useCallback((windowId: string) => {
+    closeMultiWindow(windowId);
+  }, [closeMultiWindow]);
+
+  const handleTextEditSave = useCallback((windowId: string) => {
+    const windowState = state.windows[windowId];
+    const filePath = String(windowState?.metadata?.filePath ?? "");
+    if (!filePath) return;
+    const content = String(windowState?.metadata?.content ?? "");
+    saveTextEditContent(filePath, content);
+    updateWindowMetadata(windowId, { isDirty: false });
+    touchRecent(filePath);
+  }, [state.windows, touchRecent, updateWindowMetadata]);
+
+  const handleTextEditDuplicate = useCallback((windowId: string) => {
+    const windowState = state.windows[windowId];
+    const sourcePath = String(windowState?.metadata?.filePath ?? "");
+    if (!sourcePath) return;
+    const content = String(windowState?.metadata?.content ?? "");
+    const filePath = getDuplicateTextEditPath(sourcePath, getKnownTextEditDocumentPaths());
+    createTextEditDocument(filePath, content);
+    addRecent({ path: filePath, name: filePath.split("/").pop() ?? filePath, type: "file" });
+    openMultiWindow("textedit", filePath, { filePath, content, isDirty: false });
+  }, [addRecent, openMultiWindow, state.windows]);
+
+  const handleTextEditRename = useCallback((windowId: string, fileName: string): string | null => {
+    const windowState = state.windows[windowId];
+    const previousPath = String(windowState?.metadata?.filePath ?? "");
+    if (!previousPath) return "No document is focused.";
+    if (previousPath.startsWith(`${PROJECTS_DIR}/`)) {
+      return "GitHub project files can’t be renamed here.";
+    }
+
+    const result = getRenamedTextEditPath(
+      previousPath,
+      fileName,
+      getKnownTextEditDocumentPaths()
+    );
+    if (!result.ok) return result.error;
+    if (result.path === previousPath) return null;
+
+    const content = String(windowState?.metadata?.content ?? "");
+    renameTextEditDocument(previousPath, result.path, content);
+    updateWindowMetadata(windowId, {
+      filePath: result.path,
+      content,
+      isDirty: false,
+    });
+    renameRecent(previousPath, result.path);
+    return null;
+  }, [renameRecent, state.windows, updateWindowMetadata]);
 
   // Handler for opening apps from Finder
   const handleOpenApp = useCallback((appId: string) => {
@@ -784,6 +852,12 @@ function DesktopContent({
         onFinderViewModeChange={handleFinderViewModeChange}
         finderStatusBarVisible={finderStatusBarVisible}
         onFinderStatusBarVisibleChange={setFinderStatusBarVisible}
+        onTextEditNew={handleTextEditNew}
+        onTextEditOpen={handleTextEditOpen}
+        onTextEditClose={handleTextEditClose}
+        onTextEditSave={handleTextEditSave}
+        onTextEditDuplicate={handleTextEditDuplicate}
+        onTextEditRename={handleTextEditRename}
       />
 
       {isActive && (
@@ -883,6 +957,7 @@ function DesktopContent({
                   zIndex={windowState.zIndex}
                   isFocused={state.focusedWindowId === windowState.id}
                   isMaximized={windowState.isMaximized}
+                  isDirty={windowState.metadata?.isDirty === true}
                   onFocus={() => focusMultiWindow(windowState.id)}
                   onClose={() => closeMultiWindow(windowState.id)}
                   onMinimize={() => minimizeMultiWindow(windowState.id)}
@@ -891,10 +966,9 @@ function DesktopContent({
                   onResize={(size, pos) => resizeMultiWindow(windowState.id, size, pos)}
                   onContentChange={(newContent) => {
                     // Update metadata; window state persists for this tab.
-                    updateWindowMetadata(windowState.id, { content: newContent });
+                    updateWindowMetadata(windowState.id, { content: newContent, isDirty: true });
                     if (filePath) {
-                      saveTextEditContent(filePath, newContent);
-                      debouncedTouchRecent(filePath);
+                      cacheTextEditContent(filePath, newContent);
                     }
                   }}
                 />

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -260,69 +260,71 @@ export function MenuBar({
             )}
           />
         </button>
-        <button
-          onClick={() => toggleMenu("appMenu")}
-          className={cn(
-            "text-sm font-semibold px-2 py-0.5 rounded transition-colors",
-            openMenu === "appMenu"
-              ? "bg-blue-500 text-white"
-              : "text-black dark:text-white can-hover:hover:bg-white/10"
+        <div data-testid="menu-bar-app-commands" className="flex items-center gap-1">
+          <button
+            onClick={() => toggleMenu("appMenu")}
+            className={cn(
+              "text-sm font-semibold px-2 py-0.5 rounded transition-colors",
+              openMenu === "appMenu"
+                ? "bg-blue-500 text-white"
+                : "text-black dark:text-white can-hover:hover:bg-white/10"
+            )}
+          >
+            {focusedApp?.menuBarTitle || "Finder"}
+          </button>
+          {(focusedAppId === "notes" || focusedAppId === "messages") && (
+            <button
+              onClick={() => toggleMenu("fileMenu")}
+              className={cn(
+                "text-sm px-2 py-0.5 rounded transition-colors",
+                openMenu === "fileMenu"
+                  ? "bg-blue-500 text-white"
+                  : "text-black dark:text-white can-hover:hover:bg-white/10"
+              )}
+            >
+              File
+            </button>
           )}
-        >
-          {focusedApp?.menuBarTitle || "Finder"}
-        </button>
-        {(focusedAppId === "notes" || focusedAppId === "messages") && (
-          <button
-            onClick={() => toggleMenu("fileMenu")}
-            className={cn(
-              "text-sm px-2 py-0.5 rounded transition-colors",
-              openMenu === "fileMenu"
-                ? "bg-blue-500 text-white"
-                : "text-black dark:text-white can-hover:hover:bg-white/10"
-            )}
-          >
-            File
-          </button>
-        )}
-        {focusedAppId === "textedit" && (
-          <button
-            onClick={() => toggleMenu("textEditFileMenu")}
-            className={cn(
-              "rounded px-2 py-0.5 text-sm transition-colors",
-              openMenu === "textEditFileMenu"
-                ? "bg-blue-500 text-white"
-                : "text-black can-hover:hover:bg-white/10 dark:text-white"
-            )}
-          >
-            File
-          </button>
-        )}
-        {focusedAppId === "finder" && (
-          <button
-            onClick={() => toggleMenu("finderViewMenu")}
-            className={cn(
-              "text-sm px-2 py-0.5 rounded transition-colors",
-              openMenu === "finderViewMenu"
-                ? "bg-blue-500 text-white"
-                : "text-black dark:text-white can-hover:hover:bg-white/10"
-            )}
-          >
-            View
-          </button>
-        )}
-        {focusedAppId === "textedit" && (
-          <button
-            onClick={() => toggleMenu("textEditEditMenu")}
-            className={cn(
-              "rounded px-2 py-0.5 text-sm transition-colors",
-              openMenu === "textEditEditMenu"
-                ? "bg-blue-500 text-white"
-                : "text-black can-hover:hover:bg-white/10 dark:text-white"
-            )}
-          >
-            Edit
-          </button>
-        )}
+          {focusedAppId === "textedit" && (
+            <button
+              onClick={() => toggleMenu("textEditFileMenu")}
+              className={cn(
+                "rounded px-2 py-0.5 text-sm transition-colors",
+                openMenu === "textEditFileMenu"
+                  ? "bg-blue-500 text-white"
+                  : "text-black can-hover:hover:bg-white/10 dark:text-white"
+              )}
+            >
+              File
+            </button>
+          )}
+          {focusedAppId === "finder" && (
+            <button
+              onClick={() => toggleMenu("finderViewMenu")}
+              className={cn(
+                "text-sm px-2 py-0.5 rounded transition-colors",
+                openMenu === "finderViewMenu"
+                  ? "bg-blue-500 text-white"
+                  : "text-black dark:text-white can-hover:hover:bg-white/10"
+              )}
+            >
+              View
+            </button>
+          )}
+          {focusedAppId === "textedit" && (
+            <button
+              onClick={() => toggleMenu("textEditEditMenu")}
+              className={cn(
+                "rounded px-2 py-0.5 text-sm transition-colors",
+                openMenu === "textEditEditMenu"
+                  ? "bg-blue-500 text-white"
+                  : "text-black can-hover:hover:bg-white/10 dark:text-white"
+              )}
+            >
+              Edit
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="flex items-center gap-1">

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -15,6 +15,7 @@ import { AppMenu } from "./app-menu";
 import { FileMenu } from "./file-menu";
 import { FinderViewMenu } from "./finder-view-menu";
 import { TextEditEditMenu } from "./textedit-edit-menu";
+import { TextEditFileMenu, TextEditRenameDialog } from "./textedit-file-menu";
 import { AboutDialog } from "./about-dialog";
 import { FocusMenu, FOCUS_STATUS_CONFIG } from "./focus-menu";
 import { useFileMenuActions } from "@/lib/file-menu-context";
@@ -27,7 +28,7 @@ import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 import type { FinderViewMode } from "@/components/apps/finder/view-mode";
 import { TEXTEDIT_OPEN_FIND_EVENT } from "@/lib/textedit-find";
 
-type OpenMenu = "apple" | "appMenu" | "fileMenu" | "finderViewMenu" | "textEditEditMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
+type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "finderViewMenu" | "textEditEditMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
 
 const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
 
@@ -62,6 +63,12 @@ interface MenuBarProps {
   onFinderViewModeChange?: (mode: FinderViewMode) => void;
   finderStatusBarVisible?: boolean;
   onFinderStatusBarVisibleChange?: (visible: boolean) => void;
+  onTextEditNew?: () => void;
+  onTextEditOpen?: () => void;
+  onTextEditClose?: (windowId: string) => void;
+  onTextEditSave?: (windowId: string) => void;
+  onTextEditDuplicate?: (windowId: string) => void;
+  onTextEditRename?: (windowId: string, fileName: string) => string | null;
 }
 
 export function MenuBar({
@@ -80,6 +87,12 @@ export function MenuBar({
   onFinderViewModeChange,
   finderStatusBarVisible = false,
   onFinderStatusBarVisibleChange,
+  onTextEditNew,
+  onTextEditOpen,
+  onTextEditClose,
+  onTextEditSave,
+  onTextEditDuplicate,
+  onTextEditRename,
 }: MenuBarProps) {
   const fileMenuActions = useFileMenuActions();
   const {
@@ -98,6 +111,7 @@ export function MenuBar({
   const [datePrefix, setDatePrefix] = useState<string>("");
   const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
   const [aboutDialogOpen, setAboutDialogOpen] = useState(false);
+  const [textEditRenameOpen, setTextEditRenameOpen] = useState(false);
   const [lowPowerMode, setLowPowerMode] = useState(false);
   const [hasLoadedLowPowerMode, setHasLoadedLowPowerMode] = useState(false);
 
@@ -119,6 +133,10 @@ export function MenuBar({
   const focusedAppId = getFocusedAppId(); // This returns the base app ID (e.g., "textedit")
   const focusedApp = focusedAppId ? getAppById(focusedAppId) : null;
   const focusedWindowId = state.focusedWindowId; // This is the actual window ID (e.g., "textedit-0")
+  const focusedTextEditFilePath = focusedAppId === "textedit" && focusedWindowId
+    ? String(state.windows[focusedWindowId]?.metadata?.filePath ?? "")
+    : "";
+  const focusedTextEditFileName = focusedTextEditFilePath.split("/").pop() || "Untitled.txt";
   const activeFocus =
     focusMode === "off" ? null : FOCUS_STATUS_CONFIG[focusMode];
 
@@ -261,6 +279,19 @@ export function MenuBar({
               openMenu === "fileMenu"
                 ? "bg-blue-500 text-white"
                 : "text-black dark:text-white can-hover:hover:bg-white/10"
+            )}
+          >
+            File
+          </button>
+        )}
+        {focusedAppId === "textedit" && (
+          <button
+            onClick={() => toggleMenu("textEditFileMenu")}
+            className={cn(
+              "rounded px-2 py-0.5 text-sm transition-colors",
+              openMenu === "textEditFileMenu"
+                ? "bg-blue-500 text-white"
+                : "text-black can-hover:hover:bg-white/10 dark:text-white"
             )}
           >
             File
@@ -462,6 +493,28 @@ export function MenuBar({
               detail: { windowId: focusedWindowId },
             })
           );
+        }}
+      />
+
+      <TextEditFileMenu
+        isOpen={openMenu === "textEditFileMenu"}
+        onClose={closeMenu}
+        onNew={() => onTextEditNew?.()}
+        onOpen={() => onTextEditOpen?.()}
+        onCloseDocument={() => focusedWindowId && onTextEditClose?.(focusedWindowId)}
+        onSave={() => focusedWindowId && onTextEditSave?.(focusedWindowId)}
+        onDuplicate={() => focusedWindowId && onTextEditDuplicate?.(focusedWindowId)}
+        onRename={() => setTextEditRenameOpen(true)}
+        renameDisabled={focusedTextEditFilePath.startsWith("/Users/alanagoyal/Projects/")}
+      />
+
+      <TextEditRenameDialog
+        isOpen={textEditRenameOpen}
+        initialName={focusedTextEditFileName}
+        onClose={() => setTextEditRenameOpen(false)}
+        onRename={(fileName) => {
+          if (!focusedWindowId) return "No document is focused.";
+          return onTextEditRename?.(focusedWindowId, fileName) ?? null;
         }}
       />
 

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -14,6 +14,7 @@ import { NotificationCenter } from "./notification-center";
 import { AppMenu } from "./app-menu";
 import { FileMenu } from "./file-menu";
 import { FinderViewMenu } from "./finder-view-menu";
+import { TextEditEditMenu } from "./textedit-edit-menu";
 import { AboutDialog } from "./about-dialog";
 import { FocusMenu, FOCUS_STATUS_CONFIG } from "./focus-menu";
 import { useFileMenuActions } from "@/lib/file-menu-context";
@@ -24,8 +25,9 @@ import {
 } from "@/lib/menu-bar-clock";
 import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 import type { FinderViewMode } from "@/components/apps/finder/view-mode";
+import { TEXTEDIT_OPEN_FIND_EVENT } from "@/lib/textedit-find";
 
-type OpenMenu = "apple" | "appMenu" | "fileMenu" | "finderViewMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
+type OpenMenu = "apple" | "appMenu" | "fileMenu" | "finderViewMenu" | "textEditEditMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
 
 const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
 
@@ -277,6 +279,19 @@ export function MenuBar({
             View
           </button>
         )}
+        {focusedAppId === "textedit" && (
+          <button
+            onClick={() => toggleMenu("textEditEditMenu")}
+            className={cn(
+              "rounded px-2 py-0.5 text-sm transition-colors",
+              openMenu === "textEditEditMenu"
+                ? "bg-blue-500 text-white"
+                : "text-black can-hover:hover:bg-white/10 dark:text-white"
+            )}
+          >
+            Edit
+          </button>
+        )}
       </div>
 
       <div className="flex items-center gap-1">
@@ -436,6 +451,18 @@ export function MenuBar({
         onViewModeChange={(mode) => onFinderViewModeChange?.(mode)}
         statusBarVisible={finderStatusBarVisible}
         onStatusBarVisibleChange={(visible) => onFinderStatusBarVisibleChange?.(visible)}
+      />
+
+      <TextEditEditMenu
+        isOpen={openMenu === "textEditEditMenu"}
+        onClose={closeMenu}
+        onFind={() => {
+          window.dispatchEvent(
+            new CustomEvent(TEXTEDIT_OPEN_FIND_EVENT, {
+              detail: { windowId: focusedWindowId },
+            })
+          );
+        }}
       />
 
       <NotificationCenter

--- a/components/desktop/textedit-edit-menu.tsx
+++ b/components/desktop/textedit-edit-menu.tsx
@@ -19,7 +19,7 @@ export function TextEditEditMenu({ isOpen, onClose, onFind }: TextEditEditMenuPr
   return (
     <div
       ref={menuRef}
-      className="absolute top-7 left-[120px] w-56 overflow-hidden rounded-lg border border-black/10 bg-white/95 py-1 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+      className="absolute left-[172px] top-7 w-56 overflow-hidden rounded-lg border border-black/10 bg-white/95 py-1 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
     >
       <button
         onClick={() => {

--- a/components/desktop/textedit-edit-menu.tsx
+++ b/components/desktop/textedit-edit-menu.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRef } from "react";
+import { useClickOutside } from "@/lib/hooks/use-click-outside";
+
+interface TextEditEditMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onFind: () => void;
+}
+
+export function TextEditEditMenu({ isOpen, onClose, onFind }: TextEditEditMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(menuRef, onClose, isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute top-7 left-[120px] w-56 overflow-hidden rounded-lg border border-black/10 bg-white/95 py-1 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+    >
+      <button
+        onClick={() => {
+          onFind();
+          onClose();
+        }}
+        className="w-full px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+      >
+        Find…
+      </button>
+    </div>
+  );
+}

--- a/components/desktop/textedit-file-menu.tsx
+++ b/components/desktop/textedit-file-menu.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Copy, FolderOpen, Pencil, Plus, Save, X } from "lucide-react";
+import { useClickOutside } from "@/lib/hooks/use-click-outside";
+import { cn } from "@/lib/utils";
+
+interface TextEditFileMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onNew: () => void;
+  onOpen: () => void;
+  onCloseDocument: () => void;
+  onSave: () => void;
+  onDuplicate: () => void;
+  onRename: () => void;
+  renameDisabled?: boolean;
+}
+
+const COMMANDS = [
+  { id: "new", label: "New", icon: Plus },
+  { id: "open", label: "Open…", icon: FolderOpen },
+  { id: "separator" },
+  { id: "close", label: "Close", icon: X },
+  { id: "save", label: "Save", icon: Save },
+  { id: "duplicate", label: "Duplicate", icon: Copy },
+  { id: "rename", label: "Rename…", icon: Pencil },
+] as const;
+
+export function TextEditFileMenu({
+  isOpen,
+  onClose,
+  onNew,
+  onOpen,
+  onCloseDocument,
+  onSave,
+  onDuplicate,
+  onRename,
+  renameDisabled = false,
+}: TextEditFileMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(menuRef, onClose, isOpen);
+
+  if (!isOpen) return null;
+
+  const handlers = {
+    new: onNew,
+    open: onOpen,
+    close: onCloseDocument,
+    save: onSave,
+    duplicate: onDuplicate,
+    rename: onRename,
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      data-testid="textedit-file-menu"
+      className="absolute left-[120px] top-7 z-[70] w-60 overflow-hidden rounded-xl border border-black/10 bg-white/95 py-1.5 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+    >
+      {COMMANDS.map((command) => {
+        if (command.id === "separator") {
+          return <div key="separator" className="mx-3 my-1 border-t border-black/10 dark:border-white/10" />;
+        }
+
+        const disabled = command.id === "rename" && renameDisabled;
+        const Icon = command.icon;
+        return (
+          <button
+            key={command.id}
+            type="button"
+            disabled={disabled}
+            title={disabled ? "GitHub project files can’t be renamed here" : undefined}
+            onClick={() => {
+              handlers[command.id]();
+              onClose();
+            }}
+            className={cn(
+              "flex w-full items-center gap-3 px-3 py-1.5 text-left text-sm transition-colors",
+              "can-hover:hover:bg-blue-500 can-hover:hover:text-white",
+              "disabled:pointer-events-none disabled:opacity-40"
+            )}
+          >
+            <Icon aria-hidden="true" className="h-4 w-4 shrink-0" strokeWidth={1.8} />
+            <span>{command.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface TextEditRenameDialogProps {
+  isOpen: boolean;
+  initialName: string;
+  onClose: () => void;
+  onRename: (fileName: string) => string | null;
+}
+
+export function TextEditRenameDialog({
+  isOpen,
+  initialName,
+  onClose,
+  onRename,
+}: TextEditRenameDialogProps) {
+  const [fileName, setFileName] = useState(initialName);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setFileName(initialName);
+    setError(null);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      const extensionIndex = initialName.lastIndexOf(".");
+      inputRef.current?.setSelectionRange(0, extensionIndex > 0 ? extensionIndex : initialName.length);
+    });
+  }, [initialName, isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-black/20 backdrop-blur-[1px]">
+      <form
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="textedit-rename-title"
+        className="w-[340px] rounded-2xl border border-black/10 bg-zinc-100 p-5 text-zinc-900 shadow-2xl dark:border-white/10 dark:bg-zinc-800 dark:text-zinc-100"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const nextError = onRename(fileName);
+          if (nextError) {
+            setError(nextError);
+            return;
+          }
+          onClose();
+        }}
+      >
+        <h2 id="textedit-rename-title" className="text-center text-sm font-semibold">Rename document</h2>
+        <input
+          ref={inputRef}
+          aria-label="File name"
+          value={fileName}
+          onChange={(event) => {
+            setFileName(event.target.value);
+            setError(null);
+          }}
+          className="mt-4 h-8 w-full rounded-md border border-zinc-300 bg-white px-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-zinc-600 dark:bg-zinc-900"
+        />
+        <div aria-live="polite" className="mt-1 min-h-4 text-xs text-red-600 dark:text-red-400">
+          {error}
+        </div>
+        <div className="mt-3 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md bg-zinc-200 px-4 py-1.5 text-sm can-hover:hover:bg-zinc-300 dark:bg-zinc-700 dark:can-hover:hover:bg-zinc-600"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="rounded-md bg-blue-500 px-4 py-1.5 text-sm text-white can-hover:hover:bg-blue-600"
+          >
+            Rename
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -374,6 +374,10 @@ Focus state and scheduled expiration live in `SystemSettingsContext`, not the po
 
 The Control Center Focus tile should stay generic only while Focus is off. When active, its title, icon, and accent identify the specific mode, while its second line reports `On` or the scheduled end time.
 
+### Menu Bar Command Spacing
+
+Keep the Apple icon visually separated from the focused app, then group the app title and its commands with `gap-1`. Each command already has `px-2`, so this produces a consistent roughly 20px text-to-text rhythm between the app title, File, Edit, View, and any future command menus. Do not add per-app margins between menu labels.
+
 ### Empty State
 
 ```tsx

--- a/docs/document-apps.md
+++ b/docs/document-apps.md
@@ -10,6 +10,8 @@ This note captures how file-backed document apps launch through Finder in the de
 - Navigating to `/textedit` without a valid `file` query routes into the same Finder-picker flow as launching TextEdit from Finder.
 - Choosing `TextEdit` from Finder's Applications view focuses the topmost open TextEdit document window if one exists; otherwise it opens a centered, slightly smaller Finder window at `Documents`.
 - Finder opens text files in `TextEdit` windows, and those windows persist edited file contents by file path.
+- On desktop, TextEdit's File menu supports New, Open, Close, Save, Duplicate, and Rename. New and duplicated documents are durable local documents in Finder's `Documents` folder; Open launches a dedicated Finder picker; Rename updates the Finder-visible path without mutating GitHub project files.
+- TextEdit caches edits as they are typed so closing a window does not lose work. Save explicitly commits the current modified date and clears the window's `Edited` status.
 
 ### Preview
 
@@ -47,3 +49,7 @@ Run `npm run build`, then verify:
 9. Edit that text file, minimize and restore it, and confirm the content stays in sync for that file path.
 10. Open an image or PDF from Finder and confirm it opens in a `Preview` window with the existing viewer behavior.
 11. Navigate directly to `/textedit?file=<valid text file>` and `/preview?file=<valid image-or-pdf>` and confirm deep links still work.
+12. In TextEdit, use File → New and confirm an `Untitled.txt` document opens and appears in Finder's Documents folder.
+13. Use File → Duplicate and Rename, then confirm the copied content, updated title, and Finder-visible file name persist after closing and reopening the document.
+14. Edit a document and confirm the title shows `Edited`; use File → Save and confirm the marker clears before using File → Close.
+15. In an iPhone viewport with touch/coarse-pointer emulation, confirm `/textedit` still routes to Finder and TextEdit remains absent from Applications.

--- a/lib/file-route-utils.ts
+++ b/lib/file-route-utils.ts
@@ -1,5 +1,12 @@
+import {
+  getStoredTextEditDocumentPaths,
+  getTextEditContent,
+  isTextEditPathHidden,
+} from "@/lib/file-storage";
+
 export const HOME_DIR = "/Users/alanagoyal";
 export const PROJECTS_DIR = `${HOME_DIR}/Projects`;
+const TEXT_FILE_EXTENSIONS = new Set(["txt", "md", "markdown", "json", "js", "jsx", "ts", "tsx", "css", "html", "xml", "yaml", "yml"]);
 
 export type DocumentAppId = "textedit" | "preview";
 export type LocalSampleFileKind = "text" | "preview";
@@ -90,8 +97,44 @@ export function getDocumentAppFinderTarget(appId: DocumentAppId): string {
 }
 
 export function getLocalTextFileContent(filePath: string): string | null {
+  const storedContent = getTextEditContent(filePath);
+  if (storedContent !== undefined) return storedContent;
+  if (isTextEditPathHidden(filePath)) return null;
   const file = LOCAL_SAMPLE_FILE_MAP[filePath];
   return file?.kind === "text" ? (file.content ?? null) : null;
+}
+
+export function getLocalFinderFiles(directoryPath: string): LocalFinderItem[] {
+  const staticItems = (LOCAL_FINDER_FILES[directoryPath] ?? []).filter(
+    (item) => !isTextEditPathHidden(item.path)
+  );
+  const storedItems = getStoredTextEditDocumentPaths()
+    .filter((path) => path.split("/").slice(0, -1).join("/") === directoryPath)
+    .map((path) => ({
+      name: path.split("/").pop() ?? path,
+      type: "file" as const,
+      path,
+    }));
+
+  return [...staticItems, ...storedItems]
+    .filter((item, index, items) => items.findIndex((candidate) => candidate.path === item.path) === index)
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+}
+
+export function getAllLocalFinderFiles(): Record<string, LocalFinderItem[]> {
+  return Object.fromEntries(
+    Object.keys(LOCAL_FINDER_FILES).map((directoryPath) => [
+      directoryPath,
+      getLocalFinderFiles(directoryPath),
+    ])
+  );
+}
+
+export function getKnownTextEditDocumentPaths(): string[] {
+  const staticTextPaths = LOCAL_SAMPLE_FILES
+    .filter((file) => file.kind === "text" && !isTextEditPathHidden(file.path))
+    .map((file) => file.path);
+  return [...staticTextPaths, ...getStoredTextEditDocumentPaths()];
 }
 
 export function getLocalPreviewAssetUrl(filePath: string): string | null {
@@ -102,6 +145,15 @@ export function getLocalPreviewAssetUrl(filePath: string): string | null {
 export function isSupportedDocumentAppPath(appId: DocumentAppId, filePath: string): boolean {
   if (!filePath) return false;
   if (appId === "textedit" && filePath.startsWith(`${PROJECTS_DIR}/`)) return true;
+
+  if (appId === "textedit") {
+    if (getStoredTextEditDocumentPaths().includes(filePath)) return true;
+    if (isTextEditPathHidden(filePath)) return false;
+    const extension = filePath.split(".").pop()?.toLowerCase() ?? "";
+    if (filePath.startsWith(`${HOME_DIR}/Documents/`) && TEXT_FILE_EXTENSIONS.has(extension)) {
+      return true;
+    }
+  }
 
   const file = LOCAL_SAMPLE_FILE_MAP[filePath];
   return file?.kind === DOCUMENT_APP_CONFIGS[appId].localFileKind;

--- a/lib/file-storage.ts
+++ b/lib/file-storage.ts
@@ -4,6 +4,109 @@
 
 const TEXTEDIT_CONTENTS_KEY = "textedit-file-contents";
 const FILE_MODIFIED_DATES_KEY = "file-modified-dates";
+const TEXTEDIT_DOCUMENTS_KEY = "textedit-user-documents";
+const TEXTEDIT_HIDDEN_PATHS_KEY = "textedit-hidden-paths";
+
+export const TEXTEDIT_DOCUMENTS_CHANGED_EVENT = "textedit-documents-changed";
+
+interface StoredTextEditDocument {
+  path: string;
+  createdAt: number;
+}
+
+function dispatchTextEditDocumentsChanged(): void {
+  window.dispatchEvent(new Event(TEXTEDIT_DOCUMENTS_CHANGED_EVENT));
+}
+
+function loadStoredTextEditDocuments(): StoredTextEditDocument[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const saved = localStorage.getItem(TEXTEDIT_DOCUMENTS_KEY);
+    const parsed: unknown = saved ? JSON.parse(saved) : [];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (document): document is StoredTextEditDocument =>
+        typeof document === "object" &&
+        document !== null &&
+        typeof (document as StoredTextEditDocument).path === "string" &&
+        typeof (document as StoredTextEditDocument).createdAt === "number"
+    );
+  } catch {
+    return [];
+  }
+}
+
+function loadHiddenTextEditPaths(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const saved = localStorage.getItem(TEXTEDIT_HIDDEN_PATHS_KEY);
+    const parsed: unknown = saved ? JSON.parse(saved) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((path): path is string => typeof path === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getStoredTextEditDocumentPaths(): string[] {
+  return loadStoredTextEditDocuments().map((document) => document.path);
+}
+
+export function isTextEditPathHidden(filePath: string): boolean {
+  return loadHiddenTextEditPaths().includes(filePath);
+}
+
+export function createTextEditDocument(filePath: string, content: string): void {
+  if (typeof window === "undefined") return;
+  const documents = loadStoredTextEditDocuments();
+  if (!documents.some((document) => document.path === filePath)) {
+    documents.push({ path: filePath, createdAt: Date.now() });
+    localStorage.setItem(TEXTEDIT_DOCUMENTS_KEY, JSON.stringify(documents));
+  }
+  const hiddenPaths = loadHiddenTextEditPaths().filter((path) => path !== filePath);
+  localStorage.setItem(TEXTEDIT_HIDDEN_PATHS_KEY, JSON.stringify(hiddenPaths));
+  saveTextEditContent(filePath, content);
+  dispatchTextEditDocumentsChanged();
+}
+
+export function renameTextEditDocument(
+  previousPath: string,
+  nextPath: string,
+  content: string
+): void {
+  if (typeof window === "undefined" || previousPath === nextPath) return;
+
+  const documents = loadStoredTextEditDocuments();
+  const existingDocument = documents.find((document) => document.path === previousPath);
+  const nextDocuments = documents.filter(
+    (document) => document.path !== previousPath && document.path !== nextPath
+  );
+  nextDocuments.push({
+    path: nextPath,
+    createdAt: existingDocument?.createdAt ?? Date.now(),
+  });
+  localStorage.setItem(TEXTEDIT_DOCUMENTS_KEY, JSON.stringify(nextDocuments));
+
+  const contents = loadTextEditContents();
+  delete contents[previousPath];
+  contents[nextPath] = content;
+  localStorage.setItem(TEXTEDIT_CONTENTS_KEY, JSON.stringify(contents));
+
+  const dates = loadFileModifiedDates();
+  delete dates[previousPath];
+  dates[nextPath] = Date.now();
+  localStorage.setItem(FILE_MODIFIED_DATES_KEY, JSON.stringify(dates));
+
+  const hiddenPaths = new Set(loadHiddenTextEditPaths());
+  hiddenPaths.delete(nextPath);
+  if (!existingDocument) {
+    hiddenPaths.add(previousPath);
+  }
+  localStorage.setItem(TEXTEDIT_HIDDEN_PATHS_KEY, JSON.stringify([...hiddenPaths]));
+
+  dispatchTextEditDocumentsChanged();
+}
 
 // =============================================================================
 // TextEdit Content

--- a/lib/recents-context.tsx
+++ b/lib/recents-context.tsx
@@ -13,6 +13,7 @@ interface RecentsContextValue {
   recents: RecentFile[];
   addRecent: (file: Omit<RecentFile, "accessedAt">) => void;
   touchRecent: (path: string) => void;
+  renameRecent: (previousPath: string, nextPath: string) => void;
   clearRecents: () => void;
   fileModifiedVersion: number;
 }
@@ -87,12 +88,27 @@ export function RecentsProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  const renameRecent = useCallback((previousPath: string, nextPath: string) => {
+    setRecents((previous) => {
+      const existing = previous.find((recent) => recent.path === previousPath);
+      if (!existing) return previous;
+      const renamed: RecentFile = {
+        ...existing,
+        path: nextPath,
+        name: nextPath.split("/").pop() ?? existing.name,
+        accessedAt: Date.now(),
+      };
+      return [renamed, ...previous.filter((recent) => recent.path !== previousPath && recent.path !== nextPath)];
+    });
+    setFileModifiedVersion((version) => version + 1);
+  }, []);
+
   const clearRecents = useCallback(() => {
     setRecents([]);
   }, []);
 
   return (
-    <RecentsContext.Provider value={{ recents, addRecent, touchRecent, clearRecents, fileModifiedVersion }}>
+    <RecentsContext.Provider value={{ recents, addRecent, touchRecent, renameRecent, clearRecents, fileModifiedVersion }}>
       {children}
     </RecentsContext.Provider>
   );

--- a/lib/textedit-documents.ts
+++ b/lib/textedit-documents.ts
@@ -1,0 +1,80 @@
+const DEFAULT_DOCUMENT_DIRECTORY = "/Users/alanagoyal/Documents";
+
+function splitFileName(fileName: string): { stem: string; extension: string } {
+  const extensionIndex = fileName.lastIndexOf(".");
+  if (extensionIndex <= 0) return { stem: fileName, extension: "" };
+  return {
+    stem: fileName.slice(0, extensionIndex),
+    extension: fileName.slice(extensionIndex),
+  };
+}
+
+function uniquePath(
+  directory: string,
+  stem: string,
+  extension: string,
+  existingPaths: Iterable<string>,
+  suffixForIndex: (index: number) => string
+): string {
+  const existing = new Set(existingPaths);
+  let index = 1;
+
+  while (true) {
+    const suffix = suffixForIndex(index);
+    const candidate = `${directory}/${stem}${suffix}${extension}`;
+    if (!existing.has(candidate)) return candidate;
+    index += 1;
+  }
+}
+
+export function getUntitledTextEditPath(
+  existingPaths: Iterable<string>,
+  directory = DEFAULT_DOCUMENT_DIRECTORY
+): string {
+  return uniquePath(directory, "Untitled", ".txt", existingPaths, (index) =>
+    index === 1 ? "" : ` ${index}`
+  );
+}
+
+export function getDuplicateTextEditPath(
+  sourcePath: string,
+  existingPaths: Iterable<string>,
+  directory = DEFAULT_DOCUMENT_DIRECTORY
+): string {
+  const fileName = sourcePath.split("/").pop() || "Untitled.txt";
+  const { stem, extension } = splitFileName(fileName);
+  return uniquePath(directory, stem, extension, existingPaths, (index) =>
+    index === 1 ? " copy" : ` copy ${index}`
+  );
+}
+
+export type TextEditRenameResult =
+  | { ok: true; path: string; fileName: string }
+  | { ok: false; error: string };
+
+export function getRenamedTextEditPath(
+  currentPath: string,
+  requestedName: string,
+  existingPaths: Iterable<string>
+): TextEditRenameResult {
+  const trimmedName = requestedName.trim();
+  if (!trimmedName) return { ok: false, error: "Enter a file name." };
+  if (trimmedName === "." || trimmedName === ".." || /[/\\]/.test(trimmedName)) {
+    return { ok: false, error: "File names can’t contain slashes." };
+  }
+
+  const currentName = currentPath.split("/").pop() || "Untitled.txt";
+  const currentExtension = splitFileName(currentName).extension;
+  const requestedExtension = splitFileName(trimmedName).extension;
+  const fileName = !requestedExtension && currentExtension
+    ? `${trimmedName}${currentExtension}`
+    : trimmedName;
+  const directory = currentPath.split("/").slice(0, -1).join("/");
+  const path = `${directory}/${fileName}`;
+
+  if (path !== currentPath && new Set(existingPaths).has(path)) {
+    return { ok: false, error: "A file with that name already exists." };
+  }
+
+  return { ok: true, path, fileName };
+}

--- a/lib/textedit-find.ts
+++ b/lib/textedit-find.ts
@@ -1,0 +1,43 @@
+export const TEXTEDIT_OPEN_FIND_EVENT = "textedit:open-find";
+
+export interface TextEditMatch {
+  start: number;
+  end: number;
+}
+
+export function findTextMatches(content: string, query: string): TextEditMatch[] {
+  if (!query) return [];
+
+  const matches: TextEditMatch[] = [];
+  const normalizedContent = content.toLocaleLowerCase();
+  const normalizedQuery = query.toLocaleLowerCase();
+  let searchFrom = 0;
+
+  while (searchFrom <= normalizedContent.length - normalizedQuery.length) {
+    const start = normalizedContent.indexOf(normalizedQuery, searchFrom);
+    if (start === -1) break;
+
+    matches.push({ start, end: start + query.length });
+    searchFrom = start + query.length;
+  }
+
+  return matches;
+}
+
+export function replaceTextMatch(
+  content: string,
+  match: TextEditMatch,
+  replacement: string
+): string {
+  return `${content.slice(0, match.start)}${replacement}${content.slice(match.end)}`;
+}
+
+export function replaceAllTextMatches(
+  content: string,
+  matches: TextEditMatch[],
+  replacement: string
+): string {
+  return [...matches]
+    .reverse()
+    .reduce((nextContent, match) => replaceTextMatch(nextContent, match, replacement), content);
+}

--- a/tests/textedit-documents.test.ts
+++ b/tests/textedit-documents.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getDuplicateTextEditPath,
+  getRenamedTextEditPath,
+  getUntitledTextEditPath,
+} from "../lib/textedit-documents";
+
+const documents = "/Users/alanagoyal/Documents";
+
+test("creates a numbered untitled document without collisions", () => {
+  assert.equal(getUntitledTextEditPath([]), `${documents}/Untitled.txt`);
+  assert.equal(
+    getUntitledTextEditPath([
+      `${documents}/Untitled.txt`,
+      `${documents}/Untitled 2.txt`,
+    ]),
+    `${documents}/Untitled 3.txt`
+  );
+});
+
+test("duplicates into Documents while preserving the source extension", () => {
+  assert.equal(
+    getDuplicateTextEditPath("/Users/alanagoyal/Documents/hello.md", []),
+    `${documents}/hello copy.md`
+  );
+  assert.equal(
+    getDuplicateTextEditPath("/Users/alanagoyal/Projects/site/README.md", [
+      `${documents}/README copy.md`,
+    ]),
+    `${documents}/README copy 2.md`
+  );
+});
+
+test("rename preserves an omitted extension and rejects invalid or duplicate names", () => {
+  assert.deepEqual(
+    getRenamedTextEditPath(`${documents}/hello.md`, "welcome", []),
+    { ok: true, path: `${documents}/welcome.md`, fileName: "welcome.md" }
+  );
+  assert.deepEqual(
+    getRenamedTextEditPath(`${documents}/hello.md`, "welcome.txt", []),
+    { ok: true, path: `${documents}/welcome.txt`, fileName: "welcome.txt" }
+  );
+  assert.deepEqual(
+    getRenamedTextEditPath(`${documents}/hello.md`, "bad/name", []),
+    { ok: false, error: "File names can’t contain slashes." }
+  );
+  assert.deepEqual(
+    getRenamedTextEditPath(`${documents}/hello.md`, "welcome.md", [
+      `${documents}/welcome.md`,
+    ]),
+    { ok: false, error: "A file with that name already exists." }
+  );
+});

--- a/tests/textedit-find.test.ts
+++ b/tests/textedit-find.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  findTextMatches,
+  replaceAllTextMatches,
+  replaceTextMatch,
+} from "../lib/textedit-find";
+
+test("finds non-overlapping matches without case sensitivity", () => {
+  assert.deepEqual(findTextMatches("Hello hello HELLO", "hello"), [
+    { start: 0, end: 5 },
+    { start: 6, end: 11 },
+    { start: 12, end: 17 },
+  ]);
+  assert.deepEqual(findTextMatches("aaaa", "aa"), [
+    { start: 0, end: 2 },
+    { start: 2, end: 4 },
+  ]);
+});
+
+test("returns no matches for an empty query", () => {
+  assert.deepEqual(findTextMatches("hello", ""), []);
+});
+
+test("replaces one selected match", () => {
+  const content = "hello world hello";
+  const matches = findTextMatches(content, "hello");
+
+  assert.equal(replaceTextMatch(content, matches[1], "hi"), "hello world hi");
+});
+
+test("replaces all matches without shifting later ranges", () => {
+  const content = "Hello hello HELLO";
+  const matches = findTextMatches(content, "hello");
+
+  assert.equal(replaceAllTextMatches(content, matches, "hi"), "hi hi hi");
+});


### PR DESCRIPTION
## Today's delight

TextEdit now has two genuinely useful native-style menus: `Edit` → `Find…` for in-document search and replacement, plus `File` commands for New, Open, Close, Save, Duplicate, and Rename. The new document commands are wired into the existing multi-window shell, local persistence, Recents, and Finder Documents view rather than presented as decorative menu rows. The shared menu bar now also applies one compact command rhythm across app titles, File, Edit, and View.

## Baseline and delta

- Before: TextEdit opened and edited existing text files in persistent windows, and this PR's first commit added Find/Replace, but TextEdit still had no File menu or way to create, duplicate, rename, explicitly save, close, or open another document from the menu bar.
- Now: the focused TextEdit window can create durable `Untitled.txt` documents, launch the real Finder Documents picker, close exactly that window, save and clear its `Edited` state, duplicate its current contents, and rename local documents with collision validation. Shared app commands use a 4px button-box gap—about 20px between visible labels after their click padding—in TextEdit, Notes, Messages, and Finder.
- Preserved: direct file opening, typing and close/reload persistence, multi-window focus, Find/Replace, minimize/maximize, Finder's existing open action, and the true-mobile Finder fallback all replayed successfully. GitHub-backed project files remain locally editable and duplicable but Rename is disabled because this site does not own the external path.

## Built result — desktop

> Attachment pending: Chrome reached the signed-in PR, but its file chooser rejected both verified captures because the ChatGPT Chrome Extension does not have **Allow access to file URLs** enabled. The 1440×900 production capture remains outside the worktree for upload once that permission is enabled.

The latest production capture shows TextEdit's dark File menu with New, Open…, Close, Save, Duplicate, and Rename… in the same command hierarchy as the native reference, with the tightened TextEdit–File–Edit rhythm visible above it. Functional verification created, saved, duplicated, renamed, closed, reopened, and Finder-listed documents; the duplicated content survived the full round trip.

## Built result — mobile

> Attachment pending for the same Chrome file-upload permission blocker. The verified iPhone-class 390×844 CSS / 1170×2532 physical capture remains outside the worktree.

TextEdit is intentionally unavailable on true mobile. The iPhone capture shows the preserved touch Finder Applications experience: `/textedit` redirects to Finder, `pointer: coarse` and `hover: none` are active, TextEdit remains absent, and supported apps such as Notes remain available.

## macOS inspiration

The owner supplied a current native TextEdit File menu screenshot showing New, Open…, Close, Save, Duplicate, and Rename… with the separator after Open Recent, plus a current macOS menu-bar reference showing the compact app-title/File/Edit/View rhythm. This implementation maps those commands onto the site's real document and window model, standardizes the shared label spacing without per-app offsets, and omits shortcuts and larger commands that the site cannot yet perform honestly. Apple's current TextEdit guide also documents the existing `Edit` → `Find` field and replacement workflow: https://support.apple.com/en-euro/guide/textedit/txtef6cfde1a/mac.

## Why this one

This is an owner-requested continuation of the same TextEdit delight rather than a second unrelated idea. Recent default-branch work is concentrated in Calendar, and the only open PR is this draft. The functional six-command set scored best for authenticity and net-new utility; Open Recent, Move To, Revert To, Export as PDF, Share, Properties, Page Setup, and Print were left out because they need additional history, filesystem, document-format, or platform contracts to avoid dead-end controls.

## Verification

- `npm run check` — 62 tests, typecheck, and production build passed; seven pre-existing lint warnings and zero errors
- Focused automated tests: untitled naming, collision-free duplication, extension-preserving rename, invalid-name rejection, and duplicate-name rejection
- Desktop: 1440×900 production build; shared 4px command gap measured in TextEdit, Notes, and Finder; File/Edit menus preserved; all six File commands exercised; Edited/Save state; duplicate content; rename dialog; Finder listing; close/reopen persistence; Find/Replace preserved
- Mobile: iPhone-class 390×844 CSS viewport, DPR 3, real touch, coarse pointer, hover-none; direct-route redirect and Applications policy verified

## Scope

One contained TextEdit document-command feature, plus a two-file micro follow-up that centralizes command spacing in the shared menu bar and documents the standard. No dependency, backend, schema, external service, production data, secret, keyboard shortcut, raw viewport query, or unrelated cleanup was added. Branch remains draft and mergeable against the latest `main`.
