### PR TITLE
Add a navigable Finder path bar

### DIFF
--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -1702,21 +1702,21 @@ export function FinderApp({
             renderFileGrid()
           )}
           </div>
+          {(showPathBar || showStatusBar) && (
+            <footer className="shrink-0">
+              {showPathBar && renderPathBar()}
+              {showStatusBar && (
+                <div
+                  role="status"
+                  className="flex h-[22px] items-center justify-center border-t border-zinc-200 bg-white px-3 text-[10px] leading-none text-zinc-500 select-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
+                >
+                  {statusLabel}
+                </div>
+              )}
+            </footer>
+          )}
         </div>
       </div>
-      {(showPathBar || showStatusBar) && (
-        <footer className="shrink-0">
-          {showPathBar && renderPathBar()}
-          {showStatusBar && (
-            <div
-              role="status"
-              className="flex h-[22px] items-center justify-center border-t border-zinc-200 bg-white px-3 text-[10px] leading-none text-zinc-500 select-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
-            >
-              {statusLabel}
-            </div>
-          )}
-        </footer>
-      )}
     </div>
   );
 }

--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -29,6 +29,7 @@ import {
 import { useRouter } from "next/navigation";
 import { FinderSearchEngine, type EntryInput } from "./search-engine";
 import type { FinderViewMode } from "./view-mode";
+import { getFinderPathSegments } from "@/lib/finder-path";
 
 const USERNAME = HOME_DIR.split("/").pop() ?? "alanagoyal";
 
@@ -68,6 +69,7 @@ interface FinderAppProps {
   viewMode?: FinderViewMode;
   onViewModeChange?: (mode: FinderViewMode) => void;
   showStatusBar?: boolean;
+  showPathBar?: boolean;
   onOpenApp?: (appId: string) => void;
   onOpenTextFile?: (filePath: string, content: string) => void;
   onOpenPreviewFile?: (filePath: string, fileUrl: string, fileType: "image" | "pdf") => void;
@@ -195,6 +197,7 @@ export function FinderApp({
   viewMode: controlledViewMode,
   onViewModeChange,
   showStatusBar = false,
+  showPathBar = false,
   onOpenApp,
   onOpenTextFile,
   onOpenPreviewFile,
@@ -1508,6 +1511,57 @@ export function FinderApp({
     : hasStatusSelection
       ? `1 of ${statusItemCount} selected`
       : `${statusItemCount} ${statusItemCount === 1 ? "item" : "items"}`;
+  const pathSegments = getFinderPathSegments(currentPath);
+
+  const handlePathSegmentClick = (path: string) => {
+    setSearchActive(false);
+    setSearchQuery("");
+    setPreviewContent(null);
+    setSelectedFile(null);
+    setSelectedSidebar(getSidebarForPath(path));
+    setCurrentPath(path);
+  };
+
+  const renderPathBar = () => (
+    <nav
+      aria-label="Path Bar"
+      className="flex h-6 items-center justify-center overflow-x-auto border-t border-zinc-200 bg-zinc-100 px-3 text-[11px] text-zinc-600 select-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+    >
+      <div className="flex min-w-max items-center">
+        {pathSegments.map((segment, index) => {
+          const isCurrent = index === pathSegments.length - 1;
+          return (
+            <div key={segment.path} className="flex items-center">
+              {index > 0 && (
+                <svg aria-hidden="true" className="mx-0.5 h-3 w-3 text-zinc-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              )}
+              <button
+                type="button"
+                disabled={isCurrent}
+                aria-current={isCurrent ? "location" : undefined}
+                aria-label={isCurrent ? `${segment.label}, current folder` : `Open ${segment.label}`}
+                title={segment.path}
+                onClick={() => handlePathSegmentClick(segment.path)}
+                className={cn(
+                  "flex items-center gap-1 rounded px-1.5 py-0.5",
+                  isCurrent
+                    ? "font-medium text-zinc-800 dark:text-zinc-100"
+                    : "can-hover:hover:bg-zinc-200 can-hover:hover:text-zinc-950 dark:can-hover:hover:bg-zinc-700 dark:can-hover:hover:text-white"
+                )}
+              >
+                <svg aria-hidden="true" className="h-3.5 w-3.5 text-blue-500" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" />
+                </svg>
+                <span>{segment.label}</span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </nav>
+  );
 
   const renderScopeBar = () => (
     <div className="flex items-center gap-1.5 px-4 py-1 bg-zinc-100 dark:bg-zinc-800 border-b border-zinc-200 dark:border-zinc-700 select-none">
@@ -1654,7 +1708,15 @@ export function FinderApp({
               className="h-[18px] shrink-0 border-t border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900"
             />
           )}
+          {showPathBar && (
+            <div aria-hidden="true" className="h-6 shrink-0" />
+          )}
         </div>
+        {showPathBar && (
+          <div className={cn("absolute inset-x-0", showStatusBar ? "bottom-[18px]" : "bottom-0")}>
+            {renderPathBar()}
+          </div>
+        )}
         {showStatusBar && (
           <div
             role="status"

--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -1525,7 +1525,7 @@ export function FinderApp({
   const renderPathBar = () => (
     <nav
       aria-label="Path Bar"
-      className="flex h-6 items-center justify-center overflow-x-auto border-t border-zinc-200 bg-zinc-100 px-3 text-[11px] text-zinc-600 select-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+      className="flex h-7 items-center justify-start overflow-x-auto border-t border-zinc-200 bg-zinc-100 px-3 text-[11px] text-zinc-600 select-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
     >
       <div className="flex min-w-max items-center">
         {pathSegments.map((segment, index) => {
@@ -1702,30 +1702,21 @@ export function FinderApp({
             renderFileGrid()
           )}
           </div>
+        </div>
+      </div>
+      {(showPathBar || showStatusBar) && (
+        <footer className="shrink-0">
+          {showPathBar && renderPathBar()}
           {showStatusBar && (
             <div
-              aria-hidden="true"
-              className="h-[18px] shrink-0 border-t border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900"
-            />
+              role="status"
+              className="flex h-[22px] items-center justify-center border-t border-zinc-200 bg-white px-3 text-[10px] leading-none text-zinc-500 select-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
+            >
+              {statusLabel}
+            </div>
           )}
-          {showPathBar && (
-            <div aria-hidden="true" className="h-6 shrink-0" />
-          )}
-        </div>
-        {showPathBar && (
-          <div className={cn("absolute inset-x-0", showStatusBar ? "bottom-[18px]" : "bottom-0")}>
-            {renderPathBar()}
-          </div>
-        )}
-        {showStatusBar && (
-          <div
-            role="status"
-            className="pointer-events-none absolute inset-x-0 bottom-0 flex h-[18px] items-center justify-center px-3 text-[10px] leading-none text-zinc-500 select-none dark:text-zinc-400"
-          >
-            {statusLabel}
-          </div>
-        )}
-      </div>
+        </footer>
+      )}
     </div>
   );
 }

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -57,6 +57,7 @@ const PreviewWindow = dynamic(() => import("@/components/apps/preview").then(m =
 type DesktopMode = "active" | "locked" | "sleeping" | "shuttingDown" | "restarting";
 
 const FINDER_STATUS_BAR_STORAGE_KEY = "finder-show-status-bar";
+const FINDER_PATH_BAR_STORAGE_KEY = "finder-show-path-bar";
 
 interface DesktopProps {
   initialAppId?: string;
@@ -225,6 +226,8 @@ function DesktopContent({
   const [restoreDefaultOnUnlock, setRestoreDefaultOnUnlock] = useState(false);
   const [finderStatusBarVisible, setFinderStatusBarVisible] = useState(false);
   const [hasLoadedFinderStatusBarPreference, setHasLoadedFinderStatusBarPreference] = useState(false);
+  const [finderPathBarVisible, setFinderPathBarVisible] = useState(false);
+  const [hasLoadedFinderPathBarPreference, setHasLoadedFinderPathBarPreference] = useState(false);
   const [finderRouteProcessed, setFinderRouteProcessed] = useState(initialAppId !== "finder");
   const initialDocumentRouteAppId =
     initialAppId === "textedit" || initialAppId === "preview" ? initialAppId : null;
@@ -241,12 +244,19 @@ function DesktopContent({
   useEffect(() => {
     setFinderStatusBarVisible(window.localStorage.getItem(FINDER_STATUS_BAR_STORAGE_KEY) === "true");
     setHasLoadedFinderStatusBarPreference(true);
+    setFinderPathBarVisible(window.localStorage.getItem(FINDER_PATH_BAR_STORAGE_KEY) === "true");
+    setHasLoadedFinderPathBarPreference(true);
   }, []);
 
   useEffect(() => {
     if (!hasLoadedFinderStatusBarPreference) return;
     window.localStorage.setItem(FINDER_STATUS_BAR_STORAGE_KEY, String(finderStatusBarVisible));
   }, [finderStatusBarVisible, hasLoadedFinderStatusBarPreference]);
+
+  useEffect(() => {
+    if (!hasLoadedFinderPathBarPreference) return;
+    window.localStorage.setItem(FINDER_PATH_BAR_STORAGE_KEY, String(finderPathBarVisible));
+  }, [finderPathBarVisible, hasLoadedFinderPathBarPreference]);
   const getNotesSlugForRouting = useCallback(
     () => getNotesSelectedSlugMemory() ?? loadNotesSelectedSlug() ?? undefined,
     []
@@ -784,6 +794,8 @@ function DesktopContent({
         onFinderViewModeChange={handleFinderViewModeChange}
         finderStatusBarVisible={finderStatusBarVisible}
         onFinderStatusBarVisibleChange={setFinderStatusBarVisible}
+        finderPathBarVisible={finderPathBarVisible}
+        onFinderPathBarVisibleChange={setFinderPathBarVisible}
       />
 
       {isActive && (
@@ -857,6 +869,7 @@ function DesktopContent({
                     viewMode={viewMode}
                     onViewModeChange={(mode) => updateWindowMetadata(windowState.id, { viewMode: mode })}
                     showStatusBar={finderStatusBarVisible}
+                    showPathBar={finderPathBarVisible}
                     initialPath={currentPath}
                     onPathChange={(path) => updateWindowMetadata(windowState.id, { currentPath: path })}
                     onOpenApp={handleOpenApp}

--- a/components/desktop/finder-view-menu.tsx
+++ b/components/desktop/finder-view-menu.tsx
@@ -16,6 +16,8 @@ interface FinderViewMenuProps {
   onViewModeChange: (mode: FinderViewMode) => void;
   statusBarVisible: boolean;
   onStatusBarVisibleChange: (visible: boolean) => void;
+  pathBarVisible: boolean;
+  onPathBarVisibleChange: (visible: boolean) => void;
 }
 
 export function FinderViewMenu({
@@ -25,6 +27,8 @@ export function FinderViewMenu({
   onViewModeChange,
   statusBarVisible,
   onStatusBarVisibleChange,
+  pathBarVisible,
+  onPathBarVisibleChange,
 }: FinderViewMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -59,6 +63,16 @@ export function FinderViewMenu({
       ))}
 
       <div className="my-1 border-t border-black/10 dark:border-white/10" />
+
+      <button
+        onClick={() => {
+          onPathBarVisibleChange(!pathBarVisible);
+          onClose();
+        }}
+        className="w-full px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+      >
+        {pathBarVisible ? "Hide Path Bar" : "Show Path Bar"}
+      </button>
 
       <button
         onClick={() => {

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -60,6 +60,8 @@ interface MenuBarProps {
   onFinderViewModeChange?: (mode: FinderViewMode) => void;
   finderStatusBarVisible?: boolean;
   onFinderStatusBarVisibleChange?: (visible: boolean) => void;
+  finderPathBarVisible?: boolean;
+  onFinderPathBarVisibleChange?: (visible: boolean) => void;
 }
 
 export function MenuBar({
@@ -78,6 +80,8 @@ export function MenuBar({
   onFinderViewModeChange,
   finderStatusBarVisible = false,
   onFinderStatusBarVisibleChange,
+  finderPathBarVisible = false,
+  onFinderPathBarVisibleChange,
 }: MenuBarProps) {
   const fileMenuActions = useFileMenuActions();
   const {
@@ -436,6 +440,8 @@ export function MenuBar({
         onViewModeChange={(mode) => onFinderViewModeChange?.(mode)}
         statusBarVisible={finderStatusBarVisible}
         onStatusBarVisibleChange={(visible) => onFinderStatusBarVisibleChange?.(visible)}
+        pathBarVisible={finderPathBarVisible}
+        onPathBarVisibleChange={(visible) => onFinderPathBarVisibleChange?.(visible)}
       />
 
       <NotificationCenter

--- a/lib/finder-path.ts
+++ b/lib/finder-path.ts
@@ -1,0 +1,43 @@
+import { HOME_DIR, PROJECTS_DIR } from "@/lib/file-route-utils";
+
+export interface FinderPathSegment {
+  label: string;
+  path: string;
+}
+
+const FINDER_ROOTS = [
+  { label: "Desktop", path: `${HOME_DIR}/Desktop` },
+  { label: "Documents", path: `${HOME_DIR}/Documents` },
+  { label: "Downloads", path: `${HOME_DIR}/Downloads` },
+  { label: "Projects", path: PROJECTS_DIR },
+];
+
+export function getFinderPathSegments(path: string): FinderPathSegment[] {
+  if (path === "recents") return [{ label: "Recents", path }];
+  if (path === "applications") return [{ label: "Applications", path }];
+
+  if (path === "trash" || path.startsWith("trash/")) {
+    const segments: FinderPathSegment[] = [{ label: "Trash", path: "trash" }];
+    let currentPath = "trash";
+    for (const part of path.slice("trash".length).split("/").filter(Boolean)) {
+      currentPath += `/${part}`;
+      segments.push({ label: part, path: currentPath });
+    }
+    return segments;
+  }
+
+  const root = FINDER_ROOTS.find(
+    (candidate) => path === candidate.path || path.startsWith(`${candidate.path}/`)
+  );
+  if (!root) {
+    return [{ label: path.split("/").filter(Boolean).at(-1) ?? path, path }];
+  }
+
+  const segments: FinderPathSegment[] = [{ ...root }];
+  let currentPath = root.path;
+  for (const part of path.slice(root.path.length).split("/").filter(Boolean)) {
+    currentPath += `/${part}`;
+    segments.push({ label: part, path: currentPath });
+  }
+  return segments;
+}

--- a/tests/finder-path.test.ts
+++ b/tests/finder-path.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getFinderPathSegments } from "../lib/finder-path";
+
+test("builds clickable segments from the Finder section root", () => {
+  assert.deepEqual(
+    getFinderPathSegments("/Users/alanagoyal/Projects/alanagoyal/components/apps/finder"),
+    [
+      { label: "Projects", path: "/Users/alanagoyal/Projects" },
+      { label: "alanagoyal", path: "/Users/alanagoyal/Projects/alanagoyal" },
+      { label: "components", path: "/Users/alanagoyal/Projects/alanagoyal/components" },
+      { label: "apps", path: "/Users/alanagoyal/Projects/alanagoyal/components/apps" },
+      { label: "finder", path: "/Users/alanagoyal/Projects/alanagoyal/components/apps/finder" },
+    ]
+  );
+});
+
+test("keeps local and virtual roots concise", () => {
+  assert.deepEqual(getFinderPathSegments("/Users/alanagoyal/Documents"), [
+    { label: "Documents", path: "/Users/alanagoyal/Documents" },
+  ]);
+  assert.deepEqual(getFinderPathSegments("trash/unused-assets"), [
+    { label: "Trash", path: "trash" },
+    { label: "unused-assets", path: "trash/unused-assets" },
+  ]);
+});


### PR DESCRIPTION
## Today's delight

Finder now has an authentic, persistent **View → Show Path Bar** command. On desktop, the bottom bar mirrors the current nested location and each ancestor is clickable, so a deep folder can jump straight back to any parent.

## Baseline and delta

- **Before:** Finder exposed a non-interactive title breadcrumb and a status-bar toggle, but no path bar command or ancestor navigation.
- **After:** View toggles a durable bottom path bar; nested folders render as clickable segments and the current folder is clearly identified.
- **Preserved:** sidebar selection, back/forward history, search, previews, view modes, status bar behavior, and the existing mobile Browse flow.

## Built result — desktop

> **Attachment pending:** the verified 1440×900 capture is retained outside the worktree, but GitHub upload was blocked because the ChatGPT Chrome Extension does not currently have “Allow access to file URLs” enabled.

The production build was exercised in a deep `Projects / alanagoyal / components / apps / finder` location. Clicking `components` navigated there, updated the trail, and participated in Finder history. The preference survived reload and was also checked in dark mode.

**Owner-reference follow-up:** the path and status bars now render as adjacent normal-flow rows inside the file-content pane. Both begin exactly at the sidebar’s right edge instead of covering the sidebar; the sidebar continues beside them to the window bottom. The path remains left aligned within that pane, while status text remains centered below it.

## Built result — mobile

> **Attachment pending:** the verified iPhone capture (390×844 CSS px at 3× DPR) is retained outside the worktree, but the same Chrome extension file-access permission blocked upload.

With real touch/coarse-pointer emulation, mobile keeps the existing Files-style **Browse** parent flow and does not render desktop path-bar chrome—even when the desktop preference is enabled.

## macOS inspiration

Apple documents **View → Show Path Bar**, a path display near the bottom of Finder, and clicking folders in that path to navigate. This implementation maps those behaviors to the site’s existing Finder rather than adding new interaction language: [Show the path to a file or folder on Mac](https://support.apple.com/en-gb/guide/mac-help/mchlp1774/mac).

The owner also supplied current native Finder screenshots showing that both footer rows belong to the content pane to the right of the sidebar, with the path left aligned and status centered; the follow-up layout now matches that structure.

## Why this one

This scored **28/30** on the daily-delight rubric: authenticity 5, value 4, novelty 5, desktop/mobile intent 4, finishability 5, risk 5. Recent shipped and in-flight work is concentrated in TextEdit, Calendar, Clock/Settings, Weather, and Photos, so this is visibly distinct from open PR #276 and recent changes.

## Verification

- `node --import tsx --test tests/finder-path.test.ts` — 2/2 passed
- `npm run check` — 57 tests passed, typecheck passed, production build passed; seven pre-existing lint warnings and no errors
- Desktop at 1440×900: both bars begin exactly at the 192px sidebar edge, widths match the content pane, sidebar continues beside the footer, left-aligned path and centered status preserved, no console/page errors
- Mobile at 390×844 CSS px, DPR 3, touch/coarse pointer and hover-none: Browse navigation preserved, no path or status bars, no console errors
- `git diff --check`

## Scope

Micro: six intended files across the feature, with both owner follow-ups contained to one existing Finder file. No dependencies or production data. The change introduces no keyboard shortcuts or key-driven navigation.