### PR TITLE
Messages can mark conversations unread

### DIFF
--- a/components/apps/messages/conversation-context-actions.tsx
+++ b/components/apps/messages/conversation-context-actions.tsx
@@ -5,6 +5,8 @@ import { Slot } from "@radix-ui/react-slot";
 import {
   Bell,
   BellOff,
+  Mail,
+  MailOpen,
   Pin,
   PinOff,
   Trash2,
@@ -36,6 +38,7 @@ import {
   MOBILE_CONVERSATION_LONG_PRESS_DELAY_MS,
 } from "@/lib/messages/mobile-conversation-interactions";
 import type { Conversation } from "@/types/messages";
+import { getConversationReadStateLabel } from "@/lib/messages/read-state";
 
 const MOBILE_CONVERSATION_EXPAND_DURATION_MS = 320;
 
@@ -51,6 +54,7 @@ interface ConversationContextActionsProps {
   isMobileView: boolean;
   children: ReactElement;
   onPinToggle: () => void;
+  onToggleReadState: () => void;
   onToggleAlerts: () => void;
   onDelete: () => void;
   onOpenConversation: () => void;
@@ -65,6 +69,7 @@ function MobileConversationPreview({
   onRestoreFocus,
   onOpenConversation,
   onPinToggle,
+  onToggleReadState,
   onToggleAlerts,
   onDelete,
 }: {
@@ -75,6 +80,7 @@ function MobileConversationPreview({
   onRestoreFocus: () => void;
   onOpenConversation: () => void;
   onPinToggle: () => void;
+  onToggleReadState: () => void;
   onToggleAlerts: () => void;
   onDelete: () => void;
 }) {
@@ -83,6 +89,7 @@ function MobileConversationPreview({
   const displayName = getConversationDisplayName(conversation);
   const previewMessages = getConversationPreviewMessages(conversation);
   const isGroupConversation = conversation.recipients.length > 1;
+  const readStateLabel = getConversationReadStateLabel(conversation);
 
   useEffect(() => {
     if (open) window.getSelection()?.removeAllRanges();
@@ -166,8 +173,8 @@ function MobileConversationPreview({
             Conversation actions for {displayName}
           </DialogPrimitive.Title>
           <DialogPrimitive.Description className="sr-only">
-            Preview or open the conversation, then pin, change alerts, or
-            delete it.
+            Preview or open the conversation, then change its read state, pin,
+            change alerts, or delete it.
           </DialogPrimitive.Description>
 
           <button
@@ -244,6 +251,19 @@ function MobileConversationPreview({
             <div className="mx-5 border-t border-muted-foreground/20" />
             <button
               type="button"
+              onClick={() => runAction(onToggleReadState)}
+              className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
+            >
+              {conversation.unreadCount > 0 ? (
+                <MailOpen className="h-5 w-5 shrink-0" aria-hidden />
+              ) : (
+                <Mail className="h-5 w-5 shrink-0" aria-hidden />
+              )}
+              <span>{readStateLabel}</span>
+            </button>
+            <div className="mx-5 border-t border-muted-foreground/20" />
+            <button
+              type="button"
               onClick={() => runAction(onToggleAlerts)}
               className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
             >
@@ -277,6 +297,7 @@ export function ConversationContextActions({
   isMobileView,
   children,
   onPinToggle,
+  onToggleReadState,
   onToggleAlerts,
   onDelete,
   onOpenConversation,
@@ -409,6 +430,12 @@ export function ConversationContextActions({
         <ContextMenuContent>
           <ContextMenuItem
             className="focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
+            onClick={onToggleReadState}
+          >
+            <span>{getConversationReadStateLabel(conversation)}</span>
+          </ContextMenuItem>
+          <ContextMenuItem
+            className="focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
             onClick={onPinToggle}
           >
             <span>{conversation.pinned ? "Unpin" : "Pin"}</span>
@@ -457,6 +484,7 @@ export function ConversationContextActions({
         onRestoreFocus={restoreFocus}
         onOpenConversation={onOpenConversation}
         onPinToggle={onPinToggle}
+        onToggleReadState={onToggleReadState}
         onToggleAlerts={onToggleAlerts}
         onDelete={onDelete}
       />

--- a/components/apps/messages/conversation-context-actions.tsx
+++ b/components/apps/messages/conversation-context-actions.tsx
@@ -5,7 +5,6 @@ import { Slot } from "@radix-ui/react-slot";
 import {
   Bell,
   BellOff,
-  MessageCircle,
   Pin,
   PinOff,
   Trash2,
@@ -50,10 +49,21 @@ interface TriggerBounds {
 
 function ReadStateMessageIcon() {
   return (
-    <span className="relative h-5 w-5 shrink-0" aria-hidden>
-      <MessageCircle className="h-5 w-5" />
-      <span className="absolute right-0 top-0 h-1.5 w-1.5 rounded-full border border-current bg-background" />
-    </span>
+    <svg
+      viewBox="0 0 24 24"
+      className="h-5 w-5 shrink-0"
+      fill="none"
+      aria-hidden
+    >
+      <path
+        d="M15.7 4.45c-1.2-.36-2.52-.55-3.9-.55-4.86 0-8.4 2.87-8.4 6.67 0 1.62.67 3.1 1.86 4.22l-.82 2.79 3.1-1.17c1.22.49 2.65.76 4.26.76 4.82 0 8.33-2.79 8.33-6.6 0-.89-.19-1.72-.55-2.47"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="19.15" cy="4.8" r="2.7" fill="currentColor" />
+    </svg>
   );
 }
 

--- a/components/apps/messages/conversation-context-actions.tsx
+++ b/components/apps/messages/conversation-context-actions.tsx
@@ -5,8 +5,7 @@ import { Slot } from "@radix-ui/react-slot";
 import {
   Bell,
   BellOff,
-  Mail,
-  MailOpen,
+  MessageCircle,
   Pin,
   PinOff,
   Trash2,
@@ -47,6 +46,15 @@ interface TriggerBounds {
   left: number;
   width: number;
   height: number;
+}
+
+function ReadStateMessageIcon() {
+  return (
+    <span className="relative h-5 w-5 shrink-0" aria-hidden>
+      <MessageCircle className="h-5 w-5" />
+      <span className="absolute right-0 top-0 h-1.5 w-1.5 rounded-full border border-current bg-background" />
+    </span>
+  );
 }
 
 interface ConversationContextActionsProps {
@@ -254,11 +262,7 @@ function MobileConversationPreview({
               onClick={() => runAction(onToggleReadState)}
               className="flex h-14 w-full items-center gap-3 px-5 text-left text-[17px] outline-none active:bg-muted focus-visible:bg-muted"
             >
-              {conversation.unreadCount > 0 ? (
-                <MailOpen className="h-5 w-5 shrink-0" aria-hidden />
-              ) : (
-                <Mail className="h-5 w-5 shrink-0" aria-hidden />
-              )}
+              <ReadStateMessageIcon />
               <span>{readStateLabel}</span>
             </button>
             <div className="mx-5 border-t border-muted-foreground/20" />

--- a/components/apps/messages/conversation-item.tsx
+++ b/components/apps/messages/conversation-item.tsx
@@ -6,6 +6,7 @@ import { SwipeActions } from "./swipe-actions";
 import { ConversationContextActions } from "./conversation-context-actions";
 import { Icons } from "./icons";
 import { useTheme } from "next-themes";
+import { toggleConversationReadState } from "@/lib/messages/read-state";
 
 interface ConversationItemProps {
   conversation: Conversation;
@@ -108,6 +109,12 @@ export const ConversationItem = memo(function ConversationItem({
 
   const handleContextMenuDelete = () => {
     onDeleteConversation(conversation.id);
+  };
+
+  const handleContextMenuToggleReadState = () => {
+    onUpdateConversation(
+      toggleConversationReadState(conversations, conversation.id),
+    );
   };
 
   const handleContextMenuHideAlerts = () => {
@@ -298,6 +305,7 @@ export const ConversationItem = memo(function ConversationItem({
       conversation={conversation}
       isMobileView={Boolean(isMobileView)}
       onPinToggle={handleContextMenuPin}
+      onToggleReadState={handleContextMenuToggleReadState}
       onToggleAlerts={handleContextMenuHideAlerts}
       onDelete={handleContextMenuDelete}
       onOpenConversation={() => onSelectConversation(conversation.id)}

--- a/components/apps/messages/conversation-item.tsx
+++ b/components/apps/messages/conversation-item.tsx
@@ -143,9 +143,14 @@ export const ConversationItem = memo(function ConversationItem({
           : ""
       }`}
     >
-      {conversation.unreadCount > 0 &&
-        activeConversation !== conversation.id && (
-        <div className="absolute left-0.5 w-2.5 h-2.5 bg-[#0A7CFF] rounded-full flex-shrink-0" />
+      {conversation.unreadCount > 0 && (
+        <div
+          className={`absolute left-0.5 h-2.5 w-2.5 flex-shrink-0 rounded-full ${
+            activeConversation === conversation.id && !isMobileView
+              ? "bg-white"
+              : "bg-[#0A7CFF]"
+          }`}
+        />
       )}
       <div className="flex items-center gap-2 w-full px-4">
         <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0 relative">

--- a/components/apps/messages/sidebar.tsx
+++ b/components/apps/messages/sidebar.tsx
@@ -9,6 +9,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { useWindowFocus } from "@/lib/window-focus-context";
 import Image from "next/image";
+import { toggleConversationReadState } from "@/lib/messages/read-state";
 
 interface SidebarProps {
   children: React.ReactNode;
@@ -389,6 +390,14 @@ export function Sidebar({
                                   onUpdateConversation(
                                     updatedConversations,
                                     "mute",
+                                  );
+                                }}
+                                onToggleReadState={() => {
+                                  onUpdateConversation(
+                                    toggleConversationReadState(
+                                      conversations,
+                                      conversation.id,
+                                    ),
                                   );
                                 }}
                                 onDelete={() =>

--- a/components/apps/messages/sidebar.tsx
+++ b/components/apps/messages/sidebar.tsx
@@ -569,9 +569,16 @@ export function Sidebar({
                                     </div>
                                     <div className="w-full text-center">
                                       <div className="relative max-w-full inline-flex justify-center">
-                                        {conversation.unreadCount > 0 &&
-                                          activeConversation !== conversation.id && (
-                                          <div className="absolute right-full mr-1 top-1/2 -translate-y-1/2 w-2.5 h-2.5 bg-[#0A7CFF] rounded-full" />
+                                        {conversation.unreadCount > 0 && (
+                                          <div
+                                            className={`absolute right-full top-1/2 mr-1 h-2.5 w-2.5 -translate-y-1/2 rounded-full ${
+                                              activeConversation ===
+                                                conversation.id &&
+                                              !isMobileView
+                                                ? "bg-white"
+                                                : "bg-[#0A7CFF]"
+                                            }`}
+                                          />
                                         )}
                                         <span className="text-xs truncate max-w-full">
                                           {conversation.name ||

--- a/lib/messages/read-state.ts
+++ b/lib/messages/read-state.ts
@@ -1,0 +1,21 @@
+import type { Conversation } from "@/types/messages";
+
+export function getConversationReadStateLabel(
+  conversation: Pick<Conversation, "unreadCount">,
+): "Mark as Read" | "Mark as Unread" {
+  return conversation.unreadCount > 0 ? "Mark as Read" : "Mark as Unread";
+}
+
+export function toggleConversationReadState(
+  conversations: Conversation[],
+  conversationId: string,
+): Conversation[] {
+  return conversations.map((conversation) =>
+    conversation.id === conversationId
+      ? {
+          ...conversation,
+          unreadCount: conversation.unreadCount > 0 ? 0 : 1,
+        }
+      : conversation,
+  );
+}

--- a/tests/messages-read-state.test.ts
+++ b/tests/messages-read-state.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getConversationReadStateLabel,
+  toggleConversationReadState,
+} from "../lib/messages/read-state";
+import type { Conversation } from "../types/messages";
+
+const conversations: Conversation[] = [
+  {
+    id: "read",
+    recipients: [{ id: "person-1", name: "Ada Lovelace" }],
+    messages: [],
+    lastMessageTime: "2026-08-05T12:00:00.000Z",
+    unreadCount: 0,
+  },
+  {
+    id: "unread",
+    recipients: [{ id: "person-2", name: "Grace Hopper" }],
+    messages: [],
+    lastMessageTime: "2026-08-05T12:01:00.000Z",
+    unreadCount: 3,
+  },
+];
+
+test("labels read-state actions from the current unread count", () => {
+  assert.equal(getConversationReadStateLabel(conversations[0]), "Mark as Unread");
+  assert.equal(getConversationReadStateLabel(conversations[1]), "Mark as Read");
+});
+
+test("marks read conversations unread without mutating adjacent conversations", () => {
+  const updated = toggleConversationReadState(conversations, "read");
+
+  assert.equal(updated[0].unreadCount, 1);
+  assert.equal(updated[1], conversations[1]);
+  assert.equal(conversations[0].unreadCount, 0);
+});
+
+test("marks unread conversations read", () => {
+  const updated = toggleConversationReadState(conversations, "unread");
+
+  assert.equal(updated[1].unreadCount, 0);
+});


### PR DESCRIPTION
## Today's delight

Messages conversations can now be marked unread for later—or marked read again—from the same contextual actions used by macOS Messages. The state persists through the app's existing conversation storage and immediately updates the row indicator and Dock badge.

## Baseline and delta

- **Before:** Messages already supported search, pinned conversations, unread badges, selecting a conversation to clear unread state, and Pin / Hide Alerts / Delete context actions. Marking the selected desktop conversation unread updated its state but hid the row dot until selection moved elsewhere.
- **Now:** Desktop right-click menus add **Mark as Unread / Mark as Read**, and the selected row immediately shows a white unread dot on its blue background. Mobile long-press previews add the same action with the native Messages conversation-bubble-and-dot glyph.
- **Preserved:** Search, selection, conversation opening, unread clearing on open, pinning, alert toggles, deletion, swipe behavior, long-press previews, and blue dots on unselected/mobile rows continue to work.

## Built result — desktop

![Messages selected conversation showing its white unread indicator immediately](https://github.com/user-attachments/assets/fe04b096-672f-415c-912f-04b45df20d09)

At 1440×900, marking the active Jiro Ono / Cedric Grolet conversation unread leaves it selected and immediately renders the native white dot on the blue row. The same treatment was verified for pinned conversations; the Dock badge increments at the same time.

## Built result — mobile

![Messages mobile conversation list preserving blue unread indicators](https://github.com/user-attachments/assets/90174582-9fdb-4282-8b09-ee9f021557b6)

At an iPhone-sized 390×844 viewport with touch and coarse-pointer emulation, unread rows retain their blue 10×10 indicator because mobile has no selected sidebar row. A real emulated touch still opens the conversation and hides the list normally.

## macOS inspiration

Apple's current Messages User Guide for macOS Tahoe documents **Mark as Unread** and **Mark as Read** in the conversation menu and shortcut menu, matching this web app's existing context-action model: [Mark conversations as read or unread in Messages on Mac](https://support.apple.com/en-bh/guide/messages/ichtf9781355/mac).

The selected-row treatment and mobile glyph were corrected against owner-supplied current Messages screenshots. The desktop reference shows a white unread dot on the active blue conversation; the mobile reference shows the low, wide conversation bubble with a compact tail, open upper-right outline, and solid status dot.

## Why this one

Messages had never been a primary daily-delight surface; its last user-visible default-branch touch was 2026-07-30. The two most recent daily surfaces were Music (2026-08-04) and Finder (2026-08-03), so this deliberately returns attention to a neglected registered app. The selected candidate scored 34/35 on the daily-delight rubric.

## Verification

- `npm run check` — lint (0 errors; 7 existing warnings), 70 Node tests, typecheck, and production build all passed
- Focused read-state tests cover labels, toggling, immutability, and adjacent conversations
- Desktop 1440×900: marked active regular and pinned rows unread; both immediately rendered a 10×10 white dot while remaining selected
- Mobile iPhone 390×844 at DPR 3: verified iPhone UA, `maxTouchPoints: 5`, coarse pointer, no hover, blue 10×10 unread dots, and touch-to-open behavior
- Both screenshots are GitHub-hosted attachments captured outside the worktree

## Scope

Small: five Messages/helper/test files, 144 additions and 8 deletions. No new app, token, architecture, external service, shortcut, or production data; no overlap with open PRs.