### PR TITLE
Add icons to contextual command menus

### DIFF
--- a/components/apps/messages/conversation-context-actions.tsx
+++ b/components/apps/messages/conversation-context-actions.tsx
@@ -47,18 +47,22 @@ interface TriggerBounds {
   height: number;
 }
 
-function ReadStateMessageIcon() {
+function ReadStateMessageIcon({
+  className = "h-5 w-5 shrink-0",
+}: {
+  className?: string;
+}) {
   return (
     <svg
       viewBox="0 0 24 24"
-      className="h-5 w-5 shrink-0"
+      className={className}
       fill="none"
       aria-hidden
     >
       <path
         d="M15.7 4.45c-1.2-.36-2.52-.55-3.9-.55-4.86 0-8.4 2.87-8.4 6.67 0 1.62.67 3.1 1.86 4.22l-.82 2.79 3.1-1.17c1.22.49 2.65.76 4.26.76 4.82 0 8.33-2.79 8.33-6.6 0-.89-.19-1.72-.55-2.47"
         stroke="currentColor"
-        strokeWidth="2"
+        strokeWidth="1.8"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -446,18 +450,29 @@ export function ConversationContextActions({
             className="focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
             onClick={onToggleReadState}
           >
+            <ReadStateMessageIcon className="h-4 w-4 shrink-0" />
             <span>{getConversationReadStateLabel(conversation)}</span>
           </ContextMenuItem>
           <ContextMenuItem
             className="focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
             onClick={onPinToggle}
           >
+            {conversation.pinned ? (
+              <PinOff className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+            ) : (
+              <Pin className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+            )}
             <span>{conversation.pinned ? "Unpin" : "Pin"}</span>
           </ContextMenuItem>
           <ContextMenuItem
             className="focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
             onClick={onToggleAlerts}
           >
+            {conversation.hideAlerts ? (
+              <Bell className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+            ) : (
+              <BellOff className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+            )}
             <span>
               {conversation.hideAlerts ? "Show Alerts" : "Hide Alerts"}
             </span>
@@ -466,6 +481,7 @@ export function ConversationContextActions({
             className="text-red-600 focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
             onClick={onDelete}
           >
+            <Trash2 className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
             <span>Delete</span>
           </ContextMenuItem>
         </ContextMenuContent>

--- a/components/apps/notes/nav.tsx
+++ b/components/apps/notes/nav.tsx
@@ -59,8 +59,8 @@ const MENU_CLOSE_FALLBACK_MS = 200;
 function MenuCheck({ checked }: { checked: boolean }) {
   return (
     <Check
-      className={cn("h-3.5 w-3.5 shrink-0", !checked && "opacity-0")}
-      strokeWidth={2.25}
+      className={cn("h-4 w-4 shrink-0", !checked && "opacity-0")}
+      strokeWidth={2}
       aria-hidden
     />
   );
@@ -86,7 +86,7 @@ function MobileSubmenuHeader({
         onClick={onClose}
         className="flex w-full items-center gap-2 rounded-[7px] px-2 py-1.5 text-left"
       >
-        <Icon className="h-4 w-4 shrink-0" aria-hidden />
+        <Icon className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
         <span className="min-w-0 flex-1">
           <span className="block text-[13px] leading-4">{label}</span>
           <span className="block truncate text-[11px] leading-4 text-muted-foreground">
@@ -254,9 +254,9 @@ export function Nav({
                   className={menuItemClass}
                 >
                   {viewMode === "gallery" ? (
-                    <List className="h-4 w-4 shrink-0" aria-hidden />
+                    <List className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                   ) : (
-                    <LayoutGrid className="h-4 w-4 shrink-0" aria-hidden />
+                    <LayoutGrid className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                   )}
                   <span>
                     {viewMode === "gallery"
@@ -280,7 +280,7 @@ export function Nav({
                   }}
                   className={menuItemClass}
                 >
-                  <ArrowUpDown className="h-4 w-4 shrink-0" aria-hidden />
+                  <ArrowUpDown className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                   <span className="flex-1">Sort By</span>
                   <ChevronRight className="h-4 w-4 shrink-0" aria-hidden />
                 </button>
@@ -306,7 +306,7 @@ export function Nav({
                       "cursor-default opacity-45 can-hover:hover:bg-transparent can-hover:hover:text-inherit",
                   )}
                 >
-                  <CalendarDays className="h-4 w-4 shrink-0" aria-hidden />
+                  <CalendarDays className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                   <span className="flex-1">Group By Date</span>
                   <ChevronRight className="h-4 w-4 shrink-0" aria-hidden />
                 </button>

--- a/components/apps/notes/nav.tsx
+++ b/components/apps/notes/nav.tsx
@@ -53,7 +53,7 @@ interface NavProps {
 type Submenu = "sort" | "group" | null;
 
 const menuItemClass =
-  "flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[13px] leading-5 transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white";
+  "flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[13px] leading-5 transition-colors can-hover:hover:bg-[#FFE390] can-hover:hover:text-black dark:can-hover:hover:bg-[#9D7D28] dark:can-hover:hover:text-white focus-visible:bg-[#FFE390] focus-visible:text-black dark:focus-visible:bg-[#9D7D28] dark:focus-visible:text-white focus-visible:outline-none";
 const MENU_CLOSE_FALLBACK_MS = 200;
 
 function MenuCheck({ checked }: { checked: boolean }) {
@@ -303,7 +303,7 @@ export function Nav({
                   className={cn(
                     menuItemClass,
                     groupByDateDisabled &&
-                      "cursor-default opacity-45 can-hover:hover:bg-transparent can-hover:hover:text-inherit",
+                      "cursor-default opacity-45 can-hover:hover:bg-transparent can-hover:hover:text-inherit dark:can-hover:hover:bg-transparent dark:can-hover:hover:text-inherit",
                   )}
                 >
                   <CalendarDays className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />

--- a/components/apps/notes/note-item.tsx
+++ b/components/apps/notes/note-item.tsx
@@ -218,7 +218,7 @@ export const NoteItem = React.memo(function NoteItem({
         <ContextMenuContent>
           <ContextMenuItem
             onClick={handlePinAction}
-            className="cursor-pointer focus:bg-[#0A7CFF] focus:text-white"
+            className="cursor-pointer focus:bg-[#FFE390] focus:text-black dark:focus:bg-[#9D7D28] dark:focus:text-white"
           >
             {isPinned ? (
               <PinOff className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
@@ -231,14 +231,14 @@ export const NoteItem = React.memo(function NoteItem({
             <>
               <ContextMenuItem
                 onClick={handleEdit}
-                className="cursor-pointer focus:bg-[#0A7CFF] focus:text-white"
+                className="cursor-pointer focus:bg-[#FFE390] focus:text-black dark:focus:bg-[#9D7D28] dark:focus:text-white"
               >
                 <Pencil className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                 Edit
               </ContextMenuItem>
               <ContextMenuItem
                 onClick={handleDelete}
-                className="cursor-pointer text-red-600 focus:bg-[#0A7CFF] focus:text-white"
+                className="cursor-pointer text-red-600 focus:bg-[#FFE390] focus:text-black dark:focus:bg-[#9D7D28] dark:focus:text-white"
               >
                 <Trash2 className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                 Delete

--- a/components/apps/notes/note-item.tsx
+++ b/components/apps/notes/note-item.tsx
@@ -13,6 +13,7 @@ import { Note } from "@/lib/notes/types";
 import { getDisplayCreatedAt } from "@/lib/notes/display-created-at";
 import { Dispatch, SetStateAction } from "react";
 import { getNotePreviewText } from "@/lib/notes/note-utils";
+import { Pencil, Pin, PinOff, Trash2 } from "lucide-react";
 
 const SIDEBAR_DATE_PLACEHOLDER = "00/00/0000";
 
@@ -215,18 +216,31 @@ export const NoteItem = React.memo(function NoteItem({
       <ContextMenu>
         <ContextMenuTrigger>{NoteContent}</ContextMenuTrigger>
         <ContextMenuContent>
-          <ContextMenuItem onClick={handlePinAction} className="cursor-pointer">
+          <ContextMenuItem
+            onClick={handlePinAction}
+            className="cursor-pointer focus:bg-[#0A7CFF] focus:text-white"
+          >
+            {isPinned ? (
+              <PinOff className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+            ) : (
+              <Pin className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+            )}
             {isPinned ? "Unpin" : "Pin"}
           </ContextMenuItem>
           {item.session_id === sessionId && (
             <>
-              <ContextMenuItem onClick={handleEdit} className="cursor-pointer">
+              <ContextMenuItem
+                onClick={handleEdit}
+                className="cursor-pointer focus:bg-[#0A7CFF] focus:text-white"
+              >
+                <Pencil className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                 Edit
               </ContextMenuItem>
               <ContextMenuItem
                 onClick={handleDelete}
-                className="cursor-pointer"
+                className="cursor-pointer text-red-600 focus:bg-[#0A7CFF] focus:text-white"
               >
+                <Trash2 className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                 Delete
               </ContextMenuItem>
             </>

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -527,7 +527,7 @@ function GalleryCard({
       <ContextMenuContent>
         <ContextMenuItem
           onClick={() => onPinToggle(note.slug)}
-          className="focus:bg-[#0A7CFF] focus:text-white"
+          className="focus:bg-[#FFE390] focus:text-black dark:focus:bg-[#9D7D28] dark:focus:text-white"
         >
           {isPinned ? (
             <PinOff className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
@@ -539,7 +539,7 @@ function GalleryCard({
         {canDelete && (
           <ContextMenuItem
             onClick={() => void onDelete(note)}
-            className="text-red-600 focus:bg-[#0A7CFF] focus:text-white"
+            className="text-red-600 focus:bg-[#FFE390] focus:text-black dark:focus:bg-[#9D7D28] dark:focus:text-white"
           >
             <Trash2 className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
             Delete

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -529,6 +529,11 @@ function GalleryCard({
           onClick={() => onPinToggle(note.slug)}
           className="focus:bg-[#0A7CFF] focus:text-white"
         >
+          {isPinned ? (
+            <PinOff className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+          ) : (
+            <Pin className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+          )}
           {isPinned ? "Unpin" : "Pin"}
         </ContextMenuItem>
         {canDelete && (
@@ -536,6 +541,7 @@ function GalleryCard({
             onClick={() => void onDelete(note)}
             className="text-red-600 focus:bg-[#0A7CFF] focus:text-white"
           >
+            <Trash2 className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
             Delete
           </ContextMenuItem>
         )}

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -16,6 +16,7 @@ import {
   Info,
   RotateCcwSquare,
   Share,
+  Wallpaper,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useClickOutside } from "@/lib/hooks/use-click-outside";
@@ -841,8 +842,9 @@ export function PhotoViewer({
                       setWallpaperUrl(photo.url);
                       closeShare();
                     }}
-                    className="flex w-full items-center rounded px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white focus-visible:bg-[#0A7CFF] focus-visible:text-white focus-visible:outline-none"
+                    className="flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white focus-visible:bg-[#0A7CFF] focus-visible:text-white focus-visible:outline-none"
                   >
+                    <Wallpaper className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
                     Set as Wallpaper
                   </button>
                 </div>

--- a/components/desktop/dock.tsx
+++ b/components/desktop/dock.tsx
@@ -7,7 +7,6 @@ import { useWindowManager } from "@/lib/window-context";
 import { cn } from "@/lib/utils";
 import { CalendarDockIcon } from "@/components/apps/calendar/calendar-dock-icon";
 import { useClickOutside } from "@/lib/hooks/use-click-outside";
-import { Check } from "lucide-react";
 
 interface DockProps {
   onTrashClick?: () => void;
@@ -759,16 +758,11 @@ export function Dock({
                   setMagnificationEnabled((enabled) => !enabled);
                   closeDockMenu();
                 }}
-                className="relative z-[1] flex w-full items-center gap-2 whitespace-nowrap px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white focus-visible:bg-[#0A7CFF] focus-visible:text-white focus-visible:outline-none"
+                className="relative z-[1] flex w-full items-center justify-between whitespace-nowrap px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
               >
-                <Check
-                  aria-hidden
-                  className={cn(
-                    "h-4 w-4 shrink-0",
-                    !magnificationEnabled && "opacity-0",
-                  )}
-                />
-                <span>Magnification</span>
+                {magnificationEnabled
+                  ? "Turn Magnification Off"
+                  : "Turn Magnification On"}
               </button>
             </div>
           )}

--- a/components/desktop/dock.tsx
+++ b/components/desktop/dock.tsx
@@ -7,6 +7,7 @@ import { useWindowManager } from "@/lib/window-context";
 import { cn } from "@/lib/utils";
 import { CalendarDockIcon } from "@/components/apps/calendar/calendar-dock-icon";
 import { useClickOutside } from "@/lib/hooks/use-click-outside";
+import { Check } from "lucide-react";
 
 interface DockProps {
   onTrashClick?: () => void;
@@ -758,11 +759,16 @@ export function Dock({
                   setMagnificationEnabled((enabled) => !enabled);
                   closeDockMenu();
                 }}
-                className="relative z-[1] flex w-full items-center justify-between whitespace-nowrap px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+                className="relative z-[1] flex w-full items-center gap-2 whitespace-nowrap px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white focus-visible:bg-[#0A7CFF] focus-visible:text-white focus-visible:outline-none"
               >
-                {magnificationEnabled
-                  ? "Turn Magnification Off"
-                  : "Turn Magnification On"}
+                <Check
+                  aria-hidden
+                  className={cn(
+                    "h-4 w-4 shrink-0",
+                    !magnificationEnabled && "opacity-0",
+                  )}
+                />
+                <span>Magnification</span>
               </button>
             </div>
           )}

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -80,7 +80,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -124,9 +124,11 @@ Exception: Back/navigation chevrons can use the app's accent color:
 
 Desktop context menus and compact action popovers use 16px icons with an 8px
 gap between the icon gutter and label (`h-4 w-4 shrink-0` plus `gap-2`). Keep
-the gutter present for every command in a menu so labels align. Toggle and
-radio menus use a checkmark in that gutter rather than an additional command
-pictogram. Destructive icons inherit the destructive text color.
+the gutter present for every iconized command in a menu so labels align. Toggle
+and radio menus use a checkmark in that gutter when the native surface shows
+selection state; do not force icons onto native text-only system commands such
+as the Dock magnification action. Destructive icons inherit the destructive
+text color.
 
 Touch action sheets may use 20px icons with a 12px gap to match their larger
 row height and tap targets.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -120,6 +120,17 @@ Exception: Back/navigation chevrons can use the app's accent color:
 - Compact (search bars): 14px
 - Prominent (back buttons): 20-24px
 
+### Compact Command Menus
+
+Desktop context menus and compact action popovers use 16px icons with an 8px
+gap between the icon gutter and label (`h-4 w-4 shrink-0` plus `gap-2`). Keep
+the gutter present for every command in a menu so labels align. Toggle and
+radio menus use a checkmark in that gutter rather than an additional command
+pictogram. Destructive icons inherit the destructive text color.
+
+Touch action sheets may use 20px icons with a 12px gap to match their larger
+row height and tap targets.
+
 ## Navigation Bar
 
 Standard nav bar pattern for app windows. Use `select-none` to prevent text selection when dragging the window:

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -133,6 +133,10 @@ text color.
 Touch action sheets may use 20px icons with a 12px gap to match their larger
 row height and tap targets.
 
+App-specific context menus and action popovers use the app accent for their
+highlighted item. Notes uses `#FFE390` with dark text in light mode and
+`#9D7D28` with white text in dark mode.
+
 ## Navigation Bar
 
 Standard nav bar pattern for app windows. Use `select-none` to prevent text selection when dragging the window:


### PR DESCRIPTION
## What changed

- Added macOS-style command icons to Messages conversation context actions, Notes list and gallery actions, and Photos share.
- Standardized context-menu command icons at 16×16 with consistent spacing, alignment, and destructive-state treatment.
- Normalized existing Notes display-menu icons and selection checkmarks.
- Switched Notes-specific right-click and display-menu highlights from blue to the Notes gold accent in both light and dark mode.
- Restored Dock magnification to its native text-only menu treatment.
- Removed Calendar color swatches from command-menu rows.
- Documented the shared contextual command-menu and app-accent highlight conventions.
- Preserved larger mobile touch targets while keeping the desktop visual rhythm compact.

## Why

These menus now more closely match native macOS command menus: recognizable symbols, consistent geometry, and app-specific selection color where macOS uses it. Notes uses its gold accent instead of the shell's default blue.

## Impact

The update covers contextual and action menus in Messages, Notes, Photos, Calendar, and Dock. Notes list, gallery, and display menus share one gold highlight treatment; unrelated global menu-bar UI and non-menu drag/drop states remain unchanged.

## Verification

- `npm run check`
  - lint (7 pre-existing warnings, no errors)
  - 70/70 Node tests
  - typecheck
  - production build
- Visual QA in the running app for Notes right-click and display menus
- Confirmed the dark-mode Notes highlight renders as `rgb(157, 125, 40)` with white text
