### PR TITLE
Share public Notes links

### DIFF
--- a/components/apps/notes/note-header.tsx
+++ b/components/apps/notes/note-header.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { format } from "date-fns";
 import { Input } from "@/components/ui/input";
-import { Lock } from "lucide-react";
+import { Check, Link2, Lock, Share } from "lucide-react";
 import { Note } from "@/lib/notes/types";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -18,30 +18,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Check, Link2 } from "lucide-react";
 
 const TIMESTAMP_PLACEHOLDER = "September 30, 2026 at 11:59 PM";
 const PRIVATE_BADGE_CLASS =
   "text-xs justify-center items-center bg-muted-foreground/70 can-hover:hover:bg-muted-foreground/70 text-white/90";
-
-function ShareIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      aria-hidden="true"
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.7"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M12 3v12" />
-      <path d="m7.75 7.25 4.25-4.25 4.25 4.25" />
-      <path d="M8.25 10H6.5A2.5 2.5 0 0 0 4 12.5v6A2.5 2.5 0 0 0 6.5 21h11a2.5 2.5 0 0 0 2.5-2.5v-6a2.5 2.5 0 0 0-2.5-2.5h-1.75" />
-    </svg>
-  );
-}
 
 async function copyText(text: string): Promise<boolean> {
   try {
@@ -228,24 +208,100 @@ export default function NoteHeader({
 
   const isMobileView = isMobile === true;
   const showBackButton = Boolean(onBack) || (isMobileView && pathname !== "/notes");
+  const backControl = showBackButton ? (
+    onBack ? (
+      <button onClick={onBack} className="flex h-10 items-center">
+        <Icons.back />
+        <span className="ml-1 text-base text-[#e2a727]">Notes</span>
+      </button>
+    ) : (
+      <Link href="/notes" className="flex h-10 items-center">
+        <Icons.back />
+        <span className="ml-1 text-base text-[#e2a727]">Notes</span>
+      </Link>
+    )
+  ) : null;
+  const shareControl = note.public ? (
+    <div className="relative z-20">
+      <Popover open={shareOpen} onOpenChange={setShareOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Share ${note.title}`}
+            aria-haspopup="menu"
+            aria-expanded={shareOpen}
+            onMouseDown={(event) => event.stopPropagation()}
+            className={`flex items-center justify-center rounded-md outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[#E2A727] ${
+              shareOpen
+                ? "bg-foreground/10"
+                : "can-hover:hover:bg-foreground/10"
+            } ${
+              copyStatus === "copied" ? "text-green-600" : "text-[#E2A727]"
+            } ${isMobileView ? "h-10 w-10" : "h-7 w-7"}`}
+          >
+            {copyStatus === "copied" ? (
+              <Check className="h-5 w-5" aria-hidden />
+            ) : (
+              <Share className="h-5 w-5" aria-hidden />
+            )}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          sideOffset={6}
+          className="w-44 rounded-xl border border-black/10 bg-white/95 p-1.5 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-900/95"
+        >
+          <div role="menu" aria-label={`Share ${note.title}`}>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => void handleCopyLink()}
+              className="flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[13px] leading-5 outline-none transition-colors can-hover:hover:bg-[#FFE390] can-hover:hover:text-black focus-visible:bg-[#FFE390] focus-visible:text-black focus-visible:outline-none dark:can-hover:hover:bg-[#9D7D28] dark:can-hover:hover:text-white dark:focus-visible:bg-[#9D7D28] dark:focus-visible:text-white"
+            >
+              {copyStatus === "copied" ? (
+                <Check
+                  className="h-4 w-4 shrink-0 text-green-600"
+                  strokeWidth={1.8}
+                  aria-hidden
+                />
+              ) : (
+                <Link2
+                  className="h-4 w-4 shrink-0 text-muted-foreground"
+                  strokeWidth={1.8}
+                  aria-hidden
+                />
+              )}
+              <span>
+                {copyStatus === "copied"
+                  ? "Copied"
+                  : copyStatus === "failed"
+                    ? "Copy failed"
+                    : "Copy Link"}
+              </span>
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
+      {copyStatus !== "idle" && (
+        <span
+          role="status"
+          className="absolute right-0 top-full z-20 mt-1 whitespace-nowrap rounded-md border border-muted-foreground/15 bg-background/95 px-2 py-1 text-xs font-medium shadow-md backdrop-blur-xl"
+        >
+          {copyStatus === "copied" ? "Link copied" : "Couldn’t copy link"}
+        </span>
+      )}
+    </div>
+  ) : null;
 
   return (
     <>
-      {showBackButton && (
-        onBack ? (
-          <button onClick={onBack} className="pt-2 flex items-center">
-            <Icons.back />
-            <span className="text-[#e2a727] text-base ml-1">Notes</span>
-          </button>
-        ) : (
-          <Link href="/notes">
-            <button className="pt-2 flex items-center">
-              <Icons.back />
-              <span className="text-[#e2a727] text-base ml-1">Notes</span>
-            </button>
-          </Link>
-        )
+      {isMobileView && (backControl || shareControl) && (
+        <div className="flex items-center justify-between px-2 pt-2">
+          {backControl ?? <span className="h-10 w-10" aria-hidden />}
+          {shareControl}
+        </div>
       )}
+      {!isMobileView && backControl}
       <div className="px-2 mb-4 relative">
         <div className="relative flex min-h-6 items-center justify-center">
           {!note.public && isMobileView && (
@@ -272,59 +328,10 @@ export default function NoteHeader({
               </Badge>
             </div>
           )}
-          {note.public && (
-            <>
-              <Popover open={shareOpen} onOpenChange={setShareOpen}>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label={`Share ${note.title}`}
-                    onMouseDown={(event) => event.stopPropagation()}
-                    className={`absolute right-0 z-20 flex items-center justify-center rounded-md outline-none transition-colors active:bg-muted focus-visible:ring-2 focus-visible:ring-[#E2A727] can-hover:hover:bg-muted ${
-                      copyStatus === "copied" ? "text-green-600" : "text-[#E2A727]"
-                    } ${isMobileView ? "h-9 w-9" : "h-7 w-7"}`}
-                  >
-                    {copyStatus === "copied" ? (
-                      <Check className={isMobileView ? "h-6 w-6" : "h-5 w-5"} aria-hidden />
-                    ) : (
-                      <ShareIcon className={isMobileView ? "h-6 w-6" : "h-5 w-5"} />
-                    )}
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent
-                  align="end"
-                  sideOffset={6}
-                  className="w-44 rounded-lg border-muted-foreground/20 bg-background/95 p-1 shadow-xl backdrop-blur-xl"
-                >
-                  <button
-                    type="button"
-                    onClick={() => void handleCopyLink()}
-                    className="flex min-h-10 w-full items-center gap-2 rounded-md px-3 text-left text-sm outline-none active:bg-muted focus-visible:bg-muted can-hover:hover:bg-muted"
-                  >
-                    {copyStatus === "copied" ? (
-                      <Check className="h-4 w-4 text-green-600" aria-hidden />
-                    ) : (
-                      <Link2 className="h-4 w-4 text-muted-foreground" aria-hidden />
-                    )}
-                    <span>
-                      {copyStatus === "copied"
-                        ? "Copied"
-                        : copyStatus === "failed"
-                          ? "Copy failed"
-                          : "Copy Link"}
-                    </span>
-                  </button>
-                </PopoverContent>
-              </Popover>
-              {copyStatus !== "idle" && (
-                <span
-                  role="status"
-                  className="absolute right-0 top-full z-20 mt-1 whitespace-nowrap rounded-md border border-muted-foreground/15 bg-background/95 px-2 py-1 text-xs font-medium shadow-md backdrop-blur-xl"
-                >
-                  {copyStatus === "copied" ? "Link copied" : "Couldn’t copy link"}
-                </span>
-              )}
-            </>
+          {!isMobileView && shareControl && (
+            <div className="absolute right-0 top-1/2 z-20 -translate-y-1/2">
+              {shareControl}
+            </div>
           )}
         </div>
         <div className="flex items-center relative">

--- a/components/apps/notes/note-header.tsx
+++ b/components/apps/notes/note-header.tsx
@@ -12,10 +12,54 @@ import { useTheme } from "next-themes";
 import { Badge } from "@/components/ui/badge";
 import { Icons } from "./icons";
 import { getDisplayCreatedAt } from "@/lib/notes/display-created-at";
+import { getPublicNoteUrl } from "@/lib/notes/share-link";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Check, Link2 } from "lucide-react";
 
 const TIMESTAMP_PLACEHOLDER = "September 30, 2026 at 11:59 PM";
 const PRIVATE_BADGE_CLASS =
   "text-xs justify-center items-center bg-muted-foreground/70 can-hover:hover:bg-muted-foreground/70 text-white/90";
+
+function ShareIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 3v12" />
+      <path d="m7.75 7.25 4.25-4.25 4.25 4.25" />
+      <path d="M8.25 10H6.5A2.5 2.5 0 0 0 4 12.5v6A2.5 2.5 0 0 0 6.5 21h11a2.5 2.5 0 0 0 2.5-2.5v-6a2.5 2.5 0 0 0-2.5-2.5h-1.75" />
+    </svg>
+  );
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand("copy");
+    textarea.remove();
+    return copied;
+  }
+}
 
 export default function NoteHeader({
   note,
@@ -49,9 +93,12 @@ export default function NoteHeader({
   const [emojiData, setEmojiData] = useState<unknown>(null);
   const [pickerPosition, setPickerPosition] = useState({ top: 0, left: 0 });
   const [hasMounted, setHasMounted] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle");
   const emojiButtonRef = useRef<HTMLButtonElement>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const copyStatusTimerRef = useRef<number | null>(null);
 
   const loadEmojiPicker = useCallback(async () => {
     if (emojiPickerLoaded || emojiPickerLoading) return;
@@ -82,6 +129,19 @@ export default function NoteHeader({
     setHasMounted(true);
   }, []);
 
+  useEffect(() => {
+    setShareOpen(false);
+    setCopyStatus("idle");
+  }, [note.slug]);
+
+  useEffect(() => {
+    return () => {
+      if (copyStatusTimerRef.current !== null) {
+        window.clearTimeout(copyStatusTimerRef.current);
+      }
+    };
+  }, []);
+
   const formattedDate = useMemo(() => {
     // Render timestamps only after client mount to avoid SSR/client
     // timezone differences on refresh.
@@ -101,6 +161,19 @@ export default function NoteHeader({
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     saveNote({ title: e.target.value });
+  };
+
+  const handleCopyLink = async () => {
+    const url = getPublicNoteUrl(window.location.origin, note.slug);
+    setCopyStatus((await copyText(url)) ? "copied" : "failed");
+
+    if (copyStatusTimerRef.current !== null) {
+      window.clearTimeout(copyStatusTimerRef.current);
+    }
+    copyStatusTimerRef.current = window.setTimeout(() => {
+      setCopyStatus("idle");
+      copyStatusTimerRef.current = null;
+    }, 5000);
   };
 
   const updatePickerPosition = useCallback(() => {
@@ -198,6 +271,60 @@ export default function NoteHeader({
                 Private
               </Badge>
             </div>
+          )}
+          {note.public && (
+            <>
+              <Popover open={shareOpen} onOpenChange={setShareOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`Share ${note.title}`}
+                    onMouseDown={(event) => event.stopPropagation()}
+                    className={`absolute right-0 z-20 flex items-center justify-center rounded-md outline-none transition-colors active:bg-muted focus-visible:ring-2 focus-visible:ring-[#E2A727] can-hover:hover:bg-muted ${
+                      copyStatus === "copied" ? "text-green-600" : "text-[#E2A727]"
+                    } ${isMobileView ? "h-9 w-9" : "h-7 w-7"}`}
+                  >
+                    {copyStatus === "copied" ? (
+                      <Check className={isMobileView ? "h-6 w-6" : "h-5 w-5"} aria-hidden />
+                    ) : (
+                      <ShareIcon className={isMobileView ? "h-6 w-6" : "h-5 w-5"} />
+                    )}
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="end"
+                  sideOffset={6}
+                  className="w-44 rounded-lg border-muted-foreground/20 bg-background/95 p-1 shadow-xl backdrop-blur-xl"
+                >
+                  <button
+                    type="button"
+                    onClick={() => void handleCopyLink()}
+                    className="flex min-h-10 w-full items-center gap-2 rounded-md px-3 text-left text-sm outline-none active:bg-muted focus-visible:bg-muted can-hover:hover:bg-muted"
+                  >
+                    {copyStatus === "copied" ? (
+                      <Check className="h-4 w-4 text-green-600" aria-hidden />
+                    ) : (
+                      <Link2 className="h-4 w-4 text-muted-foreground" aria-hidden />
+                    )}
+                    <span>
+                      {copyStatus === "copied"
+                        ? "Copied"
+                        : copyStatus === "failed"
+                          ? "Copy failed"
+                          : "Copy Link"}
+                    </span>
+                  </button>
+                </PopoverContent>
+              </Popover>
+              {copyStatus !== "idle" && (
+                <span
+                  role="status"
+                  className="absolute right-0 top-full z-20 mt-1 whitespace-nowrap rounded-md border border-muted-foreground/15 bg-background/95 px-2 py-1 text-xs font-medium shadow-md backdrop-blur-xl"
+                >
+                  {copyStatus === "copied" ? "Link copied" : "Couldn’t copy link"}
+                </span>
+              )}
+            </>
           )}
         </div>
         <div className="flex items-center relative">

--- a/lib/notes/share-link.ts
+++ b/lib/notes/share-link.ts
@@ -1,0 +1,4 @@
+export function getPublicNoteUrl(origin: string, slug: string): string {
+  const normalizedOrigin = origin.replace(/\/+$/, "");
+  return `${normalizedOrigin}/notes/${encodeURIComponent(slug)}`;
+}

--- a/tests/notes-share-link.test.ts
+++ b/tests/notes-share-link.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getPublicNoteUrl } from "../lib/notes/share-link";
+
+test("builds a public note URL from an origin and slug", () => {
+  assert.equal(
+    getPublicNoteUrl("https://alanagoyal.com", "about-me"),
+    "https://alanagoyal.com/notes/about-me",
+  );
+});
+
+test("normalizes the origin and encodes the slug", () => {
+  assert.equal(
+    getPublicNoteUrl("https://alanagoyal.com/", "hello world"),
+    "https://alanagoyal.com/notes/hello%20world",
+  );
+});


### PR DESCRIPTION
## Today's delight

Public Notes now use the same canonical Share glyph and compact command-menu language as the rest of the desktop, while keeping the existing stable public-link copy behavior.

## Baseline and delta

- Before: public Notes had working **Copy Link**, but the Share glyph was hand-drawn, the popover diverged from current Notes context-menu styling, and the mobile control sat below the Back control.
- Now: Share uses the standard 20px Lucide open-tray glyph at stroke 2; the popover matches Notes command menus (panel, 13px rows, 16px action icons, spacing, radius, blur, shadow, and Notes-gold interaction state); mobile Back and Share are both 40px controls on the same top plane with a measured 0px centerline delta.
- Preserved: the canonical `/notes/<slug>` URL, **Link copied** feedback, note selection and routing, reading and scrolling, inline links, private-note editing, sidebar controls, and Back-to-Notes navigation. Private notes still do not expose a public-share action.

## Built result — desktop

![Desktop Notes share menu](https://github.com/user-attachments/assets/1f6a336f-2dca-451f-97da-d323df63176a)

At 1280×720, the public **about me** note shows the canonical Share glyph and the compact Notes command-menu treatment. Copy Link writes `http://localhost:3010/notes/about-me` in local verification.

## Built result — mobile

![Mobile Notes share menu aligned with Back](https://github.com/user-attachments/assets/fb98d9b2-b6f9-4eb1-a5c3-e1cfd6c4e5d7)

At 390×844 CSS pixels and DPR 3, Back and Share share the exact same vertical centerline. Real touch taps opened Share, copied the same public URL, displayed **Link copied**, and preserved Back-to-Notes navigation.

## macOS inspiration

[Apple’s current Notes User Guide for macOS Tahoe](https://support.apple.com/guide/notes/manage-shared-notes-and-folders-apd881ec5518/mac) documents the Share button in a note’s toolbar and **Copy Link** for shared notes. This implementation maps those native entry points to the site’s already-public, read-only note URLs without inventing collaboration or permissions that the site does not have.

## Why this one

Notes was a neglected registered app: its last daily delight was 2026-07-25 and its last merged user-visible touch was 2026-07-30. It also varies away from Preview and Messages, the two most recent shipped daily primary surfaces, and does not overlap other open work.

## Verification

- Synced and merged latest `main` before the refinement
- Focused: `node --import tsx --test tests/notes-share-link.test.ts` — 2/2 pass
- `npm run check`: lint has zero errors (seven unrelated pre-existing warnings), all 73 Node tests pass, and TypeScript passes; the local Turbopack build is blocked only by this isolated environment denying its internal port bind
- Pushed head deployment: Vercel Preview is **Ready**
- Desktop: 1280×720; Share glyph, menu geometry/styles, Copy Link, and confirmation visually verified
- Mobile: iPhone-class 390×844 at DPR 3; iPhone UA, five touch points, coarse pointer, hover-none, real touch Share/Copy/Back taps, exact clipboard URL, confirmation, and 0px Back/Share centerline delta

## Scope

Micro: 170 additions and 15 deletions across one existing Notes component, one tiny URL helper, and focused tests. No dependency, backend, schema, external service, shortcut, or production-data change.