### PR TITLE
Calendar can show week numbers

### DIFF
--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -148,9 +148,14 @@ function saveUserEvents(events: CalendarEvent[]): void {
 interface CalendarAppProps {
   isMobile?: boolean;
   inShell?: boolean;
+  showWeekNumbers?: boolean;
 }
 
-export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppProps) {
+export function CalendarApp({
+  isMobile = false,
+  inShell = false,
+  showWeekNumbers = false,
+}: CalendarAppProps) {
   const windowFocus = useWindowFocus();
   const containerRef = useRef<HTMLDivElement>(null);
   const dialogContainer =
@@ -444,6 +449,7 @@ export function CalendarApp({ isMobile = false, inShell = false }: CalendarAppPr
             currentDate={currentDate}
             events={events}
             calendars={calendars}
+            showWeekNumbers={showWeekNumbers}
             onCreateEvent={handleCreateEvent}
             onDateClick={handleDateClick}
             onEditEvent={handleEditEvent}

--- a/components/apps/calendar/month-view.tsx
+++ b/components/apps/calendar/month-view.tsx
@@ -16,6 +16,7 @@ import {
   format,
   formatEventTime,
   getUpcomingEventDefaults,
+  getCalendarWeekNumber,
   prioritizeUserEvents,
 } from "./utils";
 import { CalendarEvent, Calendar } from "./types";
@@ -34,6 +35,7 @@ interface MonthViewProps {
   onMonthChange?: (date: Date) => void;
   onEditEvent?: (eventId: string) => void;
   onViewEvent?: (event: CalendarEvent) => void;
+  showWeekNumbers?: boolean;
 }
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -66,6 +68,7 @@ export function MonthView({
   onMonthChange,
   onEditEvent,
   onViewEvent,
+  showWeekNumbers = false,
 }: MonthViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [visibleMonth, setVisibleMonth] = useState(currentDate);
@@ -217,7 +220,15 @@ export function MonthView({
       </div>
 
       {/* Weekday headers */}
-      <div className="grid grid-cols-7 border-b border-border bg-muted/30">
+      <div
+        className={cn(
+          "grid border-b border-border bg-muted/30",
+          showWeekNumbers
+            ? "grid-cols-[2.25rem_repeat(7,minmax(0,1fr))]"
+            : "grid-cols-7"
+        )}
+      >
+        {showWeekNumbers && <div aria-hidden="true" className="border-r border-border" />}
         {WEEKDAYS.map((day) => (
           <div
             key={day}
@@ -240,12 +251,26 @@ export function MonthView({
           {visibleWeeks.map(({ index, days }) => (
             <div
               key={index}
-              className="grid grid-cols-7 absolute left-0 right-0"
+              className={cn(
+                "absolute left-0 right-0 grid",
+                showWeekNumbers
+                  ? "grid-cols-[2.25rem_repeat(7,minmax(0,1fr))]"
+                  : "grid-cols-7"
+              )}
               style={{
                 top: index * WEEK_HEIGHT,
                 height: WEEK_HEIGHT,
               }}
             >
+              {showWeekNumbers && (
+                <div
+                  data-week-number={getCalendarWeekNumber(days[0])}
+                  className="border-b border-r border-border pt-2 text-center text-[11px] font-medium tabular-nums text-muted-foreground/70"
+                  aria-label={`Week ${getCalendarWeekNumber(days[0])}`}
+                >
+                  {getCalendarWeekNumber(days[0])}
+                </div>
+              )}
               {days.map((day, dayIdx) => {
                 const dayEvents = getEventsForDay(events, day);
                 const orderedDayEvents = prioritizeUserEvents(dayEvents, userEventIds);

--- a/components/apps/calendar/utils.ts
+++ b/components/apps/calendar/utils.ts
@@ -21,6 +21,13 @@ import {
 } from "date-fns";
 import { CalendarEvent, ViewType } from "./types";
 
+export function getCalendarWeekNumber(date: Date): number {
+  return getWeek(date, {
+    weekStartsOn: 0,
+    firstWeekContainsDate: 1,
+  });
+}
+
 // Date night restaurants (cycled through on Saturdays)
 const DATE_NIGHT_RESTAURANTS = [
   { name: "3rd Cousin", address: "919 Cortland Ave, SF" },

--- a/components/desktop/calendar-view-menu.tsx
+++ b/components/desktop/calendar-view-menu.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRef } from "react";
+import { Check } from "lucide-react";
+import { useClickOutside } from "@/lib/hooks/use-click-outside";
+
+interface CalendarViewMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  weekNumbersVisible: boolean;
+  onWeekNumbersVisibleChange: (visible: boolean) => void;
+}
+
+export function CalendarViewMenu({
+  isOpen,
+  onClose,
+  weekNumbersVisible,
+  onWeekNumbersVisibleChange,
+}: CalendarViewMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(menuRef, onClose, isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Calendar view options"
+      className="absolute left-[128px] top-7 w-56 overflow-hidden rounded-lg border border-black/10 bg-white/95 py-1 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+    >
+      <button
+        type="button"
+        role="menuitemcheckbox"
+        aria-checked={weekNumbersVisible}
+        onClick={() => {
+          onWeekNumbersVisibleChange(!weekNumbersVisible);
+          onClose();
+        }}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+      >
+        <span className="flex h-4 w-4 items-center justify-center">
+          {weekNumbersVisible && <Check className="h-4 w-4" strokeWidth={3} />}
+        </span>
+        <span>Show Week Numbers</span>
+      </button>
+    </div>
+  );
+}

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -74,6 +74,7 @@ type DesktopMode = "active" | "locked" | "sleeping" | "shuttingDown" | "restarti
 
 const FINDER_STATUS_BAR_STORAGE_KEY = "finder-show-status-bar";
 const FINDER_PATH_BAR_STORAGE_KEY = "finder-show-path-bar";
+const CALENDAR_WEEK_NUMBERS_STORAGE_KEY = "calendar-show-week-numbers";
 
 interface DesktopProps {
   initialAppId?: string;
@@ -229,6 +230,8 @@ function DesktopContent({
   const [hasLoadedFinderStatusBarPreference, setHasLoadedFinderStatusBarPreference] = useState(false);
   const [finderPathBarVisible, setFinderPathBarVisible] = useState(false);
   const [hasLoadedFinderPathBarPreference, setHasLoadedFinderPathBarPreference] = useState(false);
+  const [calendarWeekNumbersVisible, setCalendarWeekNumbersVisible] = useState(false);
+  const [hasLoadedCalendarWeekNumbersPreference, setHasLoadedCalendarWeekNumbersPreference] = useState(false);
   const [finderRouteProcessed, setFinderRouteProcessed] = useState(initialAppId !== "finder");
   const initialDocumentRouteAppId =
     initialAppId === "textedit" || initialAppId === "preview" ? initialAppId : null;
@@ -248,6 +251,10 @@ function DesktopContent({
     setHasLoadedFinderStatusBarPreference(true);
     setFinderPathBarVisible(window.localStorage.getItem(FINDER_PATH_BAR_STORAGE_KEY) === "true");
     setHasLoadedFinderPathBarPreference(true);
+    setCalendarWeekNumbersVisible(
+      window.localStorage.getItem(CALENDAR_WEEK_NUMBERS_STORAGE_KEY) === "true"
+    );
+    setHasLoadedCalendarWeekNumbersPreference(true);
   }, []);
 
   useEffect(() => {
@@ -259,6 +266,14 @@ function DesktopContent({
     if (!hasLoadedFinderPathBarPreference) return;
     window.localStorage.setItem(FINDER_PATH_BAR_STORAGE_KEY, String(finderPathBarVisible));
   }, [finderPathBarVisible, hasLoadedFinderPathBarPreference]);
+
+  useEffect(() => {
+    if (!hasLoadedCalendarWeekNumbersPreference) return;
+    window.localStorage.setItem(
+      CALENDAR_WEEK_NUMBERS_STORAGE_KEY,
+      String(calendarWeekNumbersVisible)
+    );
+  }, [calendarWeekNumbersVisible, hasLoadedCalendarWeekNumbersPreference]);
   const getNotesSlugForRouting = useCallback(
     () => getNotesSelectedSlugMemory() ?? loadNotesSelectedSlug() ?? undefined,
     []
@@ -931,6 +946,8 @@ function DesktopContent({
         onFinderStatusBarVisibleChange={setFinderStatusBarVisible}
         finderPathBarVisible={finderPathBarVisible}
         onFinderPathBarVisibleChange={setFinderPathBarVisible}
+        calendarWeekNumbersVisible={calendarWeekNumbersVisible}
+        onCalendarWeekNumbersVisibleChange={setCalendarWeekNumbersVisible}
         onTextEditNew={handleTextEditNew}
         onTextEditOpen={handleTextEditOpen}
         onTextEditClose={handleTextEditClose}
@@ -976,7 +993,10 @@ function DesktopContent({
           </Window>
 
           <Window appId="calendar">
-            <CalendarApp inShell={true} />
+            <CalendarApp
+              inShell={true}
+              showWeekNumbers={calendarWeekNumbersVisible}
+            />
           </Window>
 
           <Window appId="weather">

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -14,6 +14,7 @@ import { NotificationCenter } from "./notification-center";
 import { AppMenu } from "./app-menu";
 import { FileMenu } from "./file-menu";
 import { FinderViewMenu } from "./finder-view-menu";
+import { CalendarViewMenu } from "./calendar-view-menu";
 import { TextEditEditMenu } from "./textedit-edit-menu";
 import { TextEditFileMenu, TextEditRenameDialog } from "./textedit-file-menu";
 import { PreviewFileMenu } from "./preview-file-menu";
@@ -29,7 +30,7 @@ import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 import type { FinderViewMode } from "@/components/apps/finder/view-mode";
 import { TEXTEDIT_OPEN_FIND_EVENT } from "@/lib/textedit-find";
 
-type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "previewFileMenu" | "finderViewMenu" | "textEditEditMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
+type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "previewFileMenu" | "finderViewMenu" | "calendarViewMenu" | "textEditEditMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
 
 const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
 
@@ -66,6 +67,8 @@ interface MenuBarProps {
   onFinderStatusBarVisibleChange?: (visible: boolean) => void;
   finderPathBarVisible?: boolean;
   onFinderPathBarVisibleChange?: (visible: boolean) => void;
+  calendarWeekNumbersVisible?: boolean;
+  onCalendarWeekNumbersVisibleChange?: (visible: boolean) => void;
   onTextEditNew?: () => void;
   onTextEditOpen?: () => void;
   onTextEditClose?: (windowId: string) => void;
@@ -94,6 +97,8 @@ export function MenuBar({
   onFinderStatusBarVisibleChange,
   finderPathBarVisible = false,
   onFinderPathBarVisibleChange,
+  calendarWeekNumbersVisible = false,
+  onCalendarWeekNumbersVisibleChange,
   onTextEditNew,
   onTextEditOpen,
   onTextEditClose,
@@ -333,6 +338,19 @@ export function MenuBar({
               View
             </button>
           )}
+          {focusedAppId === "calendar" && (
+            <button
+              onClick={() => toggleMenu("calendarViewMenu")}
+              className={cn(
+                "rounded px-2 py-0.5 text-sm transition-colors",
+                openMenu === "calendarViewMenu"
+                  ? "bg-blue-500 text-white"
+                  : "text-black can-hover:hover:bg-white/10 dark:text-white"
+              )}
+            >
+              View
+            </button>
+          )}
           {focusedAppId === "textedit" && (
             <button
               onClick={() => toggleMenu("textEditEditMenu")}
@@ -508,6 +526,15 @@ export function MenuBar({
         onStatusBarVisibleChange={(visible) => onFinderStatusBarVisibleChange?.(visible)}
         pathBarVisible={finderPathBarVisible}
         onPathBarVisibleChange={(visible) => onFinderPathBarVisibleChange?.(visible)}
+      />
+
+      <CalendarViewMenu
+        isOpen={openMenu === "calendarViewMenu"}
+        onClose={closeMenu}
+        weekNumbersVisible={calendarWeekNumbersVisible}
+        onWeekNumbersVisibleChange={(visible) =>
+          onCalendarWeekNumbersVisibleChange?.(visible)
+        }
       />
 
       <TextEditEditMenu

--- a/tests/calendar-week-numbers.test.ts
+++ b/tests/calendar-week-numbers.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getCalendarWeekNumber } from "../components/apps/calendar/utils";
+
+test("uses Sunday-based US calendar week numbers", () => {
+  assert.equal(getCalendarWeekNumber(new Date(2026, 7, 16)), 34);
+  assert.equal(getCalendarWeekNumber(new Date(2026, 7, 22)), 34);
+  assert.equal(getCalendarWeekNumber(new Date(2026, 7, 23)), 35);
+});
+
+test("starts week one with the Sunday containing January 1", () => {
+  assert.equal(getCalendarWeekNumber(new Date(2026, 11, 27)), 1);
+  assert.equal(getCalendarWeekNumber(new Date(2027, 0, 2)), 1);
+  assert.equal(getCalendarWeekNumber(new Date(2027, 0, 3)), 2);
+});


### PR DESCRIPTION
## Today's delight

Calendar's Month view can now show native-style week numbers from the desktop **View → Show Week Numbers** menu. The preference is optional, checked when active, and persists across reloads.

## Baseline and delta

- Before: Month view showed seven day columns with no week-number option; Today, view switching, New Event, day activation, and event activation already worked.
- Now: a checked View-menu command reveals a quiet week-number gutter beside the Month grid and remembers the choice.
- Preserved: the default remains unchanged, hiding restores the original seven-column layout, desktop Calendar interactions still work, and mobile keeps its focused Week view and touch-first event flow.

## Built result — desktop

![Desktop screenshot of the implemented delight](https://github.com/user-attachments/assets/0f81d40a-2083-4fd7-8dee-f38d8065aa60)

At 1440×900, August 2026 shows weeks 32–37 in the new gutter while the View menu displays the checked preference. I also exercised hide/show, reload persistence, Today, Month selection, and New Event open/cancel.

## Built result — mobile

![Mobile screenshot of the preserved Calendar experience](https://github.com/user-attachments/assets/88cecc3b-3175-49c0-9bc3-dd754c257138)

At an iPhone-sized 390×844 CSS viewport (DPR 3), Calendar retains its compact Week view without the desktop menu or gutter. Coarse-pointer touch emulation confirmed New Event opens and Cancel closes the sheet.

## macOS inspiration

Apple documents **Show week numbers** as a Calendar setting for Week, Month, and Year views: https://support.apple.com/en-gb/guide/calendar/icl26670/mac. The installed Calendar bundle also contains the exact localized label. This implementation maps that native, optional planning aid to the site's existing app-specific View-menu pattern and renders the numbers as a subdued Month gutter.

## Why this one

Calendar's last daily delight and last visible touch were both 2026-08-01, making it a neglected registered app compared with the last two daily primary surfaces, Weather (2026-08-14) and Dock (2026-08-12). It adds a recognizable, useful planning detail without overlapping open Notification Center or Games work.

## Verification

- `npm run check` (passed with the Turbopack worker disabled to avoid the sandbox's helper-port restriction; 108 tests passed, typecheck passed, 41 routes built; 7 existing lint warnings)
- Desktop: 1440×900; toggle, checked state, persistence, Today, Month, and New Event open/cancel
- Mobile: iPhone 390×844 CSS at DPR 3; real touch/coarse-pointer emulation; New Event open/cancel
- `node --import tsx --test tests/calendar-week-numbers.test.ts tests/calendar-month-events.test.ts tests/calendar-event-defaults.test.ts` (8 tests passed)

## Scope

Small: seven focused product/test files, 155 additions and 5 deletions. The 45-day default-branch delight audit, recent visible work, and open PR review found no Calendar overlap; no screenshots or review-only artifacts are committed.