### PR TITLE
Weather: delete saved locations

### DIFF
--- a/components/apps/weather/weather-app.tsx
+++ b/components/apps/weather/weather-app.tsx
@@ -13,6 +13,7 @@ import {
   Sun,
   Sunrise,
   Sunset,
+  Trash2,
   Wind,
   X,
 } from "lucide-react";
@@ -24,6 +25,7 @@ import {
   buildOpenMeteoForecastUrl,
   getWeatherDescription,
   getWeatherIconName,
+  getWeatherCitySelectionAfterRemoval,
   type WeatherMood,
   getWeatherScene,
   type WeatherScene,
@@ -40,6 +42,12 @@ import {
 } from "@/lib/sidebar-persistence";
 import { useWindowFocus } from "@/lib/window-focus-context";
 import { cn } from "@/lib/utils";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 
 interface WeatherAppProps {
   inShell?: boolean;
@@ -475,12 +483,14 @@ function SidebarCityItem({
   scene,
   isSelected,
   onSelect,
+  onDelete,
 }: {
   cityName: string;
   weather: CityWeather | null;
   scene: WeatherScene | null;
   isSelected: boolean;
   onSelect: () => void;
+  onDelete?: () => void;
 }) {
   const timeLabel = weather ? formatCityClock(weather.currentTime) : "--:--";
   const descriptionLabel = weather ? getWeatherDescription(weather.weatherCode) : "Loading...";
@@ -489,7 +499,7 @@ function SidebarCityItem({
     ? `H:${Math.round(weather.high)}° L:${Math.round(weather.low)}°`
     : "H:-- L:--";
 
-  return (
+  const cityButton = (
     <button
       type="button"
       onClick={onSelect}
@@ -535,6 +545,23 @@ function SidebarCityItem({
         </div>
       </div>
     </button>
+  );
+
+  if (!onDelete) return cityButton;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{cityButton}</ContextMenuTrigger>
+      <ContextMenuContent className="z-[100] min-w-[132px] rounded-lg border-white/10 bg-zinc-900/90 p-1 text-white shadow-2xl backdrop-blur-xl">
+        <ContextMenuItem
+          onSelect={onDelete}
+          className="text-[13px] text-red-400 focus:bg-white/10 focus:text-red-300"
+        >
+          <Trash2 className="h-4 w-4 shrink-0" aria-hidden />
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
@@ -862,6 +889,32 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
     []
   );
 
+  const handleDeleteCity = useCallback(
+    (cityId: string) => {
+      if (!customCities.some((city) => city.id === cityId)) return;
+
+      const nextSelectedCityId = getWeatherCitySelectionAfterRemoval(
+        allCities,
+        cityId,
+        selectedCityId
+      );
+
+      setCustomCities((previousCities) =>
+        previousCities.filter((city) => city.id !== cityId)
+      );
+      setWeatherByCity((previousWeatherByCity) => {
+        const nextWeatherByCity = { ...previousWeatherByCity };
+        delete nextWeatherByCity[cityId];
+        return nextWeatherByCity;
+      });
+
+      if (nextSelectedCityId) {
+        setSelectedCityId(nextSelectedCityId);
+      }
+    },
+    [allCities, customCities, selectedCityId]
+  );
+
   const dailyRange = useMemo(() => {
     const daily = selectedWeather?.daily ?? [];
     const min = Math.min(...daily.map((d) => d.low), 0);
@@ -1087,6 +1140,11 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                         scene={city.scene}
                         isSelected={city.id === selectedCityId}
                         onSelect={() => setSelectedCityId(city.id)}
+                        onDelete={
+                          customCities.some((customCity) => customCity.id === city.id)
+                            ? () => handleDeleteCity(city.id)
+                            : undefined
+                        }
                       />
                     ))}
                   </div>

--- a/components/apps/weather/weather-app.tsx
+++ b/components/apps/weather/weather-app.tsx
@@ -552,10 +552,10 @@ function SidebarCityItem({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{cityButton}</ContextMenuTrigger>
-      <ContextMenuContent className="z-[100] min-w-[132px] rounded-lg border-white/10 bg-zinc-900/90 p-1 text-white shadow-2xl backdrop-blur-xl">
+      <ContextMenuContent className="z-[100] min-w-[132px] rounded-lg border-black/70 bg-[rgba(5,24,43,0.65)] p-1 text-white shadow-2xl backdrop-blur-xl">
         <ContextMenuItem
           onSelect={onDelete}
-          className="text-[13px] text-red-400 focus:bg-white/10 focus:text-red-300"
+          className="text-[13px] text-white focus:bg-[#467ED7] focus:text-white"
         >
           <Trash2 className="h-4 w-4 shrink-0" aria-hidden />
           Delete

--- a/components/apps/weather/weather-app.tsx
+++ b/components/apps/weather/weather-app.tsx
@@ -552,13 +552,13 @@ function SidebarCityItem({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{cityButton}</ContextMenuTrigger>
-      <ContextMenuContent className="z-[100] min-w-[132px] rounded-lg border-black/70 bg-[rgba(5,24,43,0.65)] p-1 text-white shadow-2xl backdrop-blur-xl">
+      <ContextMenuContent>
         <ContextMenuItem
-          onSelect={onDelete}
-          className="text-[13px] text-white focus:bg-[#467ED7] focus:text-white"
+          className="text-red-600 focus:rounded-md focus:bg-[#0A7CFF] focus:text-white"
+          onClick={onDelete}
         >
-          <Trash2 className="h-4 w-4 shrink-0" aria-hidden />
-          Delete
+          <Trash2 className="h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden />
+          <span>Delete</span>
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/lib/weather.ts
+++ b/lib/weather.ts
@@ -35,6 +35,23 @@ export interface WeatherScene {
   isDark: boolean;
 }
 
+interface WeatherCityIdentity {
+  id: string;
+}
+
+export function getWeatherCitySelectionAfterRemoval(
+  cities: WeatherCityIdentity[],
+  removedCityId: string,
+  selectedCityId: string
+): string | null {
+  if (selectedCityId !== removedCityId) return selectedCityId;
+
+  const removedIndex = cities.findIndex((city) => city.id === removedCityId);
+  if (removedIndex === -1) return null;
+
+  return cities[removedIndex + 1]?.id ?? cities[removedIndex - 1]?.id ?? null;
+}
+
 interface WeatherThemeDefinition {
   background: string;
   heroGradient: string;

--- a/tests/weather-locations.test.ts
+++ b/tests/weather-locations.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getWeatherCitySelectionAfterRemoval } from "../lib/weather";
+
+const cities = [
+  { id: "san-francisco" },
+  { id: "seattle" },
+  { id: "tokyo" },
+];
+
+test("keeps the current Weather selection when another city is removed", () => {
+  assert.equal(
+    getWeatherCitySelectionAfterRemoval(cities, "tokyo", "seattle"),
+    "seattle"
+  );
+});
+
+test("selects the next Weather city after removing the current city", () => {
+  assert.equal(
+    getWeatherCitySelectionAfterRemoval(cities, "seattle", "seattle"),
+    "tokyo"
+  );
+});
+
+test("falls back to the previous Weather city at the end of the list", () => {
+  assert.equal(
+    getWeatherCitySelectionAfterRemoval(cities, "tokyo", "tokyo"),
+    "seattle"
+  );
+});


### PR DESCRIPTION
## Today's delight

Weather now lets people remove locations they added: Control-click or right-click a custom city and choose the native-style **Delete** command.

## Baseline and delta

- Before: search could add and select locations, but there was no visible way to remove one.
- Now: only user-added locations expose **Delete**; deleting the selected city chooses the next neighbor, or the previous city at the end of the list.
- Preserved: default cities remain fixed, normal selection and forecast loading are unchanged, and removed custom-city weather is pruned from the cache.

## Built result — desktop

![Weather Delete menu using the same context-menu treatment as Messages](https://github.com/user-attachments/assets/eebc0acd-5acf-43b6-850c-8c88b094a3b3)

At 1440×900, Tokyo is selected with live weather. Weather now uses the shared default context-menu surface and the exact Messages Delete treatment: red destructive icon/text at rest, with the Messages blue (`#0A7CFF`) and white icon/text on focus.

## Built result — mobile

![The preserved Notes fallback at a touch-emulated iPhone viewport](https://github.com/user-attachments/assets/25622ec0-3888-41f9-bbe0-810a934f2ba7)

Weather is intentionally desktop-only in the registry. At an iPhone 390×844 viewport with true touch/coarse-pointer emulation, `/weather` still redirects to the supported Notes experience; opening a note and returning to the list both passed.

## macOS inspiration

Apple's current [Weather User Guide](https://support.apple.com/en-in/guide/weather-mac/apdw6e8e3a44/mac) documents removing a location by Control-clicking it in the sidebar and choosing Delete. This implementation maps that familiar command only to user-added locations; the site's curated defaults remain fixed. The command's presentation now deliberately matches the existing Messages context menu for consistency across this desktop.

## Why this one

Weather's last daily delight was 2026-07-30, and its last user-visible touch was the 2026-08-12 mobile-availability policy. The last two daily primary surfaces were Dock and window management, while the only open non-delight PR is Games-only, so this is both neglected and non-overlapping.

## Verification

- `npm run check` with the repository environment — lint, all 106 tests, typecheck, compilation, and generation of all 41 routes passed
- Exact Messages parity — default `ContextMenuContent`, identical Delete focus classes, 16px `Trash2` icon, and `1.8` stroke width
- Computed resting command — `rgb(220, 38, 38)` icon/text on the shared `rgb(245, 245, 245)` context-menu surface
- Production desktop at 1440×900 — context menu, deletion, fallback to Paris, cache pruning, and reload persistence verified
- Production iPhone at 390×844, DPR 3 — `maxTouchPoints: 5`, `(pointer: coarse)`, `(hover: none)`, redirect to Notes, and touch open/back verified

## Scope

Micro: three files, 107 additions and one deletion. The latest follow-up changes only the Weather menu presentation to reuse the existing Messages pattern; it introduces no new behavior, mobile path, keyboard handling, schema, dependency, or external service.
