### PR TITLE
Stabilize Photos header layout

### DIFF
--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "./sidebar";
 import { PhotosGrid } from "./photos-grid";
 import { PhotoViewer } from "./photo-viewer";
 import { Nav } from "./nav";
+import { PhotosHeader } from "./header";
 import { Photo, PhotosView, TimeFilter } from "@/types/photos";
 import { usePhotos } from "@/lib/photos/use-photos";
 import {
@@ -233,7 +234,9 @@ export default function App({ isDesktop = false }: AppProps) {
               role="status"
               aria-label="Loading selected photo"
               className="flex-1 min-h-0 bg-background"
-            />
+            >
+              <PhotosHeader isMobileView={isMobileView} aria-hidden="true" />
+            </div>
           )}
 
           {/* Photo Viewer */}

--- a/components/apps/photos/header.tsx
+++ b/components/apps/photos/header.tsx
@@ -1,0 +1,33 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export const PHOTOS_HEADER_HEIGHT_PX = 69;
+export const PHOTOS_HEADER_HEIGHT_CLASS_NAME =
+  "h-[69px] min-h-[69px] shrink-0";
+
+interface PhotosHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+  isMobileView: boolean;
+}
+
+export function PhotosHeader({
+  children,
+  className,
+  isMobileView,
+  ...props
+}: PhotosHeaderProps) {
+  return (
+    <div
+      data-photos-header="true"
+      className={cn(
+        "relative flex items-center border-b px-4 py-3 select-none dark:border-foreground/20",
+        isMobileView ? "bg-background" : "bg-muted/50",
+        className,
+        PHOTOS_HEADER_HEIGHT_CLASS_NAME,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/apps/photos/nav.tsx
+++ b/components/apps/photos/nav.tsx
@@ -3,6 +3,8 @@
 import { WindowControls } from "@/components/window-controls";
 import { WindowNavShell, WindowNavSpacer } from "@/components/window-nav-shell";
 import { useWindowNavBehavior } from "@/lib/use-window-nav-behavior";
+import { cn } from "@/lib/utils";
+import { PHOTOS_HEADER_HEIGHT_CLASS_NAME } from "./header";
 
 interface NavProps {
   isMobileView: boolean;
@@ -14,23 +16,32 @@ export function Nav({ isMobileView, isScrolled, isDesktop = false }: NavProps) {
   const nav = useWindowNavBehavior({ isDesktop, isMobile: isMobileView });
 
   return (
-    <WindowNavShell
-      isMobile={isMobileView}
-      isScrolled={isScrolled}
-      onMouseDown={nav.onDragStart}
-      left={
-        <WindowControls
-          inShell={nav.inShell}
-          showWhenNotInShell={!isDesktop}
-          className="p-2"
-          onClose={nav.onClose}
-          onMinimize={nav.onMinimize}
-          onToggleMaximize={nav.onToggleMaximize}
-          isMaximized={nav.isMaximized}
-          closeLabel={nav.closeLabel}
-        />
-      }
-      right={<WindowNavSpacer isMobile={isMobileView} />}
-    />
+    <div
+      data-photos-header="true"
+      className={PHOTOS_HEADER_HEIGHT_CLASS_NAME}
+    >
+      <WindowNavShell
+        isMobile={isMobileView}
+        isScrolled={isScrolled}
+        className={cn(
+          "h-full border-b",
+          isScrolled ? "border-muted-foreground/20" : "border-transparent",
+        )}
+        onMouseDown={nav.onDragStart}
+        left={
+          <WindowControls
+            inShell={nav.inShell}
+            showWhenNotInShell={!isDesktop}
+            className="p-2"
+            onClose={nav.onClose}
+            onMinimize={nav.onMinimize}
+            onToggleMaximize={nav.onToggleMaximize}
+            isMaximized={nav.isMaximized}
+            closeLabel={nav.closeLabel}
+          />
+        }
+        right={<WindowNavSpacer isMobile={isMobileView} />}
+      />
+    </div>
   );
 }

--- a/components/apps/photos/photo-viewer.tsx
+++ b/components/apps/photos/photo-viewer.tsx
@@ -37,6 +37,7 @@ import {
   loadPhotoMetadata,
 } from "@/lib/photos/photo-metadata";
 import type { PhotoMetadata } from "@/lib/photos/photo-metadata";
+import { PhotosHeader } from "./header";
 import {
   createPhotoWheelGestureState,
   handlePhotoWheelGesture,
@@ -664,11 +665,9 @@ export function PhotoViewer({
   return (
     <div className="h-full flex flex-col bg-background">
       {/* Header - matches PhotosGrid header style */}
-      <div
-        className={cn(
-          "relative px-4 py-3 flex items-center justify-between border-b dark:border-foreground/20 select-none",
-          isMobileView ? "h-[69px] bg-background" : "bg-muted/50"
-        )}
+      <PhotosHeader
+        isMobileView={isMobileView}
+        className="justify-between"
         onMouseDown={inShell && !isMobileView ? windowFocus.onDragStart : undefined}
       >
         {/* Back button */}
@@ -879,7 +878,7 @@ export function PhotoViewer({
             />
           </button>
         </div>
-      </div>
+      </PhotosHeader>
 
       <div
         ref={mobileScrollRef}

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -9,6 +9,7 @@ import { toZonedTime } from "date-fns-tz";
 import { format, parseISO } from "date-fns";
 import Image from "next/image";
 import { getThumbnailUrl, getViewerUrl } from "@/lib/photos/image-utils";
+import { PhotosHeader } from "./header";
 
 // Preload viewer-size image on hover for faster viewer loading
 function preloadImage(url: string) {
@@ -115,47 +116,41 @@ export function PhotosGrid({
   return (
     <div className="h-full flex flex-col bg-background">
       {/* Header */}
-      <div
-        className={cn(
-          "h-[69px] px-4 py-3 flex items-center justify-between border-b dark:border-foreground/20 select-none",
-          isMobileView ? "bg-background" : "bg-muted/50"
-        )}
+      <PhotosHeader
+        isMobileView={isMobileView}
+        className="justify-between"
         onMouseDown={inShell && !isMobileView ? windowFocus.onDragStart : undefined}
       >
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           {isMobileView && (
             <button
               onClick={onBack}
               onMouseDown={(e) => e.stopPropagation()}
               aria-label="Back to Photos albums"
-              className="-ml-2 flex items-center text-muted-foreground"
+              className="-ml-2 flex shrink-0 items-center text-muted-foreground"
             >
               <ChevronLeft className="h-7 w-7" />
             </button>
           )}
-          <div>
-            <h1 className="text-lg font-semibold">{getViewTitle()}</h1>
-            {isMobileView ? (
-              <p
-                className={cn(
-                  "min-h-4 text-xs text-muted-foreground",
-                  (loading || error) && "invisible",
-                )}
-                aria-live="polite"
-              >
-                {photos.length} {photos.length === 1 ? "item" : "items"}
-              </p>
-            ) : (
-              dateRange && (
-                <p className="text-xs text-muted-foreground">{dateRange}</p>
-              )
-            )}
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-semibold">{getViewTitle()}</h1>
+            <p
+              className={cn(
+                "min-h-4 truncate text-xs text-muted-foreground",
+                (loading || error || (!isMobileView && !dateRange)) && "invisible",
+              )}
+              aria-live="polite"
+            >
+              {isMobileView
+                ? `${photos.length} ${photos.length === 1 ? "item" : "items"}`
+                : dateRange}
+            </p>
           </div>
         </div>
 
         {/* Time Filter Toggle - hidden on mobile */}
         {!isMobileView && (
-          <div className="flex items-center gap-0.5 bg-muted rounded-lg p-0.5">
+          <div className="flex shrink-0 items-center gap-0.5 bg-muted rounded-lg p-0.5">
             {(["years", "months", "all"] as TimeFilter[]).map((filter) => (
               <button
                 key={filter}
@@ -172,7 +167,7 @@ export function PhotosGrid({
             ))}
           </div>
         )}
-      </div>
+      </PhotosHeader>
 
       {/* Photo Grid */}
       <div

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -137,13 +137,13 @@ export function PhotosGrid({
             <p
               className={cn(
                 "min-h-4 truncate text-xs text-muted-foreground",
-                (loading || error || (!isMobileView && !dateRange)) && "invisible",
+                (loading || error) && "invisible",
               )}
               aria-live="polite"
             >
               {isMobileView
                 ? `${photos.length} ${photos.length === 1 ? "item" : "items"}`
-                : dateRange}
+                : dateRange || "0 photos"}
             </p>
           </div>
         </div>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -158,6 +158,13 @@ Use shared nav primitives instead of hand-rolling spacing and drag behavior:
 - `WindowNavSpacer` (`components/window-nav-shell.tsx`): standard invisible right-side spacer that balances traffic-light controls.
 - `useWindowNavBehavior` (`lib/use-window-nav-behavior.ts`): shared shell/close/minimize/maximize/drag behavior.
 
+Photos uses an app-specific fixed header frame in
+`components/apps/photos/header.tsx`. Every Photos top bar—including the
+sidebar toolbar, grid, viewer, and restored-viewer loading state—must reserve
+the shared 69px height. Keep subtitle and border space mounted when their
+content is hidden so asynchronous data and scroll-state changes cannot move
+the header contents.
+
 ```tsx
 const nav = useWindowNavBehavior({ isDesktop, isMobile: isMobileView });
 

--- a/tests/photos-header.test.ts
+++ b/tests/photos-header.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  PHOTOS_HEADER_HEIGHT_CLASS_NAME,
+  PHOTOS_HEADER_HEIGHT_PX,
+  PhotosHeader,
+} from "../components/apps/photos/header";
+
+test("Photos headers reserve one fixed-height frame", () => {
+  const markup = renderToStaticMarkup(
+    createElement(PhotosHeader, { isMobileView: false }, "Library"),
+  );
+
+  assert.equal(PHOTOS_HEADER_HEIGHT_PX, 69);
+  assert.equal(PHOTOS_HEADER_HEIGHT_CLASS_NAME, "h-[69px] min-h-[69px] shrink-0");
+  assert.match(markup, /data-photos-header="true"/);
+  assert.match(markup, /h-\[69px\]/);
+  assert.match(markup, /min-h-\[69px\]/);
+  assert.match(markup, /shrink-0/);
+});


### PR DESCRIPTION
## Summary

- introduce a shared fixed 69px Photos header frame
- apply it to the sidebar toolbar, grid, viewer, and restored-viewer loading state
- reserve subtitle and border space across asynchronous and scroll states
- truncate long titles and date ranges instead of allowing header geometry to grow
- add a regression test and document the Photos header invariant

## Root cause

Photos surfaces owned their header geometry independently. The grid used a 69px header, the desktop viewer rendered at roughly 52px, the sidebar toolbar rendered at roughly 48px, and the restored-viewer loading state rendered no header. The grid subtitle also mounted only after photo data arrived, vertically recentering the Library title.

## Impact

Photos now keeps the same header and content boundary while data loads, when switching between loaded and empty albums, and when moving between the grid and viewer. Mobile and desktop use the same fixed frame.

## Verification

- `npm run check`
- 71 tests pass
- TypeScript and production build pass
- browser verification confirmed sidebar, grid, empty Favorites, and viewer headers at 69px
- browser verification confirmed grid and viewer content both begin at the same `y=98` boundary
- no browser console warnings or errors