### PR TITLE
Add a working Preview File menu

### DIFF
--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -582,6 +582,14 @@ function DesktopContent({
     openDocumentAppPicker("textedit");
   }, [openDocumentAppPicker]);
 
+  const handlePreviewOpen = useCallback(() => {
+    openDocumentAppPicker("preview");
+  }, [openDocumentAppPicker]);
+
+  const handlePreviewClose = useCallback((windowId: string) => {
+    closeMultiWindow(windowId);
+  }, [closeMultiWindow]);
+
   const handleTextEditClose = useCallback((windowId: string) => {
     closeMultiWindow(windowId);
   }, [closeMultiWindow]);
@@ -870,6 +878,8 @@ function DesktopContent({
         onTextEditSave={handleTextEditSave}
         onTextEditDuplicate={handleTextEditDuplicate}
         onTextEditRename={handleTextEditRename}
+        onPreviewOpen={handlePreviewOpen}
+        onPreviewClose={handlePreviewClose}
       />
 
       {isActive && (

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -16,6 +16,7 @@ import { FileMenu } from "./file-menu";
 import { FinderViewMenu } from "./finder-view-menu";
 import { TextEditEditMenu } from "./textedit-edit-menu";
 import { TextEditFileMenu, TextEditRenameDialog } from "./textedit-file-menu";
+import { PreviewFileMenu } from "./preview-file-menu";
 import { AboutDialog } from "./about-dialog";
 import { FocusMenu, FOCUS_STATUS_CONFIG } from "./focus-menu";
 import { useFileMenuActions } from "@/lib/file-menu-context";
@@ -28,7 +29,7 @@ import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 import type { FinderViewMode } from "@/components/apps/finder/view-mode";
 import { TEXTEDIT_OPEN_FIND_EVENT } from "@/lib/textedit-find";
 
-type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "finderViewMenu" | "textEditEditMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
+type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "previewFileMenu" | "finderViewMenu" | "textEditEditMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
 
 const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
 
@@ -71,6 +72,8 @@ interface MenuBarProps {
   onTextEditSave?: (windowId: string) => void;
   onTextEditDuplicate?: (windowId: string) => void;
   onTextEditRename?: (windowId: string, fileName: string) => string | null;
+  onPreviewOpen?: () => void;
+  onPreviewClose?: (windowId: string) => void;
 }
 
 export function MenuBar({
@@ -97,6 +100,8 @@ export function MenuBar({
   onTextEditSave,
   onTextEditDuplicate,
   onTextEditRename,
+  onPreviewOpen,
+  onPreviewClose,
 }: MenuBarProps) {
   const fileMenuActions = useFileMenuActions();
   const {
@@ -295,6 +300,19 @@ export function MenuBar({
               className={cn(
                 "rounded px-2 py-0.5 text-sm transition-colors",
                 openMenu === "textEditFileMenu"
+                  ? "bg-blue-500 text-white"
+                  : "text-black can-hover:hover:bg-white/10 dark:text-white"
+              )}
+            >
+              File
+            </button>
+          )}
+          {focusedAppId === "preview" && (
+            <button
+              onClick={() => toggleMenu("previewFileMenu")}
+              className={cn(
+                "rounded px-2 py-0.5 text-sm transition-colors",
+                openMenu === "previewFileMenu"
                   ? "bg-blue-500 text-white"
                   : "text-black can-hover:hover:bg-white/10 dark:text-white"
               )}
@@ -514,6 +532,13 @@ export function MenuBar({
         onDuplicate={() => focusedWindowId && onTextEditDuplicate?.(focusedWindowId)}
         onRename={() => setTextEditRenameOpen(true)}
         renameDisabled={focusedTextEditFilePath.startsWith("/Users/alanagoyal/Projects/")}
+      />
+
+      <PreviewFileMenu
+        isOpen={openMenu === "previewFileMenu"}
+        onClose={closeMenu}
+        onOpen={() => onPreviewOpen?.()}
+        onCloseWindow={() => focusedWindowId && onPreviewClose?.(focusedWindowId)}
       />
 
       <TextEditRenameDialog

--- a/components/desktop/preview-file-menu.tsx
+++ b/components/desktop/preview-file-menu.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useRef } from "react";
+import { FolderOpen, X } from "lucide-react";
+import { useClickOutside } from "@/lib/hooks/use-click-outside";
+
+interface PreviewFileMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onOpen: () => void;
+  onCloseWindow: () => void;
+}
+
+export function PreviewFileMenu({
+  isOpen,
+  onClose,
+  onOpen,
+  onCloseWindow,
+}: PreviewFileMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(menuRef, onClose, isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      data-testid="preview-file-menu"
+      className="absolute left-[120px] top-7 z-[70] w-56 overflow-hidden rounded-xl border border-black/10 bg-white/95 py-1.5 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+    >
+      <button
+        type="button"
+        onClick={() => {
+          onOpen();
+          onClose();
+        }}
+        className="flex w-full items-center gap-3 px-3 py-1.5 text-left text-sm transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+      >
+        <FolderOpen aria-hidden="true" className="h-4 w-4 shrink-0" strokeWidth={1.8} />
+        <span>Open…</span>
+      </button>
+
+      <div className="mx-3 my-1 border-t border-black/10 dark:border-white/10" />
+
+      <button
+        type="button"
+        onClick={() => {
+          onCloseWindow();
+          onClose();
+        }}
+        className="flex w-full items-center gap-3 px-3 py-1.5 text-left text-sm transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+      >
+        <X aria-hidden="true" className="h-4 w-4 shrink-0" strokeWidth={1.8} />
+        <span>Close Window</span>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Today's delight

Preview now has a working **File** menu. **Open…** launches a dedicated Finder window at Desktop without closing the current PDF, and **Close Window** closes only the focused Preview document.

## Baseline and delta

- Before: Preview could display and navigate a PDF, use its traffic-light controls, and expose its existing app menu, but it had no File menu and no route to another document.
- Now: A focused Preview window exposes **File → Open…** and **File → Close Window**.
- Preserved: the current PDF remains open during the Finder handoff; Finder selection and double-click still open Preview documents; multiple Preview windows, PDF controls, traffic lights, URL routing, and the Preview app menu continue to work.

## Built result — desktop

![Desktop screenshot of Preview's working File menu](https://github.com/user-attachments/assets/c9150813-16ae-4a3f-bc17-0097d41bd2b9)

The 1440×900 capture shows the working File menu over an open PDF. Verification covered open/dismiss, the Finder Desktop handoff, original-document persistence, opening a second PDF, focused-window close, and mutual exclusion with the app menu.

## Built result — mobile

![Mobile screenshot of Finder Applications with Preview intentionally unavailable](https://github.com/user-attachments/assets/f6ad0f6f-9088-4504-9baa-b19b94c04c23)

Preview is intentionally desktop-only. At an iPhone 390×844 CSS viewport with DPR 3, an iPhone user agent, five touch points, coarse pointer, and hover-none, a direct Preview URL routed to Finder. A dispatched touch opened Applications, where Preview remains unavailable and the supported mobile apps remain usable.

## macOS inspiration

The installed macOS Preview app's current MainMenu resource contains the exact **File**, **Open**, and **Close Window** commands. Apple's current [Preview User Guide for macOS Tahoe 26](https://support.apple.com/en-ie/guide/preview/prvw81f73d4e/mac) also documents **File → Open**, choosing one or more files, and opening them. This implementation maps those native commands onto the site's existing Finder and focused-window systems.

## Why this one

Preview was a neglected registered app: its last daily delight and last visible touch were both 2026-07-26. The two most recent daily primary surfaces were Messages (2026-08-05) and Music (2026-08-04), so this rotates to a safe, bounded surface without overlapping recent or open work.

## Verification

- `npm run check` — 70 tests, typecheck, production build, seven pre-existing lint warnings, zero errors
- Desktop: 1440×900; File menu open/dismiss, Finder handoff, original PDF persistence, second PDF open, focused-window close, app-menu mutual exclusion, zero visible runtime errors
- Mobile: iPhone 390×844 CSS / 1170×2532 physical at DPR 3; iPhone UA, `maxTouchPoints=5`, coarse pointer, hover-none; direct route fallback and touch-opened Applications verified
- `git diff --check origin/main...HEAD`

## Scope

Micro: three product files, 94 additions and one deletion. The 45-day first-parent daily-delight audit, recent non-delight work, app registry, coverage ledger, and open PRs were reconciled before selection; there was no in-flight overlap.