### PR TITLE
Choose wallpaper from Photos and Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ a macos sierra 10.12 themed desktop with:
 - photo library with grid view and full-screen viewer
 - collections: flowers, food, friends
 - favorites (per-browser, stored in localstorage)
+- set a library photo as the persistent desktop and lock-screen wallpaper
 - time filters (today, this week, this month, this year, all)
 - keyboard navigation (arrow keys, escape to close)
 - upload via ios shortcut with ai auto-categorization

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ a macos sierra 10.12 themed desktop with:
 **settings** - system preferences
 - wi-fi and bluetooth panels
 - appearance (light/dark/system theme)
+- wallpaper picker with theme wallpapers and photos library support
 - menu bar appearance and clock format options
 - airdrop and focus mode toggles
 - about this mac

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -15,6 +15,7 @@ import {
   Heart,
   Info,
   RotateCcwSquare,
+  Share,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useClickOutside } from "@/lib/hooks/use-click-outside";
@@ -53,25 +54,6 @@ import type {
   PhotoNavigationDirection,
   PhotoNavigationSource,
 } from "@/lib/photos/photo-transition";
-
-function PhotosShareIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      aria-hidden="true"
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M12 14.5V2" />
-      <path d="m9 5 3-3 3 3" />
-      <path d="M8.25 7.5H8A2.5 2.5 0 0 0 5.5 10v9A2.5 2.5 0 0 0 8 21.5h8a2.5 2.5 0 0 0 2.5-2.5v-9A2.5 2.5 0 0 0 16 7.5h-.25" />
-    </svg>
-  );
-}
 
 // Preload an image for faster navigation
 function preloadImage(url: string) {
@@ -843,7 +825,7 @@ export function PhotoViewer({
                     : "can-hover:hover:bg-foreground/10",
                 )}
               >
-                <PhotosShareIcon className="-m-px h-[22px] w-[22px]" />
+                <Share aria-hidden="true" className="h-5 w-5" />
               </button>
 
               {isShareOpen && (

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -15,7 +15,6 @@ import {
   Heart,
   Info,
   RotateCcwSquare,
-  SquareArrowUp,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useClickOutside } from "@/lib/hooks/use-click-outside";
@@ -54,6 +53,25 @@ import type {
   PhotoNavigationDirection,
   PhotoNavigationSource,
 } from "@/lib/photos/photo-transition";
+
+function PhotosShareIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 15V3" />
+      <path d="m7.75 7.25 4.25-4.25 4.25 4.25" />
+      <path d="M8 9H6.5A2.5 2.5 0 0 0 4 11.5v6A2.5 2.5 0 0 0 6.5 20h11a2.5 2.5 0 0 0 2.5-2.5v-6A2.5 2.5 0 0 0 17.5 9H16" />
+    </svg>
+  );
+}
 
 // Preload an image for faster navigation
 function preloadImage(url: string) {
@@ -825,7 +843,7 @@ export function PhotoViewer({
                     : "can-hover:hover:bg-foreground/10",
                 )}
               >
-                <SquareArrowUp className="h-5 w-5" />
+                <PhotosShareIcon className="h-5 w-5" />
               </button>
 
               {isShareOpen && (

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -62,13 +62,13 @@ function PhotosShareIcon({ className }: { className?: string }) {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="2"
+      strokeWidth="1.6"
       strokeLinecap="round"
       strokeLinejoin="round"
     >
-      <path d="M12 15V3" />
-      <path d="m7.75 7.25 4.25-4.25 4.25 4.25" />
-      <path d="M8 9H6.5A2.5 2.5 0 0 0 4 11.5v6A2.5 2.5 0 0 0 6.5 20h11a2.5 2.5 0 0 0 2.5-2.5v-6A2.5 2.5 0 0 0 17.5 9H16" />
+      <path d="M12 14.5V2" />
+      <path d="m9 5 3-3 3 3" />
+      <path d="M8.25 7.5H8A2.5 2.5 0 0 0 5.5 10v9A2.5 2.5 0 0 0 8 21.5h8a2.5 2.5 0 0 0 2.5-2.5v-9A2.5 2.5 0 0 0 16 7.5h-.25" />
     </svg>
   );
 }

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -15,6 +15,7 @@ import {
   Heart,
   Info,
   RotateCcwSquare,
+  SquareArrowUp,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useClickOutside } from "@/lib/hooks/use-click-outside";
@@ -23,6 +24,7 @@ import { toZonedTime } from "date-fns-tz";
 import { format, parseISO } from "date-fns";
 import Image from "next/image";
 import { getViewerUrl } from "@/lib/photos/image-utils";
+import { useSystemSettings } from "@/lib/system-settings-context";
 import {
   formatCameraName,
   formatDimensions,
@@ -368,6 +370,7 @@ export function PhotoViewer({
   isDesktop = false,
 }: PhotoViewerProps) {
   const windowFocus = useWindowFocus();
+  const { setWallpaperUrl } = useSystemSettings();
   const inShell = isDesktop && windowFocus;
   const [shouldAnimateRotation, setShouldAnimateRotation] = useState(false);
   const [containerSize, setContainerSize] = useState<{
@@ -379,10 +382,12 @@ export function PhotoViewer({
   const wheelIdleTimerRef = useRef<number | null>(null);
   const reducedMotionRef = useRef(false);
   const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const [isShareOpen, setIsShareOpen] = useState(false);
   const [metadata, setMetadata] = useState<PhotoMetadata | null>(null);
   const [isMetadataLoading, setIsMetadataLoading] = useState(false);
   const [metadataError, setMetadataError] = useState(false);
   const infoContainerRef = useRef<HTMLDivElement>(null);
+  const shareContainerRef = useRef<HTMLDivElement>(null);
   const mobileScrollRef = useRef<HTMLDivElement>(null);
   const wheelGestureStateRef = useRef(createPhotoWheelGestureState());
   // Keep the wheel listener stable while the selected photo changes so the
@@ -400,12 +405,14 @@ export function PhotoViewer({
     onNext,
   };
   const closeInfo = useCallback(() => setIsInfoOpen(false), []);
+  const closeShare = useCallback(() => setIsShareOpen(false), []);
   const rotateLeft = useCallback(() => {
     setShouldAnimateRotation(true);
     onRotate();
   }, [onRotate]);
 
   useClickOutside(infoContainerRef, closeInfo, isInfoOpen);
+  useClickOutside(shareContainerRef, closeShare, isShareOpen);
 
   useEffect(() => {
     const media = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -584,6 +591,7 @@ export function PhotoViewer({
   useEffect(() => {
     mobileScrollRef.current?.scrollTo({ top: 0 });
     setShouldAnimateRotation(false);
+    setIsShareOpen(false);
   }, [photo.id]);
 
   // Swipe handlers for mobile navigation and direct gesture tracking
@@ -703,7 +711,10 @@ export function PhotoViewer({
                 aria-label={isInfoOpen ? "Hide photo information" : "Show photo information"}
                 aria-expanded={isInfoOpen}
                 aria-controls="photo-info-panel"
-                onClick={() => setIsInfoOpen((open) => !open)}
+                onClick={() => {
+                  setIsInfoOpen((open) => !open);
+                  closeShare();
+                }}
                 className={cn(
                   "rounded-md p-1 text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]",
                   isInfoOpen
@@ -787,6 +798,54 @@ export function PhotoViewer({
                     </dl>
                   </div>
                 </aside>
+              )}
+            </div>
+          )}
+
+          {!isMobileView && (
+            <div
+              ref={shareContainerRef}
+              className="relative"
+              onMouseDown={(event) => event.stopPropagation()}
+            >
+              <button
+                type="button"
+                aria-label="Share photo"
+                aria-haspopup="menu"
+                aria-expanded={isShareOpen}
+                aria-controls="photo-share-menu"
+                onClick={() => {
+                  setIsShareOpen((open) => !open);
+                  closeInfo();
+                }}
+                className={cn(
+                  "rounded-md p-1 text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]",
+                  isShareOpen
+                    ? "bg-foreground/10"
+                    : "can-hover:hover:bg-foreground/10",
+                )}
+              >
+                <SquareArrowUp className="h-5 w-5" />
+              </button>
+
+              {isShareOpen && (
+                <div
+                  id="photo-share-menu"
+                  role="menu"
+                  className="absolute right-0 top-[calc(100%+8px)] z-20 w-max min-w-44 rounded-lg border border-black/10 bg-white/95 p-1 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setWallpaperUrl(photo.url);
+                      closeShare();
+                    }}
+                    className="flex w-full items-center rounded px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white focus-visible:bg-[#0A7CFF] focus-visible:text-white focus-visible:outline-none"
+                  >
+                    Set as Wallpaper
+                  </button>
+                </div>
               )}
             </div>
           )}

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -843,7 +843,7 @@ export function PhotoViewer({
                     : "can-hover:hover:bg-foreground/10",
                 )}
               >
-                <PhotosShareIcon className="h-5 w-5" />
+                <PhotosShareIcon className="-m-px h-[22px] w-[22px]" />
               </button>
 
               {isShareOpen && (

--- a/components/apps/settings/content.tsx
+++ b/components/apps/settings/content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Settings, Paintbrush, Bluetooth, Wifi, Moon, PanelTop } from "lucide-react";
+import { Settings, Paintbrush, Bluetooth, Wifi, Moon, PanelTop, ImageIcon } from "lucide-react";
 import { SettingsCategory, SettingsPanel } from "./settings-app";
 import { GeneralPanel } from "./panels/general";
 import { AboutPanel } from "./panels/about";
@@ -11,6 +11,7 @@ import { WifiPanel } from "./panels/wifi";
 import { StoragePanel } from "./panels/storage";
 import { FocusPanel } from "./panels/focus";
 import { MenuBarPanel } from "./panels/menu-bar";
+import { WallpaperPanel } from "./panels/wallpaper";
 import { cn } from "@/lib/utils";
 
 interface ContentProps {
@@ -39,6 +40,12 @@ const categoryInfo: Record<
     title: "Appearance",
     description: "Customize the look and feel of your Mac.",
     iconBg: "bg-blue-500",
+  },
+  wallpaper: {
+    icon: <ImageIcon className="w-8 h-8" />,
+    title: "Wallpaper",
+    description: "Choose a theme wallpaper or use a photo from your library.",
+    iconBg: "bg-gradient-to-b from-cyan-400 to-blue-500",
   },
   wifi: {
     icon: <Wifi className="w-8 h-8" />,
@@ -119,6 +126,14 @@ export function Content({
     return (
       <div className="flex-1 overflow-y-auto bg-background">
         <MenuBarPanel />
+      </div>
+    );
+  }
+
+  if (selectedCategory === "wallpaper") {
+    return (
+      <div className={cn("flex-1 overflow-y-auto", isMobile ? "bg-muted/30" : "bg-background")}>
+        <WallpaperPanel isMobile={isMobile} />
       </div>
     );
   }

--- a/components/apps/settings/panels/wallpaper.tsx
+++ b/components/apps/settings/panels/wallpaper.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Check, ImagePlus, LoaderCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getThumbnailPath, getWallpaperPath, OS_VERSIONS } from "@/lib/os-versions";
+import { getOptimizedImageUrl } from "@/lib/photos/image-utils";
 import { usePhotos } from "@/lib/photos/use-photos";
 import { useSystemSettings } from "@/lib/system-settings-context";
 
@@ -18,7 +19,13 @@ interface WallpaperPanelProps {
 export function WallpaperPanel({ isMobile = false }: WallpaperPanelProps) {
   const { osVersionId, wallpaperUrl, setWallpaperUrl } = useSystemSettings();
   const [isPhotoPickerOpen, setIsPhotoPickerOpen] = useState(false);
+  const [dialogContainer, setDialogContainer] = useState<HTMLElement | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const { photos, loading, error } = usePhotos({ enabled: isPhotoPickerOpen });
+
+  useEffect(() => {
+    setDialogContainer(panelRef.current?.closest<HTMLElement>("[data-app='settings']") ?? null);
+  }, []);
 
   const orderedPhotos = useMemo(
     () => [...photos].sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp)),
@@ -37,6 +44,7 @@ export function WallpaperPanel({ isMobile = false }: WallpaperPanelProps) {
 
   return (
     <div
+      ref={panelRef}
       className={cn(
         "mx-auto w-full max-w-5xl",
         isMobile ? "space-y-7 px-4 py-5 pb-10" : "space-y-8 p-6 pb-10"
@@ -152,16 +160,16 @@ export function WallpaperPanel({ isMobile = false }: WallpaperPanelProps) {
       </section>
 
       <Dialog.Root open={isPhotoPickerOpen} onOpenChange={setIsPhotoPickerOpen}>
-        <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 z-[95] bg-black/35 backdrop-blur-[2px]" />
+        <Dialog.Portal container={dialogContainer ?? undefined}>
+          <Dialog.Overlay className="absolute inset-0 z-[95] bg-black/35 backdrop-blur-[2px]" />
           <Dialog.Content
             id="wallpaper-photo-picker"
             data-testid="photo-wallpaper-picker"
             className={cn(
-              "fixed left-1/2 top-1/2 z-[96] flex -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden border border-black/10 bg-background/95 shadow-2xl backdrop-blur-2xl focus:outline-none dark:border-white/15",
+              "absolute left-1/2 top-1/2 z-[96] flex -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden border border-black/10 bg-background/95 shadow-2xl backdrop-blur-2xl focus:outline-none dark:border-white/15",
               isMobile
-                ? "h-[min(720px,calc(100dvh-24px))] w-[calc(100vw-24px)] rounded-[22px]"
-                : "h-[min(510px,calc(100vh-90px))] w-[min(600px,calc(100vw-90px))] rounded-[26px]"
+                ? "h-[calc(100%_-_24px)] max-h-[720px] w-[calc(100%_-_24px)] rounded-[22px]"
+                : "h-[min(440px,calc(100%_-_48px))] w-[min(560px,calc(100%_-_64px))] rounded-[24px]"
             )}
           >
             <div className={cn("border-b border-border/70 text-center", isMobile ? "px-4 py-3.5" : "px-6 py-4")}>
@@ -202,11 +210,13 @@ export function WallpaperPanel({ isMobile = false }: WallpaperPanelProps) {
                       className="relative aspect-square overflow-hidden rounded-lg bg-muted transition-shadow can-hover:hover:ring-2 can-hover:hover:ring-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
                     >
                       <Image
-                        src={photo.url}
+                        src={getOptimizedImageUrl(photo.url, 240, 70)}
                         alt=""
                         fill
                         sizes={isMobile ? "28vw" : "120px"}
                         className="object-cover transition-transform can-hover:hover:scale-105"
+                        decoding="async"
+                        loading="eager"
                         unoptimized
                       />
                     </button>

--- a/components/apps/settings/panels/wallpaper.tsx
+++ b/components/apps/settings/panels/wallpaper.tsx
@@ -161,7 +161,7 @@ export function WallpaperPanel({ isMobile = false }: WallpaperPanelProps) {
               "fixed left-1/2 top-1/2 z-[96] flex -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden border border-black/10 bg-background/95 shadow-2xl backdrop-blur-2xl focus:outline-none dark:border-white/15",
               isMobile
                 ? "h-[min(720px,calc(100dvh-24px))] w-[calc(100vw-24px)] rounded-[22px]"
-                : "h-[min(600px,calc(100vh-48px))] w-[min(720px,calc(100vw-48px))] rounded-[26px]"
+                : "h-[min(510px,calc(100vh-90px))] w-[min(600px,calc(100vw-90px))] rounded-[26px]"
             )}
           >
             <div className={cn("border-b border-border/70 text-center", isMobile ? "px-4 py-3.5" : "px-6 py-4")}>

--- a/components/apps/settings/panels/wallpaper.tsx
+++ b/components/apps/settings/panels/wallpaper.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo, useState } from "react";
 import Image from "next/image";
-import { Check, ImagePlus, LoaderCircle, X } from "lucide-react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Check, ImagePlus, LoaderCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getThumbnailPath, getWallpaperPath, OS_VERSIONS } from "@/lib/os-versions";
 import { usePhotos } from "@/lib/photos/use-photos";
@@ -139,63 +140,94 @@ export function WallpaperPanel({ isMobile = false }: WallpaperPanelProps) {
           <button
             type="button"
             aria-expanded={isPhotoPickerOpen}
+            aria-haspopup="dialog"
             aria-controls="wallpaper-photo-picker"
-            onClick={() => setIsPhotoPickerOpen((open) => !open)}
+            onClick={() => setIsPhotoPickerOpen(true)}
             className="flex aspect-[4/3] w-[150px] flex-col items-center justify-center gap-2 rounded-lg border border-border/70 bg-muted/60 text-muted-foreground transition-colors can-hover:hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
           >
-            {isPhotoPickerOpen ? <X className="h-7 w-7" /> : <ImagePlus className="h-8 w-8" />}
-            <span className="text-sm font-medium">{isPhotoPickerOpen ? "Close Photos" : "Add from Photos…"}</span>
+            <ImagePlus className="h-8 w-8" />
+            <span className="text-sm font-medium">Add from Photos…</span>
           </button>
         </div>
+      </section>
 
-        {isPhotoPickerOpen && (
-          <div
+      <Dialog.Root open={isPhotoPickerOpen} onOpenChange={setIsPhotoPickerOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-[95] bg-black/35 backdrop-blur-[2px]" />
+          <Dialog.Content
             id="wallpaper-photo-picker"
             data-testid="photo-wallpaper-picker"
-            className="mt-4 rounded-xl border border-border/70 bg-muted/30 p-3"
+            className={cn(
+              "fixed left-1/2 top-1/2 z-[96] flex -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden border border-black/10 bg-background/95 shadow-2xl backdrop-blur-2xl focus:outline-none dark:border-white/15",
+              isMobile
+                ? "h-[min(720px,calc(100dvh-24px))] w-[calc(100vw-24px)] rounded-[22px]"
+                : "h-[min(600px,calc(100vh-48px))] w-[min(720px,calc(100vw-48px))] rounded-[26px]"
+            )}
           >
-            {loading && (
-              <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
-                <LoaderCircle className="h-4 w-4 animate-spin" />
-                Loading Photos…
-              </div>
-            )}
-            {!loading && error && (
-              <p role="alert" className="py-10 text-center text-sm text-muted-foreground">
-                Photos couldn’t be loaded. Try again in a moment.
-              </p>
-            )}
-            {!loading && !error && orderedPhotos.length === 0 && (
-              <p className="py-10 text-center text-sm text-muted-foreground">No photos available.</p>
-            )}
-            {!loading && !error && orderedPhotos.length > 0 && (
-              <div className={cn("grid max-h-[360px] gap-1.5 overflow-y-auto", isMobile ? "grid-cols-3" : "grid-cols-5")}>
-                {orderedPhotos.map((photo) => (
-                  <button
-                    key={photo.id}
-                    type="button"
-                    aria-label={`Use ${photo.filename} as wallpaper`}
-                    onClick={() => {
-                      setWallpaperUrl(photo.url);
-                      setIsPhotoPickerOpen(false);
-                    }}
-                    className="relative aspect-square overflow-hidden rounded-md bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
-                  >
-                    <Image
-                      src={photo.url}
-                      alt=""
-                      fill
-                      sizes={isMobile ? "28vw" : "110px"}
-                      className="object-cover transition-transform can-hover:hover:scale-105"
-                      unoptimized
-                    />
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      </section>
+            <div className={cn("border-b border-border/70 text-center", isMobile ? "px-4 py-3.5" : "px-6 py-4")}>
+              <Dialog.Title className="text-lg font-semibold">Choose a Photo</Dialog.Title>
+              <Dialog.Description className="sr-only">
+                Select a photo to use as the desktop and lock-screen wallpaper.
+              </Dialog.Description>
+            </div>
+
+            <div className={cn("min-h-0 flex-1 overflow-y-auto", isMobile ? "p-3" : "p-5")}>
+              {loading && (
+                <div className="flex h-full min-h-40 items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                  Loading Photos…
+                </div>
+              )}
+              {!loading && error && (
+                <p role="alert" className="flex h-full min-h-40 items-center justify-center text-center text-sm text-muted-foreground">
+                  Photos couldn’t be loaded. Try again in a moment.
+                </p>
+              )}
+              {!loading && !error && orderedPhotos.length === 0 && (
+                <p className="flex h-full min-h-40 items-center justify-center text-center text-sm text-muted-foreground">
+                  No photos available.
+                </p>
+              )}
+              {!loading && !error && orderedPhotos.length > 0 && (
+                <div className={cn("grid gap-2", isMobile ? "grid-cols-3" : "grid-cols-5")}>
+                  {orderedPhotos.map((photo) => (
+                    <button
+                      key={photo.id}
+                      type="button"
+                      aria-label={`Use ${photo.filename} as wallpaper`}
+                      onClick={() => {
+                        setWallpaperUrl(photo.url);
+                        setIsPhotoPickerOpen(false);
+                      }}
+                      className="relative aspect-square overflow-hidden rounded-lg bg-muted transition-shadow can-hover:hover:ring-2 can-hover:hover:ring-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
+                    >
+                      <Image
+                        src={photo.url}
+                        alt=""
+                        fill
+                        sizes={isMobile ? "28vw" : "120px"}
+                        className="object-cover transition-transform can-hover:hover:scale-105"
+                        unoptimized
+                      />
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className={cn("flex justify-end border-t border-border/70", isMobile ? "p-3" : "px-5 py-3.5")}>
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="rounded-full border border-border bg-muted/70 px-5 py-2 text-sm font-semibold transition-colors can-hover:hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/components/apps/settings/panels/wallpaper.tsx
+++ b/components/apps/settings/panels/wallpaper.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Image from "next/image";
+import { Check, ImagePlus, LoaderCircle, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getThumbnailPath, getWallpaperPath, OS_VERSIONS } from "@/lib/os-versions";
+import { usePhotos } from "@/lib/photos/use-photos";
+import { useSystemSettings } from "@/lib/system-settings-context";
+
+const THEME_WALLPAPERS = [...OS_VERSIONS].reverse();
+
+interface WallpaperPanelProps {
+  isMobile?: boolean;
+}
+
+export function WallpaperPanel({ isMobile = false }: WallpaperPanelProps) {
+  const { osVersionId, wallpaperUrl, setWallpaperUrl } = useSystemSettings();
+  const [isPhotoPickerOpen, setIsPhotoPickerOpen] = useState(false);
+  const { photos, loading, error } = usePhotos({ enabled: isPhotoPickerOpen });
+
+  const orderedPhotos = useMemo(
+    () => [...photos].sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp)),
+    [photos]
+  );
+  const selectedThemeId = THEME_WALLPAPERS.find((os) =>
+    wallpaperUrl ? getWallpaperPath(os.id) === wallpaperUrl : os.id === osVersionId
+  )?.id;
+  const isPhotoWallpaper = Boolean(wallpaperUrl && !selectedThemeId);
+  const activeWallpaperUrl = wallpaperUrl ?? getWallpaperPath(osVersionId);
+  const activeTheme = THEME_WALLPAPERS.find((os) => os.id === selectedThemeId);
+
+  const selectThemeWallpaper = (osId: string) => {
+    setWallpaperUrl(osId === osVersionId ? null : getWallpaperPath(osId));
+  };
+
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full max-w-5xl",
+        isMobile ? "space-y-7 px-4 py-5 pb-10" : "space-y-8 p-6 pb-10"
+      )}
+      data-testid="settings-wallpaper-panel"
+    >
+      {isMobile && <h1 className="text-2xl font-bold">Wallpaper</h1>}
+
+      <section className={cn("grid gap-5", !isMobile && "grid-cols-[minmax(220px,0.9fr)_minmax(250px,1.1fr)] items-center")}>
+        <div className="relative aspect-[8/5] overflow-hidden rounded-xl border border-border/70 bg-muted shadow-sm">
+          <Image
+            src={activeWallpaperUrl}
+            alt="Current wallpaper"
+            fill
+            priority
+            sizes={isMobile ? "calc(100vw - 32px)" : "420px"}
+            className="object-cover"
+            unoptimized
+          />
+        </div>
+        <div className={cn("rounded-2xl bg-muted/50", isMobile ? "p-4" : "p-5")}>
+          <p className="text-sm text-muted-foreground">Current wallpaper</p>
+          <h2 className="mt-1 text-xl font-semibold">
+            {isPhotoWallpaper ? "From Photos" : activeTheme?.name ?? "Theme wallpaper"}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This wallpaper appears on both the desktop and lock screen.
+          </p>
+        </div>
+      </section>
+
+      <section aria-labelledby="theme-wallpapers-heading">
+        <h2 id="theme-wallpapers-heading" className="mb-3 text-base font-semibold">
+          Theme Wallpapers
+        </h2>
+        <div className={cn(isMobile ? "grid grid-cols-2 gap-x-3 gap-y-5" : "flex gap-4 overflow-x-auto pb-3")}>
+          {THEME_WALLPAPERS.map((os) => {
+            const isSelected = selectedThemeId === os.id;
+            return (
+              <button
+                key={os.id}
+                type="button"
+                aria-label={`Use ${os.name} wallpaper`}
+                aria-pressed={isSelected}
+                onClick={() => selectThemeWallpaper(os.id)}
+                className={cn("group text-left focus-visible:outline-none", !isMobile && "w-[140px] shrink-0")}
+              >
+                <span
+                  className={cn(
+                    "relative block aspect-[8/5] overflow-hidden rounded-lg border bg-muted transition-shadow",
+                    isSelected
+                      ? "border-[#0A7CFF] ring-2 ring-[#0A7CFF] ring-offset-2 ring-offset-background"
+                      : "border-border/70 can-hover:group-hover:ring-2 can-hover:group-hover:ring-foreground/15"
+                  )}
+                >
+                  <Image
+                    src={getThumbnailPath(os.id)}
+                    alt=""
+                    fill
+                    sizes={isMobile ? "42vw" : "190px"}
+                    className="object-cover"
+                    unoptimized
+                  />
+                  {isSelected && (
+                    <span className="absolute bottom-2 right-2 flex h-5 w-5 items-center justify-center rounded-full bg-[#0A7CFF] shadow-sm">
+                      <Check className="h-3.5 w-3.5 text-white" strokeWidth={3} />
+                    </span>
+                  )}
+                </span>
+                <span className="mt-2 block truncate text-center text-sm font-medium">{os.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section aria-labelledby="your-photos-heading">
+        <h2 id="your-photos-heading" className="mb-3 text-base font-semibold">
+          Your Photos
+        </h2>
+        <div className="flex flex-wrap gap-3">
+          {isPhotoWallpaper && (
+            <div className="w-[150px]">
+              <div className="relative aspect-[4/3] overflow-hidden rounded-lg border border-[#0A7CFF] ring-2 ring-[#0A7CFF] ring-offset-2 ring-offset-background">
+                <Image
+                  src={activeWallpaperUrl}
+                  alt="Selected photo wallpaper"
+                  fill
+                  sizes="150px"
+                  className="object-cover"
+                  unoptimized
+                />
+                <span className="absolute bottom-2 right-2 flex h-5 w-5 items-center justify-center rounded-full bg-[#0A7CFF] shadow-sm">
+                  <Check className="h-3.5 w-3.5 text-white" strokeWidth={3} />
+                </span>
+              </div>
+              <span className="mt-2 block text-center text-sm font-medium">From Photos</span>
+            </div>
+          )}
+
+          <button
+            type="button"
+            aria-expanded={isPhotoPickerOpen}
+            aria-controls="wallpaper-photo-picker"
+            onClick={() => setIsPhotoPickerOpen((open) => !open)}
+            className="flex aspect-[4/3] w-[150px] flex-col items-center justify-center gap-2 rounded-lg border border-border/70 bg-muted/60 text-muted-foreground transition-colors can-hover:hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
+          >
+            {isPhotoPickerOpen ? <X className="h-7 w-7" /> : <ImagePlus className="h-8 w-8" />}
+            <span className="text-sm font-medium">{isPhotoPickerOpen ? "Close Photos" : "Add from Photos…"}</span>
+          </button>
+        </div>
+
+        {isPhotoPickerOpen && (
+          <div
+            id="wallpaper-photo-picker"
+            data-testid="photo-wallpaper-picker"
+            className="mt-4 rounded-xl border border-border/70 bg-muted/30 p-3"
+          >
+            {loading && (
+              <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+                Loading Photos…
+              </div>
+            )}
+            {!loading && error && (
+              <p role="alert" className="py-10 text-center text-sm text-muted-foreground">
+                Photos couldn’t be loaded. Try again in a moment.
+              </p>
+            )}
+            {!loading && !error && orderedPhotos.length === 0 && (
+              <p className="py-10 text-center text-sm text-muted-foreground">No photos available.</p>
+            )}
+            {!loading && !error && orderedPhotos.length > 0 && (
+              <div className={cn("grid max-h-[360px] gap-1.5 overflow-y-auto", isMobile ? "grid-cols-3" : "grid-cols-5")}>
+                {orderedPhotos.map((photo) => (
+                  <button
+                    key={photo.id}
+                    type="button"
+                    aria-label={`Use ${photo.filename} as wallpaper`}
+                    onClick={() => {
+                      setWallpaperUrl(photo.url);
+                      setIsPhotoPickerOpen(false);
+                    }}
+                    className="relative aspect-square overflow-hidden rounded-md bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
+                  >
+                    <Image
+                      src={photo.url}
+                      alt=""
+                      fill
+                      sizes={isMobile ? "28vw" : "110px"}
+                      className="object-cover transition-transform can-hover:hover:scale-105"
+                      unoptimized
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/components/apps/settings/panels/wallpaper.tsx
+++ b/components/apps/settings/panels/wallpaper.tsx
@@ -116,7 +116,7 @@ export function WallpaperPanel({ isMobile = false }: WallpaperPanelProps) {
         <h2 id="your-photos-heading" className="mb-3 text-base font-semibold">
           Your Photos
         </h2>
-        <div className="flex flex-wrap gap-3">
+        <div className="flex flex-wrap items-start gap-3">
           {isPhotoWallpaper && (
             <div className="w-[150px]">
               <div className="relative aspect-[4/3] overflow-hidden rounded-lg border border-[#0A7CFF] ring-2 ring-[#0A7CFF] ring-offset-2 ring-offset-background">

--- a/components/apps/settings/settings-app.tsx
+++ b/components/apps/settings/settings-app.tsx
@@ -22,14 +22,24 @@ interface SettingsAppProps {
   navigationRequestId?: number;
 }
 
+function categoryForPlatform(category: SettingsCategory, isMobile: boolean): SettingsCategory {
+  return isMobile && category === "wallpaper" ? "general" : category;
+}
+
 export function SettingsApp({ isMobile = false, inShell = false, initialPanel, initialCategory, navigationRequestId }: SettingsAppProps) {
   // Load persisted state (props take precedence if provided)
   const getInitialState = (): HistoryEntry => {
     if (initialCategory || initialPanel) {
-      return { category: initialCategory || "general", panel: initialPanel || null };
+      return {
+        category: categoryForPlatform(initialCategory || "general", isMobile),
+        panel: initialPanel || null,
+      };
     }
     const saved = loadSettingsState();
-    return { category: saved.category, panel: saved.panel };
+    return {
+      category: categoryForPlatform(saved.category, isMobile),
+      panel: saved.panel,
+    };
   };
 
   const [history, setHistory] = useState<HistoryEntry[]>(() => [getInitialState()]);
@@ -39,10 +49,13 @@ export function SettingsApp({ isMobile = false, inShell = false, initialPanel, i
   // Handle initialPanel/initialCategory changes (e.g., from menu bar)
   useEffect(() => {
     if (initialPanel || initialCategory) {
-      setHistory([{ category: initialCategory || "general", panel: initialPanel || null }]);
+      setHistory([{
+        category: categoryForPlatform(initialCategory || "general", isMobile),
+        panel: initialPanel || null,
+      }]);
       setHistoryIndex(0);
     }
-  }, [initialPanel, initialCategory, navigationRequestId]);
+  }, [initialPanel, initialCategory, navigationRequestId, isMobile]);
   const [showSidebar, setShowSidebar] = useState(true);
 
   // Persist settings state
@@ -66,7 +79,7 @@ export function SettingsApp({ isMobile = false, inShell = false, initialPanel, i
   }, [history, historyIndex]);
 
   const handleCategorySelect = (category: SettingsCategory, options?: { scrollToOSVersion?: boolean }) => {
-    navigate(category, null);
+    navigate(categoryForPlatform(category, isMobile), null);
     if (options?.scrollToOSVersion) {
       setScrollToOSVersion(true);
     }

--- a/components/apps/settings/settings-app.tsx
+++ b/components/apps/settings/settings-app.tsx
@@ -154,7 +154,7 @@ export function SettingsApp({ isMobile = false, inShell = false, initialPanel, i
 
   if (isMobile) {
     return (
-      <div className="h-full flex flex-col bg-background" data-app="settings">
+      <div className="relative flex h-full flex-col overflow-hidden bg-background" data-app="settings">
         {showSidebar ? (
           <Sidebar
             selectedCategory={selectedCategory}
@@ -193,7 +193,7 @@ export function SettingsApp({ isMobile = false, inShell = false, initialPanel, i
   }
 
   return (
-    <div className="h-full flex flex-col bg-background" data-app="settings">
+    <div className="relative flex h-full flex-col overflow-hidden bg-background" data-app="settings">
       <div className="flex flex-1 overflow-hidden">
         <Sidebar
           selectedCategory={selectedCategory}

--- a/components/apps/settings/settings-app.tsx
+++ b/components/apps/settings/settings-app.tsx
@@ -6,7 +6,7 @@ import { Sidebar } from "./sidebar";
 import { Content } from "./content";
 import { loadSettingsState, saveSettingsState } from "@/lib/sidebar-persistence";
 
-export type SettingsCategory = "general" | "appearance" | "wifi" | "bluetooth" | "focus" | "menu-bar";
+export type SettingsCategory = "general" | "appearance" | "wallpaper" | "wifi" | "bluetooth" | "focus" | "menu-bar";
 export type SettingsPanel = "about" | "personal-info" | "storage" | null;
 
 interface HistoryEntry {
@@ -131,6 +131,7 @@ export function SettingsApp({ isMobile = false, inShell = false, initialPanel, i
     if (!isMobile) {
       if (selectedCategory === "general") return "General";
       if (selectedCategory === "appearance") return "Appearance";
+      if (selectedCategory === "wallpaper") return "Wallpaper";
       if (selectedCategory === "wifi") return "Wi-Fi";
       if (selectedCategory === "bluetooth") return "Bluetooth";
       if (selectedCategory === "focus") return "Focus";

--- a/components/apps/settings/sidebar.tsx
+++ b/components/apps/settings/sidebar.tsx
@@ -55,6 +55,7 @@ const categories: { id: SettingsCategory; name: string; icon: React.ReactNode; i
     icon: <ImageIcon className="w-5 h-5 text-white" />,
     iconBg: "bg-gradient-to-b from-cyan-400 to-blue-500",
     keywords: ["wallpaper", "background", "desktop", "photo", "photos", "theme"],
+    desktopOnly: true,
   },
   {
     id: "menu-bar",

--- a/components/apps/settings/sidebar.tsx
+++ b/components/apps/settings/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { Settings, Paintbrush, Search, X, ChevronRight, Plane, Wifi, Bluetooth, Radio, Link2, Battery, Moon, PanelTop } from "lucide-react";
+import { Settings, Paintbrush, Search, X, ChevronRight, Plane, Wifi, Bluetooth, Radio, Link2, Battery, Moon, PanelTop, ImageIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettingsSwitch } from "./settings-switch";
 import { SettingsCategory, SettingsPanel } from "./settings-app";
@@ -48,6 +48,13 @@ const categories: { id: SettingsCategory; name: string; icon: React.ReactNode; i
     icon: <Paintbrush className="w-5 h-5 text-white" />,
     iconBg: "bg-blue-500",
     keywords: ["light", "dark", "auto", "theme", "mode"],
+  },
+  {
+    id: "wallpaper",
+    name: "Wallpaper",
+    icon: <ImageIcon className="w-5 h-5 text-white" />,
+    iconBg: "bg-gradient-to-b from-cyan-400 to-blue-500",
+    keywords: ["wallpaper", "background", "desktop", "photo", "photos", "theme"],
   },
   {
     id: "menu-bar",

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -213,7 +213,7 @@ function DesktopContent({
     updateWindowMetadata,
     getWindowsByApp,
   } = useWindowManager();
-  const { focusMode, currentOS } = useSystemSettings();
+  const { focusMode, currentOS, wallpaperUrl } = useSystemSettings();
   const { addRecent, renameRecent, touchRecent } = useRecents();
 
   const [mode, setMode] = useState<DesktopMode>("active");
@@ -839,7 +839,7 @@ function DesktopContent({
   return (
     <div className="fixed inset-0" data-shell="desktop">
       <Image
-        src={getWallpaperPath(currentOS.id)}
+        src={wallpaperUrl ?? getWallpaperPath(currentOS.id)}
         alt="Desktop wallpaper"
         fill
         className="object-cover -z-10"

--- a/components/desktop/lock-screen.tsx
+++ b/components/desktop/lock-screen.tsx
@@ -10,7 +10,7 @@ interface LockScreenProps {
 }
 
 export function LockScreen({ onUnlock }: LockScreenProps) {
-  const { currentOS } = useSystemSettings();
+  const { currentOS, wallpaperUrl } = useSystemSettings();
   const [currentTime, setCurrentTime] = useState<string>("");
   const [currentDate, setCurrentDate] = useState<string>("");
   const [isUnlocking, setIsUnlocking] = useState(false);
@@ -53,7 +53,7 @@ export function LockScreen({ onUnlock }: LockScreenProps) {
       {/* Wallpaper background (not blurred) - covers everything */}
       <div className="absolute inset-0">
         <Image
-          src={getWallpaperPath(currentOS.id)}
+          src={wallpaperUrl ?? getWallpaperPath(currentOS.id)}
           alt="Lock screen wallpaper"
           fill
           className="object-cover"

--- a/lib/sidebar-persistence.ts
+++ b/lib/sidebar-persistence.ts
@@ -309,7 +309,7 @@ export function clearPhotosState(storage?: StorageArea): void {
 
 // Note: SettingsCategory and SettingsPanel types are defined in settings-app.tsx.
 // These arrays must match those types.
-const SETTINGS_CATEGORIES = ["general", "appearance", "wifi", "bluetooth", "focus", "menu-bar"] as const;
+const SETTINGS_CATEGORIES = ["general", "appearance", "wallpaper", "wifi", "bluetooth", "focus", "menu-bar"] as const;
 const SETTINGS_PANELS = ["about", "personal-info", "storage"] as const;
 
 type SettingsCategory = (typeof SETTINGS_CATEGORIES)[number];

--- a/lib/system-settings-context.tsx
+++ b/lib/system-settings-context.tsx
@@ -37,6 +37,8 @@ interface SystemSettingsContextValue {
   setClockFlashSeparators: (flash: boolean) => void;
   clockShowSeconds: boolean;
   setClockShowSeconds: (show: boolean) => void;
+  wallpaperUrl: string | null;
+  setWallpaperUrl: (url: string | null) => void;
   osVersionId: string;
   setOSVersionId: (id: string) => void;
   currentOS: OSVersion;
@@ -57,6 +59,7 @@ const CLOCK_STYLE_KEY = "menu-bar-clock-style";
 const CLOCK_SHOW_AM_PM_KEY = "menu-bar-clock-show-am-pm";
 const CLOCK_FLASH_SEPARATORS_KEY = "menu-bar-clock-flash-separators";
 const CLOCK_SHOW_SECONDS_KEY = "menu-bar-clock-show-seconds";
+const WALLPAPER_URL_KEY = "desktop-custom-wallpaper";
 const OS_VERSION_KEY = "system-os-version";
 
 // Helper to load settings from localStorage synchronously
@@ -76,6 +79,7 @@ function getInitialSettings() {
       clockShowAmPm: true,
       clockFlashSeparators: false,
       clockShowSeconds: false,
+      wallpaperUrl: null,
       osVersionId: DEFAULT_OS_VERSION_ID,
     };
   }
@@ -88,6 +92,7 @@ function getInitialSettings() {
   const storedFocusEndsAt = localStorage.getItem(FOCUS_ENDS_AT_KEY);
   const storedClockStyle = localStorage.getItem(CLOCK_STYLE_KEY);
   const storedClockShowSeconds = localStorage.getItem(CLOCK_SHOW_SECONDS_KEY);
+  const storedWallpaperUrl = localStorage.getItem(WALLPAPER_URL_KEY);
   const storedOSVersion = localStorage.getItem(OS_VERSION_KEY);
   const parsedFocusEndsAt = storedFocusEndsAt
     ? Number(storedFocusEndsAt)
@@ -110,6 +115,7 @@ function getInitialSettings() {
     clockShowAmPm: localStorage.getItem(CLOCK_SHOW_AM_PM_KEY) !== "false",
     clockFlashSeparators: localStorage.getItem(CLOCK_FLASH_SEPARATORS_KEY) === "true",
     clockShowSeconds: storedClockShowSeconds === "true",
+    wallpaperUrl: storedWallpaperUrl || null,
     osVersionId: storedOSVersion || DEFAULT_OS_VERSION_ID,
   };
 }
@@ -148,6 +154,9 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
   );
   const [clockShowSeconds, setClockShowSecondsState] = useState(
     initial.clockShowSeconds
+  );
+  const [wallpaperUrl, setWallpaperUrlState] = useState<string | null>(
+    initial.wallpaperUrl
   );
   const [osVersionId, setOSVersionIdState] = useState<string>(initial.osVersionId);
 
@@ -251,8 +260,20 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
 
   const setOSVersionId = useCallback((id: string) => {
     setOSVersionIdState(id);
+    setWallpaperUrlState(null);
     if (typeof window !== "undefined") {
       localStorage.setItem(OS_VERSION_KEY, id);
+      localStorage.removeItem(WALLPAPER_URL_KEY);
+    }
+  }, []);
+
+  const setWallpaperUrl = useCallback((url: string | null) => {
+    setWallpaperUrlState(url);
+    if (typeof window === "undefined") return;
+    if (url) {
+      localStorage.setItem(WALLPAPER_URL_KEY, url);
+    } else {
+      localStorage.removeItem(WALLPAPER_URL_KEY);
     }
   }, []);
 
@@ -296,7 +317,7 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
   const currentOS = useMemo(() => getOSVersion(osVersionId), [osVersionId]);
 
   return (
-    <SystemSettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, wifiEnabled, setWifiEnabled, bluetoothEnabled, setBluetoothEnabled, airdropMode, setAirdropMode, focusMode, setFocusMode, focusEndsAt, scheduleFocusEnd, menuBarBackground, setMenuBarBackground, clockShowDate, setClockShowDate, clockShowDayOfWeek, setClockShowDayOfWeek, clockStyle, setClockStyle, clockShowAmPm, setClockShowAmPm, clockFlashSeparators, setClockFlashSeparators, clockShowSeconds, setClockShowSeconds, osVersionId, setOSVersionId, currentOS }}>
+    <SystemSettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, wifiEnabled, setWifiEnabled, bluetoothEnabled, setBluetoothEnabled, airdropMode, setAirdropMode, focusMode, setFocusMode, focusEndsAt, scheduleFocusEnd, menuBarBackground, setMenuBarBackground, clockShowDate, setClockShowDate, clockShowDayOfWeek, setClockShowDayOfWeek, clockStyle, setClockStyle, clockShowAmPm, setClockShowAmPm, clockFlashSeparators, setClockFlashSeparators, clockShowSeconds, setClockShowSeconds, wallpaperUrl, setWallpaperUrl, osVersionId, setOSVersionId, currentOS }}>
       {children}
       {/* Brightness overlay - dims everything below system overlays */}
       {brightness < 100 && (
@@ -347,6 +368,8 @@ const defaultSettings: SystemSettingsContextValue = {
   setClockFlashSeparators: () => {},
   clockShowSeconds: false,
   setClockShowSeconds: () => {},
+  wallpaperUrl: null,
+  setWallpaperUrl: () => {},
   osVersionId: DEFAULT_OS_VERSION_ID,
   setOSVersionId: () => {},
   currentOS: getOSVersion(DEFAULT_OS_VERSION_ID),


### PR DESCRIPTION
## Today's delight

Wallpaper has two native desktop entry points: Photos can set the selected image from its Share menu, and System Settings has a dedicated **Wallpaper** pane for browsing theme wallpapers or choosing from the Photos library. **Add from Photos…** opens a compact OS-style chooser contained by the Settings window, with transformed thumbnails that stay ready while scrolling.

## Baseline and delta

- **Before:** Photos could set a wallpaper, but Settings had no Wallpaper surface. The first Settings implementation expanded all 152 photos inline; early modal iterations could extend below Settings and decoded original-resolution files as rows entered the viewport. Share was also a hand-drawn SVG that did not match the neighboring icon family.
- **Now:** Photos uses Lucide’s standard `Share` component—the same installed icon set as Info, Heart, and Rotate—with the family’s shared 20px sizing, 2px stroke, rounded caps, and open-tray proportions. Desktop Settings shows theme wallpapers and a contained 560×440 photo chooser using eager 240px transformed thumbnails.
- **Preserved:** Share still opens **Set as Wallpaper**; choosing it updates desktop and lock screen. Favorite, rotate, info, photo navigation, selected/Add card alignment, picker Cancel, theme selection, and Appearance reset behavior are unchanged.
- **Mobile is intentional:** Wallpaper is omitted from mobile Settings because the mobile surface has no background to configure. The Photos mobile viewer still exposes favorite, rotate, and back—but not the desktop-only Share action.

## Built result — desktop

![Photos toolbar using one consistent Lucide icon family](https://github.com/user-attachments/assets/f318359f-5185-457a-91ca-f1ef21299106)

At 1440×900, Share is now the standard `lucide-share` glyph at 20×20px with the default 2px stroke, directly beside Lucide Info, Heart, and Rotate. The unchanged 28×28px Share control opens **Set as Wallpaper**.

## Built result — mobile

![Unchanged mobile Photos viewer without the desktop-only Share action](https://github.com/user-attachments/assets/3da83e24-9fcd-44f4-a5cb-824042ce4e42)

At 390×844 CSS pixels and DPR 3, an isolated iPhone profile exposed five touch points, `(pointer: coarse)`, and `(hover: none)`. The viewer intentionally has no Share button; Favorite responds to real touch, while Rotate and Back remain present.

## macOS inspiration

[Apple’s current Mac User Guide](https://support.apple.com/en-mide/guide/mac-help/mchlp3013/mac) documents selecting a photo in Photos, clicking Share, and choosing **Set Wallpaper**. The owner supplied current Photos and System Settings references. The Lucide Share glyph provides the real Photos open-tray silhouette while keeping every web toolbar icon in one coherent system.

## Why this one

The original daily selection addressed Photos, whose last daily delight was 2026-07-27 and last visible touch was 2026-07-30. These owner-requested corrections remain within the same open wallpaper workflow and use Settings only as a secondary desktop surface; Settings’ last daily delight and visible touch were both 2026-07-31. No shortcut, service, secret, schema, dependency, or production-data write was introduced.

## Verification

- `npm run check`
- 70 Node tests, TypeScript, and production build pass; lint retains seven unrelated pre-existing warnings and zero errors
- Desktop: 1440×900; standard `lucide-share`, 20px size, 2px stroke, and Share → Set as Wallpaper menu
- Mobile: 390×844 at DPR 3; iPhone UA, five touch points, coarse pointer, hover-none, no Share button, and real-touch Favorite behavior
- Both GitHub-hosted screenshots were uploaded from captures stored outside the worktree

## Scope

This final correction removes the 19-line bespoke SVG component and replaces it with one import and one standard Lucide component in the existing Photos viewer. No living-doc or architecture change was needed.
