### PR TITLE
Fix Photos sidebar gallery navigation

### DIFF
--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -97,6 +97,7 @@ export default function App({ isDesktop = false }: AppProps) {
 
   const handleViewSelect = useCallback((view: PhotosView) => {
     setActiveView(view);
+    setSelectedPhotoId(null);
     setShowGrid(true);
   }, []);
 


### PR DESCRIPTION
## Summary

- Clear the open photo viewer whenever a Photos sidebar destination is selected.
- Ensure Favorites, Library, and collections consistently open in gallery view.

## Root cause

Sidebar navigation changed the active photo filter but retained `selectedPhotoId`. When the selected photo belonged to the newly selected destination—especially immediately after favoriting it—the filtered collection still resolved that photo and kept the viewer mounted instead of showing the gallery.

## User impact

Clicking Favorites in the Photos sidebar now always opens the Favorites gallery instead of carrying the currently viewed photo into that destination.

## Verification

- `npm run lint` (passes with 7 pre-existing warnings)
- `npm run test` (70 tests passed)
- `npm run typecheck`
- `npm run build` (with the repository's local Supabase environment)