### PR TITLE
Add Music song favorites

### DIFF
--- a/components/apps/music/app.tsx
+++ b/components/apps/music/app.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { useMusic } from "@/lib/music/use-music";
 import { useAudio } from "@/lib/music/audio-context";
@@ -11,6 +11,11 @@ import { Sidebar } from "./sidebar";
 import { Nav } from "./nav";
 import { NowPlayingBar } from "./now-playing-bar";
 import { ChevronLeft } from "lucide-react";
+import {
+  MUSIC_FAVORITES_STORAGE_KEY,
+  parseFavoriteSongIds,
+  serializeFavoriteSongIds,
+} from "@/lib/music/favorites";
 import {
   HomeView,
   BrowseView,
@@ -45,6 +50,8 @@ export default function App({ isDesktop = false }: AppProps) {
   const [isLayoutInitialized, setIsLayoutInitialized] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const [showContent, setShowContent] = useState(initialState.showContent);
+  const [favoriteSongIds, setFavoriteSongIds] = useState<Set<string>>(new Set());
+  const [favoritesHydrated, setFavoritesHydrated] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const windowFocus = useWindowFocus();
@@ -60,6 +67,52 @@ export default function App({ isDesktop = false }: AppProps) {
   useEffect(() => {
     saveMusicState(activeView, selectedPlaylistId);
   }, [activeView, selectedPlaylistId]);
+
+  useEffect(() => {
+    try {
+      setFavoriteSongIds(
+        new Set(parseFavoriteSongIds(localStorage.getItem(MUSIC_FAVORITES_STORAGE_KEY)))
+      );
+    } catch {
+      setFavoriteSongIds(new Set());
+    }
+    setFavoritesHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!favoritesHydrated) return;
+    try {
+      localStorage.setItem(
+        MUSIC_FAVORITES_STORAGE_KEY,
+        serializeFavoriteSongIds(favoriteSongIds)
+      );
+    } catch {
+      // Keep favorites usable for the current render when storage is unavailable.
+    }
+  }, [favoriteSongIds, favoritesHydrated]);
+
+  const toggleFavorite = useCallback((trackId: string) => {
+    setFavoriteSongIds((current) => {
+      const next = new Set(current);
+      if (next.has(trackId)) {
+        next.delete(trackId);
+      } else {
+        next.add(trackId);
+      }
+      return next;
+    });
+  }, []);
+
+  const favoritePlaylist = useMemo(
+    () => ({
+      id: "favorite-songs",
+      name: "Favorite Songs",
+      description: "Songs you’ve marked as favorites",
+      coverArt: "",
+      tracks: songs.filter((song) => favoriteSongIds.has(song.id)),
+    }),
+    [favoriteSongIds, songs]
+  );
 
   // Handle view selection
   const handleViewSelect = useCallback((view: MusicView, playlistId?: string) => {
@@ -121,7 +174,9 @@ export default function App({ isDesktop = false }: AppProps) {
 
   // Get selected playlist
   const selectedPlaylist = selectedPlaylistId
-    ? playlists.find((p) => p.id === selectedPlaylistId)
+    ? selectedPlaylistId === favoritePlaylist.id
+      ? favoritePlaylist
+      : playlists.find((p) => p.id === selectedPlaylistId)
     : null;
 
   // Get title and subtitle for mobile header
@@ -176,11 +231,18 @@ export default function App({ isDesktop = false }: AppProps) {
           <SongsView
             songs={songs}
             isMobileView={isMobileView}
+            favoriteSongIds={favoriteSongIds}
+            onToggleFavorite={toggleFavorite}
           />
         );
       case "playlist":
         return selectedPlaylist ? (
-          <PlaylistView playlist={selectedPlaylist} isMobileView={isMobileView} />
+          <PlaylistView
+            playlist={selectedPlaylist}
+            isMobileView={isMobileView}
+            favoriteSongIds={favoriteSongIds}
+            onToggleFavorite={toggleFavorite}
+          />
         ) : (
           <HomeView
             playlists={playlists}
@@ -216,6 +278,7 @@ export default function App({ isDesktop = false }: AppProps) {
         >
           <Sidebar
             playlists={playlists}
+            favoritePlaylist={favoritePlaylist}
             activeView={activeView}
             selectedPlaylistId={selectedPlaylistId}
             onViewSelect={handleViewSelect}

--- a/components/apps/music/content-views/playlist-view.tsx
+++ b/components/apps/music/content-views/playlist-view.tsx
@@ -5,15 +5,23 @@ import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Playlist, PlaylistTrack } from "../types";
 import { useAudio } from "@/lib/music/audio-context";
-import { Play, Pause, Shuffle } from "lucide-react";
+import { Play, Pause, Shuffle, Star } from "lucide-react";
 import { formatDuration, formatTotalDuration } from "@/lib/music/utils";
+import { TrackFavoriteButton } from "../track-favorite-button";
 
 interface PlaylistViewProps {
   playlist: Playlist;
   isMobileView: boolean;
+  favoriteSongIds: Set<string>;
+  onToggleFavorite: (trackId: string) => void;
 }
 
-export function PlaylistView({ playlist, isMobileView }: PlaylistViewProps) {
+export function PlaylistView({
+  playlist,
+  isMobileView,
+  favoriteSongIds,
+  onToggleFavorite,
+}: PlaylistViewProps) {
   const { playbackState, play, pause, resume, toggleShuffle } = useAudio();
 
   const handleTrackPlay = (track: PlaylistTrack) => {
@@ -57,6 +65,7 @@ export function PlaylistView({ playlist, isMobileView }: PlaylistViewProps) {
   };
 
   const totalDuration = playlist.tracks.reduce((sum, t) => sum + t.duration, 0);
+  const hasPlayableTracks = playlist.tracks.some((track) => track.previewUrl);
 
   return (
     <ScrollArea className="h-full">
@@ -104,7 +113,8 @@ export function PlaylistView({ playlist, isMobileView }: PlaylistViewProps) {
             <div className="flex items-center gap-3 mt-4">
               <button
                 onClick={handlePlayAll}
-                className="flex items-center gap-2 px-5 py-2.5 rounded-full bg-red-500 text-white text-sm font-medium hover:bg-red-600 transition-colors"
+                disabled={!hasPlayableTracks}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-full bg-red-500 text-white text-sm font-medium transition-colors can-hover:hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {isPlayingPlaylist ? (
                   <>
@@ -120,7 +130,8 @@ export function PlaylistView({ playlist, isMobileView }: PlaylistViewProps) {
               </button>
               <button
                 onClick={handleShufflePlay}
-                className="p-2.5 rounded-full bg-muted hover:bg-muted/80 transition-colors"
+                disabled={!hasPlayableTracks}
+                className="p-2.5 rounded-full bg-muted transition-colors can-hover:hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-40"
                 title="Shuffle Play"
               >
                 <Shuffle className="w-4 h-4" />
@@ -138,10 +149,18 @@ export function PlaylistView({ playlist, isMobileView }: PlaylistViewProps) {
               <span className="w-10" />
               <span className="flex-1">Title</span>
               <span className="w-[150px]">Album</span>
+              <span className="w-16 text-center">Favorite</span>
               <span className="w-12 text-right">Time</span>
             </div>
           )}
 
+          {playlist.tracks.length === 0 ? (
+            <div className="flex flex-col items-center py-14 text-center text-muted-foreground">
+              <Star className="mb-3 h-8 w-8" />
+              <p className="text-sm font-medium text-foreground">No Favorite Songs</p>
+              <p className="mt-1 text-xs">Favorite a song to see it here.</p>
+            </div>
+          ) : (
           <div className="space-y-1 mt-1">
             {playlist.tracks.map((track, index) => {
               const isCurrentTrack = playbackState.currentTrack?.id === track.id;
@@ -198,6 +217,12 @@ export function PlaylistView({ playlist, isMobileView }: PlaylistViewProps) {
                       {track.album}
                     </span>
                   )}
+                  <TrackFavoriteButton
+                    track={track}
+                    isFavorite={favoriteSongIds.has(track.id)}
+                    isMobileView={isMobileView}
+                    onToggle={onToggleFavorite}
+                  />
                   <span className="text-xs text-muted-foreground w-12 text-right flex-shrink-0">
                     {formatDuration(track.duration)}
                   </span>
@@ -205,6 +230,7 @@ export function PlaylistView({ playlist, isMobileView }: PlaylistViewProps) {
               );
             })}
           </div>
+          )}
         </div>
       </div>
     </ScrollArea>

--- a/components/apps/music/content-views/playlist-view.tsx
+++ b/components/apps/music/content-views/playlist-view.tsx
@@ -149,7 +149,13 @@ export function PlaylistView({
               <span className="w-10" />
               <span className="flex-1">Title</span>
               <span className="w-[150px]">Album</span>
-              <span className="w-16 text-center">Favorite</span>
+              <span
+                aria-label="Favorite"
+                title="Favorite"
+                className="flex w-16 justify-center"
+              >
+                <Star className="h-4 w-4" />
+              </span>
               <span className="w-12 text-right">Time</span>
             </div>
           )}

--- a/components/apps/music/content-views/songs-view.tsx
+++ b/components/apps/music/content-views/songs-view.tsx
@@ -7,13 +7,21 @@ import { PlaylistTrack } from "../types";
 import { useAudio } from "@/lib/music/audio-context";
 import { Play, Pause } from "lucide-react";
 import { formatDuration } from "@/lib/music/utils";
+import { TrackFavoriteButton } from "../track-favorite-button";
 
 interface SongsViewProps {
   songs: PlaylistTrack[];
   isMobileView: boolean;
+  favoriteSongIds: Set<string>;
+  onToggleFavorite: (trackId: string) => void;
 }
 
-export function SongsView({ songs, isMobileView }: SongsViewProps) {
+export function SongsView({
+  songs,
+  isMobileView,
+  favoriteSongIds,
+  onToggleFavorite,
+}: SongsViewProps) {
   const { playbackState, play, pause, resume } = useAudio();
 
   const handleTrackPlay = (track: PlaylistTrack) => {
@@ -42,6 +50,7 @@ export function SongsView({ songs, isMobileView }: SongsViewProps) {
               <span className="w-10" /> {/* Album art space */}
               <span className="flex-1">Title</span>
               <span className="w-[150px]">Album</span>
+              <span className="w-16 text-center">Favorite</span>
               <span className="w-12 text-right">Time</span>
             </div>
           )}
@@ -102,6 +111,12 @@ export function SongsView({ songs, isMobileView }: SongsViewProps) {
                       {track.album}
                     </span>
                   )}
+                  <TrackFavoriteButton
+                    track={track}
+                    isFavorite={favoriteSongIds.has(track.id)}
+                    isMobileView={isMobileView}
+                    onToggle={onToggleFavorite}
+                  />
                   <span className="text-xs text-muted-foreground w-12 text-right flex-shrink-0">
                     {formatDuration(track.duration)}
                   </span>

--- a/components/apps/music/content-views/songs-view.tsx
+++ b/components/apps/music/content-views/songs-view.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { PlaylistTrack } from "../types";
 import { useAudio } from "@/lib/music/audio-context";
-import { Play, Pause } from "lucide-react";
+import { Play, Pause, Star } from "lucide-react";
 import { formatDuration } from "@/lib/music/utils";
 import { TrackFavoriteButton } from "../track-favorite-button";
 
@@ -50,7 +50,13 @@ export function SongsView({
               <span className="w-10" /> {/* Album art space */}
               <span className="flex-1">Title</span>
               <span className="w-[150px]">Album</span>
-              <span className="w-16 text-center">Favorite</span>
+              <span
+                aria-label="Favorite"
+                title="Favorite"
+                className="flex w-16 justify-center"
+              >
+                <Star className="h-4 w-4" />
+              </span>
               <span className="w-12 text-right">Time</span>
             </div>
           )}

--- a/components/apps/music/sidebar.tsx
+++ b/components/apps/music/sidebar.tsx
@@ -3,11 +3,12 @@
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { MusicView, Playlist } from "./types";
-import { Home, Compass, User, Disc3, Music, ListMusic } from "lucide-react";
+import { Home, Compass, User, Disc3, Music, ListMusic, Star } from "lucide-react";
 
 interface SidebarProps {
   children: React.ReactNode;
   playlists: Playlist[];
+  favoritePlaylist: Playlist;
   activeView: MusicView;
   selectedPlaylistId: string | null;
   onViewSelect: (view: MusicView, playlistId?: string) => void;
@@ -18,6 +19,7 @@ interface SidebarProps {
 export function Sidebar({
   children,
   playlists,
+  favoritePlaylist,
   activeView,
   selectedPlaylistId,
   onViewSelect,
@@ -88,11 +90,20 @@ export function Sidebar({
             </div>
 
             {/* Playlists Section */}
-            {playlists.length > 0 && (
+            {(playlists.length > 0 || favoritePlaylist.tracks.length > 0 || selectedPlaylistId === favoritePlaylist.id) && (
               <div>
                 <p className="text-xs text-muted-foreground px-3 py-1 font-semibold uppercase tracking-wide">
                   Playlists
                 </p>
+                {(favoritePlaylist.tracks.length > 0 || selectedPlaylistId === favoritePlaylist.id) && (
+                  <SidebarItem
+                    icon={<Star className="w-4 h-4 fill-current" />}
+                    label={favoritePlaylist.name}
+                    isActive={activeView === "playlist" && selectedPlaylistId === favoritePlaylist.id}
+                    onClick={() => onViewSelect("playlist", favoritePlaylist.id)}
+                    isMobileView={isMobileView}
+                  />
+                )}
                 {playlists.map((playlist) => (
                   <SidebarItem
                     key={playlist.id}

--- a/components/apps/music/track-favorite-button.tsx
+++ b/components/apps/music/track-favorite-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { PlaylistTrack } from "./types";
+
+export function TrackFavoriteButton({
+  track,
+  isFavorite,
+  isMobileView,
+  onToggle,
+}: {
+  track: PlaylistTrack;
+  isFavorite: boolean;
+  isMobileView: boolean;
+  onToggle: (trackId: string) => void;
+}) {
+  const label = isFavorite
+    ? `Undo favorite ${track.name}`
+    : `Favorite ${track.name}`;
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={isFavorite}
+      title={isFavorite ? "Undo Favorite" : "Favorite"}
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggle(track.id);
+      }}
+      className={cn(
+        "flex flex-shrink-0 items-center justify-center rounded-full transition-colors can-hover:hover:bg-muted",
+        isMobileView ? "h-11 w-11" : "h-8 w-16",
+        isFavorite ? "text-red-500" : "text-muted-foreground"
+      )}
+    >
+      <Star className={cn("h-4 w-4", isFavorite && "fill-current")} />
+    </button>
+  );
+}

--- a/components/apps/music/track-favorite-button.tsx
+++ b/components/apps/music/track-favorite-button.tsx
@@ -30,9 +30,11 @@ export function TrackFavoriteButton({
         onToggle(track.id);
       }}
       className={cn(
-        "flex flex-shrink-0 items-center justify-center rounded-full transition-colors can-hover:hover:bg-muted",
+        "flex flex-shrink-0 items-center justify-center rounded-full text-red-500 transition-[color,opacity] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/50",
         isMobileView ? "h-11 w-11" : "h-8 w-16",
-        isFavorite ? "text-red-500" : "text-muted-foreground"
+        !isMobileView &&
+          !isFavorite &&
+          "opacity-0 can-hover:group-hover:opacity-100 focus-visible:opacity-100"
       )}
     >
       <Star className={cn("h-4 w-4", isFavorite && "fill-current")} />

--- a/lib/music/favorites.ts
+++ b/lib/music/favorites.ts
@@ -1,0 +1,18 @@
+export const MUSIC_FAVORITES_STORAGE_KEY = "music-favorite-song-ids";
+
+export function parseFavoriteSongIds(value: string | null): string[] {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+
+    return [...new Set(parsed.filter((id): id is string => typeof id === "string" && id.length > 0))];
+  } catch {
+    return [];
+  }
+}
+
+export function serializeFavoriteSongIds(ids: Iterable<string>): string {
+  return JSON.stringify([...new Set(ids)]);
+}

--- a/tests/music-favorites.test.ts
+++ b/tests/music-favorites.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseFavoriteSongIds,
+  serializeFavoriteSongIds,
+} from "../lib/music/favorites";
+
+test("favorite song ids round-trip without duplicates", () => {
+  const stored = serializeFavoriteSongIds(["hh1", "ec1", "hh1"]);
+  assert.deepEqual(parseFavoriteSongIds(stored), ["hh1", "ec1"]);
+});
+
+test("favorite song ids ignore malformed entries", () => {
+  assert.deepEqual(
+    parseFavoriteSongIds(JSON.stringify(["hh1", 42, "", null, "hh2"])),
+    ["hh1", "hh2"]
+  );
+});
+
+test("favorite song ids recover from invalid storage", () => {
+  assert.deepEqual(parseFavoriteSongIds("not-json"), []);
+  assert.deepEqual(parseFavoriteSongIds(JSON.stringify({ id: "hh1" })), []);
+});


### PR DESCRIPTION
## Today's delight

Music now lets you favorite any song without interrupting playback, then gathers those picks into a durable **Favorite Songs** playlist that behaves like a native library view. This follow-up aligns the Songs and playlist tables with the current macOS Music presentation: a star-only column header, empty unfavorited cells at rest on desktop, and a pink outline star when the row is hovered.

## Baseline and delta

Before this PR, song rows only played or paused tracks and the sidebar exposed a fixed set of playlists. There was no way to mark a song as a favorite or revisit favorites as a collection.

The first implementation added durable favorites but used a **Favorite** text header and kept gray outline stars visible in every desktop row. An owner-supplied screenshot of the current Music app showed the native behavior more precisely. The corrected version now uses:

- a neutral star glyph in the column header;
- blank unfavorited desktop cells until row hover or keyboard focus;
- a pink outline star on hover;
- filled, always-visible stars for favorited songs;
- persistent pink outlines on touch devices, where hover is unavailable.

Favorite Songs still appears under Playlists as soon as the first song is starred, persists across reloads, and supports the existing play, shuffle, queue, and Now Playing flows. Favoriting remains independent of row playback.

## Built result — desktop

<img width="1440" height="900" alt="Music favorite column on desktop with a star header, a filled favorite, a hovered pink outline, and blank resting cells" src="https://github.com/user-attachments/assets/91811f41-adca-47fe-b42a-089b37d1be30" />

The screenshot intentionally captures three desktop states together: an active filled favorite, a hovered unfavorited row with the pink outline, and blank resting cells below it.

## Built result — mobile

<img width="1170" height="2532" alt="Music favorite controls on an iPhone viewport with visible pink outline stars" src="https://github.com/user-attachments/assets/f6e02929-4045-4faa-8e99-21adefab3550" />

Mobile preserves visible favorite controls because coarse pointers have no hover. Each control retains the existing 44×44 CSS-pixel touch target. The verification run used a 390×844 CSS viewport at DPR 3, one touch point, and real coarse-pointer/hover-none emulation.

## macOS inspiration

The owner supplied a current screenshot from the installed Music app showing the star column header and hover-revealed pink outline. Apple’s current [Music User Guide for Mac](https://support.apple.com/guide/music/musf33a29ebf/mac) documents the Favorite control in Songs and the Favorite Songs playlist under Playlists. This implementation follows that native information architecture and the supplied visual behavior while fitting the project’s existing Music table.

## Why this one

The improvement is immediately discoverable when relevant, durable across sessions, and useful without changing playback semantics. The native hover treatment also reduces table noise: desktop rows stay visually quiet until the user expresses intent, while mobile remains fully operable.

## Verification

- Focused favorites tests: **3/3 passed**
- `npm run check`: **passed**
  - lint completed with 7 pre-existing warnings and 0 errors
  - Node suite: **67/67 passed**
  - typecheck passed
  - production build passed
- Desktop behavior:
  - header text count: 0
  - header star count: 1
  - resting unfavorited opacity: 0
  - hovered opacity: 1
  - hovered color: `rgb(239, 68, 68)`
  - favorited resting opacity: 1
  - favorite click did not play the row
  - row click still played
- iPhone behavior:
  - 390×844 CSS viewport, DPR 3
  - `maxTouchPoints: 1`
  - coarse pointer: true
  - hover-none: true
  - resting outline opacity: 1
  - 44×44 touch target
  - favorite click did not play the row
  - row tap still played
- No browser console errors in either surface

## Scope

Overall PR size: **Small** — 7 intended product/test files. The native column correction itself is **Micro**: 3 files, 19 additions, and 5 deletions. No dependencies, production data, secrets, shortcuts, external-service changes, or unrelated files are included.
