### PR TITLE
Fill windows from title-bar double-clicks

### DIFF
--- a/components/desktop/window.tsx
+++ b/components/desktop/window.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useRef, useCallback } from "react";
+import { useRef, useCallback, useEffect } from "react";
 import { useWindowManager, MAXIMIZED_Z_INDEX } from "@/lib/window-context";
 import { getAppById } from "@/lib/app-config";
 import type { Position, Size, WindowState } from "@/types/window";
 import { cn } from "@/lib/utils";
 import { WindowFocusProvider } from "@/lib/window-focus-context";
-import { useWindowBehavior, CORNER_SIZE, EDGE_SIZE } from "@/lib/use-window-behavior";
+import {
+  useWindowBehavior,
+  CORNER_SIZE,
+  DOCK_HEIGHT,
+  EDGE_SIZE,
+  MENU_BAR_HEIGHT,
+} from "@/lib/use-window-behavior";
 
 interface ControlledWindowHandlers {
   closeWindow: () => void;
@@ -62,6 +68,13 @@ export function Window({
   const wasFocusedBeforeMouseDown = useRef(true);
   // Track recently consumed focus-transfer clicks so dblclick handlers don't fire.
   const suppressDoubleClickUntil = useRef(0);
+  const titleBarRestoreFrameRef = useRef<{ position: Position; size: Size } | null>(null);
+
+  useEffect(() => {
+    if (windowState?.isMaximized) {
+      titleBarRestoreFrameRef.current = null;
+    }
+  }, [windowState?.isMaximized]);
 
   // Wrap WindowManager callbacks for the hook
   const handleMove = useCallback(
@@ -212,10 +225,49 @@ export function Window({
           return;
         }
 
-        const isWindowControl = (e.target as HTMLElement).closest(".window-controls");
+        const target = e.target as HTMLElement;
+        const isWindowControl = target.closest(".window-controls");
         if (!isWindowControl && performance.now() < suppressDoubleClickUntil.current) {
           e.stopPropagation();
           e.preventDefault();
+          return;
+        }
+
+        const isTitleBar = target.closest("[data-window-drag-handle='true']");
+        const isInteractive = target.closest(
+          "a, button, input, select, textarea, [contenteditable='true'], [role='button'], [role='menuitem']",
+        );
+        if (isTitleBar && !isInteractive) {
+          e.stopPropagation();
+          e.preventDefault();
+
+          const restoreFrame = titleBarRestoreFrameRef.current;
+          if (restoreFrame) {
+            titleBarRestoreFrameRef.current = null;
+            handleResize(restoreFrame.size, restoreFrame.position);
+            return;
+          }
+
+          if (isMaximized) {
+            if (controlledHandlers) {
+              controlledHandlers.toggleMaximize();
+            } else {
+              toggleMaximize(appId);
+            }
+            return;
+          }
+
+          titleBarRestoreFrameRef.current = { position, size };
+          handleResize(
+            {
+              width: window.innerWidth,
+              height: Math.max(
+                app.minSize.height,
+                window.innerHeight - MENU_BAR_HEIGHT - DOCK_HEIGHT,
+              ),
+            },
+            { x: 0, y: MENU_BAR_HEIGHT },
+          );
         }
       }}
     >

--- a/components/window-nav-shell.tsx
+++ b/components/window-nav-shell.tsx
@@ -24,6 +24,7 @@ export function WindowNavShell({
 }: WindowNavShellProps) {
   return (
     <div
+      data-window-drag-handle={onMouseDown ? "true" : undefined}
       className={cn(
         "px-4 py-2 flex items-center sticky top-0 z-[1] select-none",
         isScrolled && "border-b shadow-[0_2px_4px_-1px_rgba(0,0,0,0.15)]",

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -139,7 +139,7 @@ Standard nav bar pattern for app windows. Use `select-none` to prevent text sele
 </div>
 ```
 
-The nav bar acts as the window drag handle on desktop - `select-none` prevents accidental text selection while dragging.
+The nav bar acts as the window drag handle on desktop - `select-none` prevents accidental text selection while dragging. `WindowNavShell` marks that drag surface for the shared window manager, so double-clicking neutral title-bar space fills the area between the menu bar and Dock; double-clicking again restores the prior frame. Nested controls are excluded automatically, so do not add per-app double-click handlers.
 
 ### Hover States
 


### PR DESCRIPTION
## Today's delight

Desktop windows now support macOS-style title-bar Fill: double-click neutral title-bar space to expand the window between the menu bar and Dock, then double-click again to restore the exact prior frame.

## Baseline and delta

- Before: users could focus, drag, resize, minimize, and use the green full-screen control, but a title-bar double-click had no visible result.
- Now: double-clicking a neutral draggable title-bar area fills the available desktop while preserving the menu bar and Dock; a second double-click restores the previous position and size exactly.
- Preserved: first-click focus suppression, title dragging, resize handles, all traffic-light controls, nested title-bar controls, in-app content double-clicks, and the full-screen mobile iTerm flow remain unchanged.

## Built result — desktop

![Desktop iTerm window filled between the menu bar and Dock](https://github.com/user-attachments/assets/1fe0a436-49cd-43d2-8c6c-74a903624b61)

At 1440×900, iTerm changed from x121/y71/798×498 to x1/y29/1438×790, leaving the 28px menu bar and 80px Dock visible. A second title-bar double-click restored x121/y71/798×498 exactly. The existing green button still uses its distinct x1/y1/1438×898 full-screen frame and restores correctly.

## Built result — mobile

![Mobile iTerm after real touch interaction](https://github.com/user-attachments/assets/cfb59edc-0dba-46a3-8e73-2f53f35e4837)

At 390×844 CSS pixels and DPR 3, an iPhone UA with five touch points, coarse pointer, and hover-none retained the existing full-screen iTerm experience. A real touch tap focused the terminal and `pwd` returned `/Users/alanagoyal`; no desktop title-bar affordance leaked into mobile.

## macOS inspiration

[Apple’s current macOS 26 Desktop & Dock guide](https://support.apple.com/guide/mac-help/change-desktop-dock-settings-mchlp1119/26/mac/26) defines **Fill** as a window title-bar double-click action that expands a window into the space between the menu bar and Dock. This implementation maps that behavior directly onto the site’s shared draggable title-bar surface, while keeping its existing green-button full-screen action separate. The installed comparison system is macOS 26.5.1 (25F80).

## Why this one

`window-management` has never been the primary surface of a shipped daily delight; its last merged visible touch was 2026-07-23. The change varies away from open Photos/Settings wallpaper PR #282 and Notes PR #283, plus the two latest merged primary surfaces, Preview and Messages. PR #282 touches wallpaper/window framing secondarily but has no file or behavior overlap with this title-bar interaction.

## Verification

- `npm run check`
- Focused: ESLint on the two changed components and `npm run typecheck`
- Desktop: 1440×900; exact Fill and restore geometry, existing green-button full-screen and restore geometry, and content double-click isolation
- Mobile: iPhone-class 390×844 at DPR 3; iPhone UA, five touch points, coarse pointer, hover-none, real touch terminal focus, and visible `pwd` output
- 70 Node tests pass; TypeScript and production build pass; lint retains seven unrelated pre-existing warnings and zero errors

## Scope

Micro: 57 additions and 4 deletions across the shared window component, shared title-bar shell, and its design-system contract. No dependency, backend, schema, service, secret, shortcut, production-data, or app-availability change.