### PR TITLE
Add collapsible Notes sections

### DIFF
--- a/components/apps/notes/note-content.tsx
+++ b/components/apps/notes/note-content.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import React, { useCallback, useRef, useEffect, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Image from "next/image";
 import { Textarea } from "@/components/ui/textarea";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { ChevronRight } from "lucide-react";
 import { Note } from "@/lib/notes/types";
 import { Icons } from "./icons";
 import {
@@ -13,6 +21,7 @@ import {
   uploadNoteImage,
   insertImageMarkdown,
 } from "@/lib/notes/image-upload";
+import { getPrimaryCollapsibleHeadingLevel } from "@/lib/notes/collapsible-sections";
 import { cn } from "@/lib/utils";
 
 const SPACE_TAB = "  ";
@@ -51,6 +60,97 @@ function getTaskText(node: React.ReactNode): string {
   return getTaskText(node.props.children);
 }
 
+type MarkdownHeadingProps = React.ComponentPropsWithoutRef<"h2"> & {
+  node?: unknown;
+};
+
+function setSectionContentHidden(
+  heading: HTMLHeadingElement | null,
+  level: number,
+  hidden: boolean,
+) {
+  let sibling = heading?.nextElementSibling;
+
+  while (sibling) {
+    const siblingHeading = sibling.tagName.match(/^H([1-6])$/);
+    if (siblingHeading && Number(siblingHeading[1]) <= level) break;
+
+    (sibling as HTMLElement).hidden = hidden;
+    sibling = sibling.nextElementSibling;
+  }
+}
+
+function CollapsibleMarkdownHeading({
+  children,
+  level,
+  isCollapsible,
+  node: _node,
+  ...props
+}: MarkdownHeadingProps & {
+  level: number;
+  isCollapsible: boolean;
+}) {
+  void _node;
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const Heading = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+  useLayoutEffect(() => {
+    if (!isCollapsible) return;
+
+    const heading = headingRef.current;
+    setSectionContentHidden(heading, level, isCollapsed);
+    return () => {
+      if (isCollapsed) {
+        setSectionContentHidden(heading, level, false);
+      }
+    };
+  }, [isCollapsed, isCollapsible, level]);
+
+  if (!isCollapsible) {
+    return <Heading {...props}>{children}</Heading>;
+  }
+
+  const headingText = getTaskText(children).trim() || "section";
+
+  return (
+    <Heading
+      {...props}
+      ref={headingRef}
+      className={cn("group flex items-start", props.className)}
+      data-collapsible-section-heading
+    >
+      <button
+        type="button"
+        aria-expanded={!isCollapsed}
+        aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${headingText}`}
+        className={cn(
+          "mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+          "desktop:size-5",
+          isCollapsed
+            ? "desktop:opacity-100"
+            : "desktop:opacity-0 desktop:can-hover:group-hover:opacity-100 desktop:group-focus-within:opacity-100",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF] focus-visible:ring-offset-1",
+        )}
+        onClick={(event) => {
+          event.stopPropagation();
+          setIsCollapsed((current) => !current);
+        }}
+      >
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            "size-4 transition-transform motion-reduce:transition-none",
+            !isCollapsed && "rotate-90",
+          )}
+          strokeWidth={2.25}
+        />
+      </button>
+      <span className="min-w-0">{children}</span>
+    </Heading>
+  );
+}
+
 export default function NoteContent({
   note,
   saveNote,
@@ -71,6 +171,10 @@ export default function NoteContent({
   const [isUploadingImages, setIsUploadingImages] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [isUploadFeedbackDismissed, setIsUploadFeedbackDismissed] = useState(false);
+  const collapsibleHeadingLevel = useMemo(
+    () => getPrimaryCollapsibleHeadingLevel(note.content),
+    [note.content],
+  );
 
   const stopPropagation = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -466,6 +570,48 @@ export default function NoteContent({
               li: renderListItem,
               a: renderLink,
               img: renderImage,
+              h1: (props) => (
+                <CollapsibleMarkdownHeading
+                  {...props}
+                  level={1}
+                  isCollapsible={collapsibleHeadingLevel === 1}
+                />
+              ),
+              h2: (props) => (
+                <CollapsibleMarkdownHeading
+                  {...props}
+                  level={2}
+                  isCollapsible={collapsibleHeadingLevel === 2}
+                />
+              ),
+              h3: (props) => (
+                <CollapsibleMarkdownHeading
+                  {...props}
+                  level={3}
+                  isCollapsible={collapsibleHeadingLevel === 3}
+                />
+              ),
+              h4: (props) => (
+                <CollapsibleMarkdownHeading
+                  {...props}
+                  level={4}
+                  isCollapsible={collapsibleHeadingLevel === 4}
+                />
+              ),
+              h5: (props) => (
+                <CollapsibleMarkdownHeading
+                  {...props}
+                  level={5}
+                  isCollapsible={collapsibleHeadingLevel === 5}
+                />
+              ),
+              h6: (props) => (
+                <CollapsibleMarkdownHeading
+                  {...props}
+                  level={6}
+                  isCollapsible={collapsibleHeadingLevel === 6}
+                />
+              ),
             }}
           >
             {note.content || "Start writing..."}

--- a/components/apps/notes/note-content.tsx
+++ b/components/apps/notes/note-content.tsx
@@ -74,60 +74,47 @@ type MarkdownHeadingProps = React.ComponentPropsWithoutRef<"h2"> & {
 function CollapsibleMarkdownHeading({
   children,
   level,
-  isCollapsed,
-  onToggle,
   node: _node,
   ...props
 }: MarkdownHeadingProps & {
   level: number;
-  isCollapsed: boolean;
-  onToggle: () => void;
 }) {
   void _node;
-  const headingText = getTaskText(children).trim() || "section";
   const Heading = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
   return (
-    <Heading
-      {...props}
-      className={cn("group", props.className)}
-      data-collapsible-section-heading
-      data-collapsed={isCollapsed}
+    <summary
+      className={cn(
+        "group/heading list-none rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF] focus-visible:ring-offset-1",
+        "[&::-webkit-details-marker]:hidden",
+      )}
+      onClick={(event) => event.stopPropagation()}
     >
-      <button
-        type="button"
-        aria-expanded={!isCollapsed}
-        aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${headingText}`}
+      <Heading
+        {...props}
         className={cn(
-          "flex w-full items-start rounded-md text-left text-inherit",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF] focus-visible:ring-offset-1",
+          "flex w-full items-start text-left text-inherit",
+          props.className,
         )}
-        onClick={(event) => {
-          event.stopPropagation();
-          onToggle();
-        }}
+        data-collapsible-section-heading
       >
         <span
           className={cn(
-            "mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+            "section-chevron-shell mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
             "desktop:size-5",
-            isCollapsed
-              ? "desktop:opacity-100"
-              : "desktop:opacity-0 desktop:can-hover:group-hover:opacity-100 desktop:group-focus-within:opacity-100",
+            "desktop:opacity-100 desktop:group-open/section:opacity-0",
+            "desktop:can-hover:group-hover/heading:opacity-100 desktop:group-focus-within/heading:opacity-100",
           )}
         >
           <ChevronRight
             aria-hidden="true"
-            className={cn(
-              "size-4 transition-transform motion-reduce:transition-none",
-              !isCollapsed && "rotate-90",
-            )}
+            className="section-chevron size-4 transition-transform motion-reduce:transition-none group-open/section:rotate-90"
             strokeWidth={2.25}
           />
         </span>
         <span className="min-w-0">{children}</span>
-      </button>
-    </Heading>
+      </Heading>
+    </summary>
   );
 }
 
@@ -148,10 +135,16 @@ function CollapsibleMarkdownSection({
     level,
     getMarkdownHeadingText(headingMarkdown),
   );
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  const hasRestoredRef = useRef(false);
 
   useLayoutEffect(() => {
-    setIsCollapsed(loadCollapsedSection(noteId, sectionKey));
+    const details = detailsRef.current;
+    if (!details) return;
+
+    hasRestoredRef.current = false;
+    details.open = !loadCollapsedSection(noteId, sectionKey);
+    hasRestoredRef.current = true;
   }, [noteId, sectionKey]);
 
   const headingTag = `h${level}` as keyof Components;
@@ -161,29 +154,30 @@ function CollapsibleMarkdownSection({
       <CollapsibleMarkdownHeading
         {...props}
         level={level}
-        isCollapsed={isCollapsed}
-        onToggle={() => {
-          setIsCollapsed((current) => {
-            const next = !current;
-            saveCollapsedSection(noteId, sectionKey, next);
-            return next;
-          });
-        }}
       />
     ),
   } as Components;
 
   return (
-    <>
+    <details
+      ref={detailsRef}
+      open
+      className="group/section"
+      data-collapsible-section
+      onToggle={(event) => {
+        if (!hasRestoredRef.current) return;
+        saveCollapsedSection(noteId, sectionKey, !event.currentTarget.open);
+      }}
+    >
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={headingComponents}>
         {headingMarkdown}
       </ReactMarkdown>
-      {!isCollapsed && bodyMarkdown && (
+      {bodyMarkdown && (
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
           {bodyMarkdown}
         </ReactMarkdown>
       )}
-    </>
+    </details>
   );
 }
 

--- a/components/apps/notes/note-content.tsx
+++ b/components/apps/notes/note-content.tsx
@@ -161,7 +161,6 @@ function CollapsibleMarkdownSection({
   return (
     <details
       ref={detailsRef}
-      open
       className="group/section"
       data-collapsible-section
       onToggle={(event) => {

--- a/components/apps/notes/note-content.tsx
+++ b/components/apps/notes/note-content.tsx
@@ -129,7 +129,7 @@ function CollapsibleMarkdownHeading({
     <Heading
       {...props}
       ref={headingRef}
-      className={cn("group flex items-start", props.className)}
+      className={cn("group", props.className)}
       data-collapsible-section-heading
     >
       <button
@@ -137,11 +137,7 @@ function CollapsibleMarkdownHeading({
         aria-expanded={!isCollapsed}
         aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${headingText}`}
         className={cn(
-          "mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
-          "desktop:size-5",
-          isCollapsed
-            ? "desktop:opacity-100"
-            : "desktop:opacity-0 desktop:can-hover:group-hover:opacity-100 desktop:group-focus-within:opacity-100",
+          "flex w-full items-start rounded-md text-left text-inherit",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF] focus-visible:ring-offset-1",
         )}
         onClick={(event) => {
@@ -153,16 +149,26 @@ function CollapsibleMarkdownHeading({
           });
         }}
       >
-        <ChevronRight
-          aria-hidden="true"
+        <span
           className={cn(
-            "size-4 transition-transform motion-reduce:transition-none",
-            !isCollapsed && "rotate-90",
+            "mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+            "desktop:size-5",
+            isCollapsed
+              ? "desktop:opacity-100"
+              : "desktop:opacity-0 desktop:can-hover:group-hover:opacity-100 desktop:group-focus-within:opacity-100",
           )}
-          strokeWidth={2.25}
-        />
+        >
+          <ChevronRight
+            aria-hidden="true"
+            className={cn(
+              "size-4 transition-transform motion-reduce:transition-none",
+              !isCollapsed && "rotate-90",
+            )}
+            strokeWidth={2.25}
+          />
+        </span>
+        <span className="min-w-0">{children}</span>
       </button>
-      <span className="min-w-0">{children}</span>
     </Heading>
   );
 }

--- a/components/apps/notes/note-content.tsx
+++ b/components/apps/notes/note-content.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React, {
+  createContext,
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -22,12 +24,9 @@ import {
   insertImageMarkdown,
 } from "@/lib/notes/image-upload";
 import {
-  getCollapsibleSectionKey,
-  getMarkdownHeadingText,
-  getPrimaryCollapsibleHeadingLevel,
   loadCollapsedSection,
+  remarkCollapsibleSections,
   saveCollapsedSection,
-  splitMarkdownIntoCollapsibleSections,
 } from "@/lib/notes/collapsible-sections";
 import { cn } from "@/lib/utils";
 
@@ -69,35 +68,50 @@ function getTaskText(node: React.ReactNode): string {
 
 type MarkdownHeadingProps = React.ComponentPropsWithoutRef<"h2"> & {
   node?: unknown;
+  "data-collapsible-heading"?: string;
+  "data-heading-level"?: string;
 };
+
+type CollapsibleSectionContextValue = {
+  isCollapsed: boolean;
+  toggleSection: () => void;
+};
+
+const CollapsibleNoteIdContext = createContext<string | null>(null);
+const CollapsibleSectionContext = createContext<CollapsibleSectionContextValue | null>(null);
 
 function CollapsibleMarkdownHeading({
   children,
   level,
-  isCollapsed,
-  onToggle,
   node: _node,
+  "data-collapsible-heading": collapsibleHeading,
+  "data-heading-level": _headingLevel,
   ...props
 }: MarkdownHeadingProps & {
   level: number;
-  isCollapsed: boolean;
-  onToggle: () => void;
 }) {
   void _node;
-  const headingText = getTaskText(children).trim() || "section";
+  void _headingLevel;
   const Heading = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  const section = useContext(CollapsibleSectionContext);
+
+  if (collapsibleHeading === undefined || !section) {
+    return <Heading {...props}>{children}</Heading>;
+  }
+
+  const headingText = getTaskText(children).trim() || "section";
 
   return (
     <Heading
       {...props}
       className={cn("group/heading", props.className)}
       data-collapsible-section-heading
-      data-collapsed={isCollapsed}
+      data-collapsed={section.isCollapsed}
     >
       <button
         type="button"
-        aria-expanded={!isCollapsed}
-        aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${headingText}`}
+        aria-expanded={!section.isCollapsed}
+        aria-label={`${section.isCollapsed ? "Expand" : "Collapse"} ${headingText}`}
         className={cn(
           "flex w-full items-start rounded-md text-left text-inherit",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF] focus-visible:ring-offset-1",
@@ -105,14 +119,14 @@ function CollapsibleMarkdownHeading({
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();
-          onToggle();
+          section.toggleSection();
         }}
       >
         <span
           className={cn(
             "section-chevron-shell mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
             "desktop:size-5",
-            isCollapsed
+            section.isCollapsed
               ? "desktop:opacity-100"
               : "desktop:opacity-0 desktop:can-hover:group-hover/heading:opacity-100 desktop:group-focus-within/heading:opacity-100",
           )}
@@ -121,7 +135,7 @@ function CollapsibleMarkdownHeading({
             aria-hidden="true"
             className={cn(
               "section-chevron size-4 transition-transform motion-reduce:transition-none",
-              !isCollapsed && "rotate-90",
+              !section.isCollapsed && "rotate-90",
             )}
             strokeWidth={2.25}
           />
@@ -132,64 +146,82 @@ function CollapsibleMarkdownHeading({
   );
 }
 
+function MarkdownH1(props: MarkdownHeadingProps) {
+  return <CollapsibleMarkdownHeading {...props} level={1} />;
+}
+
+function MarkdownH2(props: MarkdownHeadingProps) {
+  return <CollapsibleMarkdownHeading {...props} level={2} />;
+}
+
+function MarkdownH3(props: MarkdownHeadingProps) {
+  return <CollapsibleMarkdownHeading {...props} level={3} />;
+}
+
+function MarkdownH4(props: MarkdownHeadingProps) {
+  return <CollapsibleMarkdownHeading {...props} level={4} />;
+}
+
+function MarkdownH5(props: MarkdownHeadingProps) {
+  return <CollapsibleMarkdownHeading {...props} level={5} />;
+}
+
+function MarkdownH6(props: MarkdownHeadingProps) {
+  return <CollapsibleMarkdownHeading {...props} level={6} />;
+}
+
+type CollapsibleMarkdownSectionProps = React.ComponentPropsWithoutRef<"section"> & {
+  node?: unknown;
+  "data-section-key"?: string;
+};
+
 function CollapsibleMarkdownSection({
-  noteId,
-  level,
-  headingMarkdown,
-  bodyMarkdown,
-  components,
-}: {
-  noteId: string;
-  level: number;
-  headingMarkdown: string;
-  bodyMarkdown: string;
-  components: Components;
-}) {
-  const sectionKey = getCollapsibleSectionKey(
-    level,
-    getMarkdownHeadingText(headingMarkdown),
-  );
+  children,
+  node: _node,
+  "data-section-key": sectionKey,
+  ...props
+}: CollapsibleMarkdownSectionProps) {
+  void _node;
+  const noteId = useContext(CollapsibleNoteIdContext);
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   useLayoutEffect(() => {
+    if (!noteId || !sectionKey) return;
     setIsCollapsed(loadCollapsedSection(noteId, sectionKey));
   }, [noteId, sectionKey]);
 
-  const headingTag = `h${level}` as keyof Components;
   const toggleSection = useCallback(() => {
+    if (!noteId || !sectionKey) return;
+
     setIsCollapsed((current) => {
       const next = !current;
       saveCollapsedSection(noteId, sectionKey, next);
       return next;
     });
   }, [noteId, sectionKey]);
-  const renderHeading = useCallback(
-    (props: MarkdownHeadingProps) => (
-      <CollapsibleMarkdownHeading
-        {...props}
-        level={level}
-        isCollapsed={isCollapsed}
-        onToggle={toggleSection}
-      />
-    ),
-    [isCollapsed, level, toggleSection],
+  const contextValue = useMemo(
+    () => ({ isCollapsed, toggleSection }),
+    [isCollapsed, toggleSection],
   );
-  const headingComponents = useMemo(
-    () => ({ ...components, [headingTag]: renderHeading }) as Components,
-    [components, headingTag, renderHeading],
+  const childNodes = React.Children.toArray(children);
+  const headingIndex = childNodes.findIndex(
+    (child) =>
+      React.isValidElement<{ "data-collapsible-heading"?: string }>(child) &&
+      child.props["data-collapsible-heading"] !== undefined,
   );
+  const bodyStartIndex = headingIndex >= 0 ? headingIndex + 1 : 1;
 
   return (
-    <section data-collapsible-section>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={headingComponents}>
-        {headingMarkdown}
-      </ReactMarkdown>
-      {!isCollapsed && bodyMarkdown && (
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-          {bodyMarkdown}
-        </ReactMarkdown>
-      )}
-    </section>
+    <CollapsibleSectionContext.Provider value={contextValue}>
+      <section
+        {...props}
+        data-collapsible-section
+        data-section-key={sectionKey}
+      >
+        {childNodes.slice(0, bodyStartIndex)}
+        {!isCollapsed && childNodes.slice(bodyStartIndex)}
+      </section>
+    </CollapsibleSectionContext.Provider>
   );
 }
 
@@ -213,14 +245,6 @@ export default function NoteContent({
   const [isUploadingImages, setIsUploadingImages] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [isUploadFeedbackDismissed, setIsUploadFeedbackDismissed] = useState(false);
-  const collapsibleHeadingLevel = useMemo(
-    () => getPrimaryCollapsibleHeadingLevel(note.content),
-    [note.content],
-  );
-  const markdownChunks = useMemo(
-    () => splitMarkdownIntoCollapsibleSections(note.content, collapsibleHeadingLevel),
-    [collapsibleHeadingLevel, note.content],
-  );
 
   const stopPropagation = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -587,6 +611,13 @@ export default function NoteContent({
       li: renderListItem,
       a: renderLink,
       img: renderImage,
+      section: CollapsibleMarkdownSection,
+      h1: MarkdownH1,
+      h2: MarkdownH2,
+      h3: MarkdownH3,
+      h4: MarkdownH4,
+      h5: MarkdownH5,
+      h6: MarkdownH6,
     }),
     [renderImage, renderLink, renderListItem],
   );
@@ -621,26 +652,14 @@ export default function NoteContent({
           className="markdown-body text-base desktop:text-sm"
           onClick={handleMarkdownClick}
         >
-          {markdownChunks.map((chunk, index) =>
-            chunk.type === "section" ? (
-              <CollapsibleMarkdownSection
-                key={`${note.id}:section:${index}`}
-                noteId={note.id}
-                level={chunk.level}
-                headingMarkdown={chunk.headingMarkdown}
-                bodyMarkdown={chunk.bodyMarkdown}
-                components={markdownComponents}
-              />
-            ) : (
-              <ReactMarkdown
-                key={`${note.id}:markdown:${index}`}
-                remarkPlugins={[remarkGfm]}
-                components={markdownComponents}
-              >
-                {chunk.markdown || "Start writing..."}
-              </ReactMarkdown>
-            ),
-          )}
+          <CollapsibleNoteIdContext.Provider value={note.id}>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm, remarkCollapsibleSections]}
+              components={markdownComponents}
+            >
+              {note.content || "Start writing..."}
+            </ReactMarkdown>
+          </CollapsibleNoteIdContext.Provider>
         </div>
       )}
     </div>

--- a/components/apps/notes/note-content.tsx
+++ b/components/apps/notes/note-content.tsx
@@ -10,7 +10,7 @@ import React, {
 } from "react";
 import Image from "next/image";
 import { Textarea } from "@/components/ui/textarea";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ChevronRight } from "lucide-react";
 import { Note } from "@/lib/notes/types";
@@ -23,9 +23,11 @@ import {
 } from "@/lib/notes/image-upload";
 import {
   getCollapsibleSectionKey,
+  getMarkdownHeadingText,
   getPrimaryCollapsibleHeadingLevel,
   loadCollapsedSection,
   saveCollapsedSection,
+  splitMarkdownIntoCollapsibleSections,
 } from "@/lib/notes/collapsible-sections";
 import { cn } from "@/lib/utils";
 
@@ -69,68 +71,28 @@ type MarkdownHeadingProps = React.ComponentPropsWithoutRef<"h2"> & {
   node?: unknown;
 };
 
-function setSectionContentHidden(
-  heading: HTMLHeadingElement | null,
-  level: number,
-  hidden: boolean,
-) {
-  let sibling = heading?.nextElementSibling;
-
-  while (sibling) {
-    const siblingHeading = sibling.tagName.match(/^H([1-6])$/);
-    if (siblingHeading && Number(siblingHeading[1]) <= level) break;
-
-    (sibling as HTMLElement).hidden = hidden;
-    sibling = sibling.nextElementSibling;
-  }
-}
-
 function CollapsibleMarkdownHeading({
   children,
   level,
-  isCollapsible,
-  noteId,
+  isCollapsed,
+  onToggle,
   node: _node,
   ...props
 }: MarkdownHeadingProps & {
   level: number;
-  isCollapsible: boolean;
-  noteId: string;
+  isCollapsed: boolean;
+  onToggle: () => void;
 }) {
   void _node;
   const headingText = getTaskText(children).trim() || "section";
-  const sectionKey = getCollapsibleSectionKey(level, headingText);
-  const [isCollapsed, setIsCollapsed] = useState(false);
-  const headingRef = useRef<HTMLHeadingElement>(null);
   const Heading = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-
-  useLayoutEffect(() => {
-    if (!isCollapsible) return;
-    setIsCollapsed(loadCollapsedSection(noteId, sectionKey));
-  }, [isCollapsible, noteId, sectionKey]);
-
-  useLayoutEffect(() => {
-    if (!isCollapsible) return;
-
-    const heading = headingRef.current;
-    setSectionContentHidden(heading, level, isCollapsed);
-    return () => {
-      if (isCollapsed) {
-        setSectionContentHidden(heading, level, false);
-      }
-    };
-  }, [isCollapsed, isCollapsible, level]);
-
-  if (!isCollapsible) {
-    return <Heading {...props}>{children}</Heading>;
-  }
 
   return (
     <Heading
       {...props}
-      ref={headingRef}
       className={cn("group", props.className)}
       data-collapsible-section-heading
+      data-collapsed={isCollapsed}
     >
       <button
         type="button"
@@ -142,11 +104,7 @@ function CollapsibleMarkdownHeading({
         )}
         onClick={(event) => {
           event.stopPropagation();
-          setIsCollapsed((current) => {
-            const next = !current;
-            saveCollapsedSection(noteId, sectionKey, next);
-            return next;
-          });
+          onToggle();
         }}
       >
         <span
@@ -173,6 +131,62 @@ function CollapsibleMarkdownHeading({
   );
 }
 
+function CollapsibleMarkdownSection({
+  noteId,
+  level,
+  headingMarkdown,
+  bodyMarkdown,
+  components,
+}: {
+  noteId: string;
+  level: number;
+  headingMarkdown: string;
+  bodyMarkdown: string;
+  components: Components;
+}) {
+  const sectionKey = getCollapsibleSectionKey(
+    level,
+    getMarkdownHeadingText(headingMarkdown),
+  );
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  useLayoutEffect(() => {
+    setIsCollapsed(loadCollapsedSection(noteId, sectionKey));
+  }, [noteId, sectionKey]);
+
+  const headingTag = `h${level}` as keyof Components;
+  const headingComponents = {
+    ...components,
+    [headingTag]: (props: MarkdownHeadingProps) => (
+      <CollapsibleMarkdownHeading
+        {...props}
+        level={level}
+        isCollapsed={isCollapsed}
+        onToggle={() => {
+          setIsCollapsed((current) => {
+            const next = !current;
+            saveCollapsedSection(noteId, sectionKey, next);
+            return next;
+          });
+        }}
+      />
+    ),
+  } as Components;
+
+  return (
+    <>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={headingComponents}>
+        {headingMarkdown}
+      </ReactMarkdown>
+      {!isCollapsed && bodyMarkdown && (
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+          {bodyMarkdown}
+        </ReactMarkdown>
+      )}
+    </>
+  );
+}
+
 export default function NoteContent({
   note,
   saveNote,
@@ -196,6 +210,10 @@ export default function NoteContent({
   const collapsibleHeadingLevel = useMemo(
     () => getPrimaryCollapsibleHeadingLevel(note.content),
     [note.content],
+  );
+  const markdownChunks = useMemo(
+    () => splitMarkdownIntoCollapsibleSections(note.content, collapsibleHeadingLevel),
+    [collapsibleHeadingLevel, note.content],
   );
 
   const stopPropagation = useCallback((e: React.MouseEvent) => {
@@ -558,6 +576,12 @@ export default function NoteContent({
     );
   }, []);
 
+  const markdownComponents: Components = {
+    li: renderListItem,
+    a: renderLink,
+    img: renderImage,
+  };
+
   return (
     <div
       className="px-2 relative"
@@ -584,66 +608,30 @@ export default function NoteContent({
           onFocus={handleFocus}
         />
       ) : (
-        <div className="text-base desktop:text-sm" onClick={handleMarkdownClick}>
-          <ReactMarkdown
-            className="markdown-body"
-            remarkPlugins={[remarkGfm]}
-            components={{
-              li: renderListItem,
-              a: renderLink,
-              img: renderImage,
-              h1: (props) => (
-                <CollapsibleMarkdownHeading
-                  {...props}
-                  level={1}
-                  isCollapsible={collapsibleHeadingLevel === 1}
-                  noteId={note.id}
-                />
-              ),
-              h2: (props) => (
-                <CollapsibleMarkdownHeading
-                  {...props}
-                  level={2}
-                  isCollapsible={collapsibleHeadingLevel === 2}
-                  noteId={note.id}
-                />
-              ),
-              h3: (props) => (
-                <CollapsibleMarkdownHeading
-                  {...props}
-                  level={3}
-                  isCollapsible={collapsibleHeadingLevel === 3}
-                  noteId={note.id}
-                />
-              ),
-              h4: (props) => (
-                <CollapsibleMarkdownHeading
-                  {...props}
-                  level={4}
-                  isCollapsible={collapsibleHeadingLevel === 4}
-                  noteId={note.id}
-                />
-              ),
-              h5: (props) => (
-                <CollapsibleMarkdownHeading
-                  {...props}
-                  level={5}
-                  isCollapsible={collapsibleHeadingLevel === 5}
-                  noteId={note.id}
-                />
-              ),
-              h6: (props) => (
-                <CollapsibleMarkdownHeading
-                  {...props}
-                  level={6}
-                  isCollapsible={collapsibleHeadingLevel === 6}
-                  noteId={note.id}
-                />
-              ),
-            }}
-          >
-            {note.content || "Start writing..."}
-          </ReactMarkdown>
+        <div
+          className="markdown-body text-base desktop:text-sm"
+          onClick={handleMarkdownClick}
+        >
+          {markdownChunks.map((chunk, index) =>
+            chunk.type === "section" ? (
+              <CollapsibleMarkdownSection
+                key={`${note.id}:section:${index}`}
+                noteId={note.id}
+                level={chunk.level}
+                headingMarkdown={chunk.headingMarkdown}
+                bodyMarkdown={chunk.bodyMarkdown}
+                components={markdownComponents}
+              />
+            ) : (
+              <ReactMarkdown
+                key={`${note.id}:markdown:${index}`}
+                remarkPlugins={[remarkGfm]}
+                components={markdownComponents}
+              >
+                {chunk.markdown || "Start writing..."}
+              </ReactMarkdown>
+            ),
+          )}
         </div>
       )}
     </div>

--- a/components/apps/notes/note-content.tsx
+++ b/components/apps/notes/note-content.tsx
@@ -74,47 +74,61 @@ type MarkdownHeadingProps = React.ComponentPropsWithoutRef<"h2"> & {
 function CollapsibleMarkdownHeading({
   children,
   level,
+  isCollapsed,
+  onToggle,
   node: _node,
   ...props
 }: MarkdownHeadingProps & {
   level: number;
+  isCollapsed: boolean;
+  onToggle: () => void;
 }) {
   void _node;
+  const headingText = getTaskText(children).trim() || "section";
   const Heading = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
   return (
-    <summary
-      className={cn(
-        "group/heading list-none rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF] focus-visible:ring-offset-1",
-        "[&::-webkit-details-marker]:hidden",
-      )}
-      onClick={(event) => event.stopPropagation()}
+    <Heading
+      {...props}
+      className={cn("group/heading", props.className)}
+      data-collapsible-section-heading
+      data-collapsed={isCollapsed}
     >
-      <Heading
-        {...props}
+      <button
+        type="button"
+        aria-expanded={!isCollapsed}
+        aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${headingText}`}
         className={cn(
-          "flex w-full items-start text-left text-inherit",
-          props.className,
+          "flex w-full items-start rounded-md text-left text-inherit",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF] focus-visible:ring-offset-1",
         )}
-        data-collapsible-section-heading
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onToggle();
+        }}
       >
         <span
           className={cn(
             "section-chevron-shell mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
             "desktop:size-5",
-            "desktop:opacity-100 desktop:group-open/section:opacity-0",
-            "desktop:can-hover:group-hover/heading:opacity-100 desktop:group-focus-within/heading:opacity-100",
+            isCollapsed
+              ? "desktop:opacity-100"
+              : "desktop:opacity-0 desktop:can-hover:group-hover/heading:opacity-100 desktop:group-focus-within/heading:opacity-100",
           )}
         >
           <ChevronRight
             aria-hidden="true"
-            className="section-chevron size-4 transition-transform motion-reduce:transition-none group-open/section:rotate-90"
+            className={cn(
+              "section-chevron size-4 transition-transform motion-reduce:transition-none",
+              !isCollapsed && "rotate-90",
+            )}
             strokeWidth={2.25}
           />
         </span>
         <span className="min-w-0">{children}</span>
-      </Heading>
-    </summary>
+      </button>
+    </Heading>
   );
 }
 
@@ -135,48 +149,47 @@ function CollapsibleMarkdownSection({
     level,
     getMarkdownHeadingText(headingMarkdown),
   );
-  const detailsRef = useRef<HTMLDetailsElement>(null);
-  const hasRestoredRef = useRef(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
 
   useLayoutEffect(() => {
-    const details = detailsRef.current;
-    if (!details) return;
-
-    hasRestoredRef.current = false;
-    details.open = !loadCollapsedSection(noteId, sectionKey);
-    hasRestoredRef.current = true;
+    setIsCollapsed(loadCollapsedSection(noteId, sectionKey));
   }, [noteId, sectionKey]);
 
   const headingTag = `h${level}` as keyof Components;
-  const headingComponents = {
-    ...components,
-    [headingTag]: (props: MarkdownHeadingProps) => (
+  const toggleSection = useCallback(() => {
+    setIsCollapsed((current) => {
+      const next = !current;
+      saveCollapsedSection(noteId, sectionKey, next);
+      return next;
+    });
+  }, [noteId, sectionKey]);
+  const renderHeading = useCallback(
+    (props: MarkdownHeadingProps) => (
       <CollapsibleMarkdownHeading
         {...props}
         level={level}
+        isCollapsed={isCollapsed}
+        onToggle={toggleSection}
       />
     ),
-  } as Components;
+    [isCollapsed, level, toggleSection],
+  );
+  const headingComponents = useMemo(
+    () => ({ ...components, [headingTag]: renderHeading }) as Components,
+    [components, headingTag, renderHeading],
+  );
 
   return (
-    <details
-      ref={detailsRef}
-      className="group/section"
-      data-collapsible-section
-      onToggle={(event) => {
-        if (!hasRestoredRef.current) return;
-        saveCollapsedSection(noteId, sectionKey, !event.currentTarget.open);
-      }}
-    >
+    <section data-collapsible-section>
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={headingComponents}>
         {headingMarkdown}
       </ReactMarkdown>
-      {bodyMarkdown && (
+      {!isCollapsed && bodyMarkdown && (
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
           {bodyMarkdown}
         </ReactMarkdown>
       )}
-    </details>
+    </section>
   );
 }
 
@@ -569,11 +582,14 @@ export default function NoteContent({
     );
   }, []);
 
-  const markdownComponents: Components = {
-    li: renderListItem,
-    a: renderLink,
-    img: renderImage,
-  };
+  const markdownComponents = useMemo<Components>(
+    () => ({
+      li: renderListItem,
+      a: renderLink,
+      img: renderImage,
+    }),
+    [renderImage, renderLink, renderListItem],
+  );
 
   return (
     <div

--- a/components/apps/notes/note-content.tsx
+++ b/components/apps/notes/note-content.tsx
@@ -21,7 +21,12 @@ import {
   uploadNoteImage,
   insertImageMarkdown,
 } from "@/lib/notes/image-upload";
-import { getPrimaryCollapsibleHeadingLevel } from "@/lib/notes/collapsible-sections";
+import {
+  getCollapsibleSectionKey,
+  getPrimaryCollapsibleHeadingLevel,
+  loadCollapsedSection,
+  saveCollapsedSection,
+} from "@/lib/notes/collapsible-sections";
 import { cn } from "@/lib/utils";
 
 const SPACE_TAB = "  ";
@@ -84,16 +89,25 @@ function CollapsibleMarkdownHeading({
   children,
   level,
   isCollapsible,
+  noteId,
   node: _node,
   ...props
 }: MarkdownHeadingProps & {
   level: number;
   isCollapsible: boolean;
+  noteId: string;
 }) {
   void _node;
+  const headingText = getTaskText(children).trim() || "section";
+  const sectionKey = getCollapsibleSectionKey(level, headingText);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const Heading = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+  useLayoutEffect(() => {
+    if (!isCollapsible) return;
+    setIsCollapsed(loadCollapsedSection(noteId, sectionKey));
+  }, [isCollapsible, noteId, sectionKey]);
 
   useLayoutEffect(() => {
     if (!isCollapsible) return;
@@ -110,8 +124,6 @@ function CollapsibleMarkdownHeading({
   if (!isCollapsible) {
     return <Heading {...props}>{children}</Heading>;
   }
-
-  const headingText = getTaskText(children).trim() || "section";
 
   return (
     <Heading
@@ -134,7 +146,11 @@ function CollapsibleMarkdownHeading({
         )}
         onClick={(event) => {
           event.stopPropagation();
-          setIsCollapsed((current) => !current);
+          setIsCollapsed((current) => {
+            const next = !current;
+            saveCollapsedSection(noteId, sectionKey, next);
+            return next;
+          });
         }}
       >
         <ChevronRight
@@ -575,6 +591,7 @@ export default function NoteContent({
                   {...props}
                   level={1}
                   isCollapsible={collapsibleHeadingLevel === 1}
+                  noteId={note.id}
                 />
               ),
               h2: (props) => (
@@ -582,6 +599,7 @@ export default function NoteContent({
                   {...props}
                   level={2}
                   isCollapsible={collapsibleHeadingLevel === 2}
+                  noteId={note.id}
                 />
               ),
               h3: (props) => (
@@ -589,6 +607,7 @@ export default function NoteContent({
                   {...props}
                   level={3}
                   isCollapsible={collapsibleHeadingLevel === 3}
+                  noteId={note.id}
                 />
               ),
               h4: (props) => (
@@ -596,6 +615,7 @@ export default function NoteContent({
                   {...props}
                   level={4}
                   isCollapsible={collapsibleHeadingLevel === 4}
+                  noteId={note.id}
                 />
               ),
               h5: (props) => (
@@ -603,6 +623,7 @@ export default function NoteContent({
                   {...props}
                   level={5}
                   isCollapsible={collapsibleHeadingLevel === 5}
+                  noteId={note.id}
                 />
               ),
               h6: (props) => (
@@ -610,6 +631,7 @@ export default function NoteContent({
                   {...props}
                   level={6}
                   isCollapsible={collapsibleHeadingLevel === 6}
+                  noteId={note.id}
                 />
               ),
             }}

--- a/lib/notes/collapsible-sections.ts
+++ b/lib/notes/collapsible-sections.ts
@@ -1,5 +1,94 @@
 const FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
 const ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:[\t ]+|$)/;
+const COLLAPSED_SECTIONS_STORAGE_KEY = "notes-collapsed-sections";
+
+type StorageArea = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+type CollapsedSectionState = Record<string, string[]>;
+
+function getSessionStorage(storage?: StorageArea): StorageArea | null {
+  if (storage) return storage;
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function loadState(storage: StorageArea): CollapsedSectionState {
+  try {
+    const saved = storage.getItem(COLLAPSED_SECTIONS_STORAGE_KEY);
+    if (!saved) return {};
+
+    const parsed: unknown = JSON.parse(saved);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, string[]] =>
+          Array.isArray(entry[1]) && entry[1].every((value) => typeof value === "string"),
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function getCollapsibleSectionKey(level: number, heading: string): string {
+  return `${level}:${heading.trim().replace(/\s+/g, " ").toLocaleLowerCase()}`;
+}
+
+export function loadCollapsedSection(
+  noteId: string,
+  sectionKey: string,
+  storage?: StorageArea,
+): boolean {
+  const target = getSessionStorage(storage);
+  if (!target) return false;
+
+  return loadState(target)[noteId]?.includes(sectionKey) ?? false;
+}
+
+export function saveCollapsedSection(
+  noteId: string,
+  sectionKey: string,
+  collapsed: boolean,
+  storage?: StorageArea,
+): void {
+  const target = getSessionStorage(storage);
+  if (!target) return;
+
+  try {
+    const state = loadState(target);
+    const sections = new Set(state[noteId] ?? []);
+
+    if (collapsed) sections.add(sectionKey);
+    else sections.delete(sectionKey);
+
+    if (sections.size > 0) state[noteId] = [...sections];
+    else delete state[noteId];
+
+    if (Object.keys(state).length > 0) {
+      target.setItem(COLLAPSED_SECTIONS_STORAGE_KEY, JSON.stringify(state));
+    } else {
+      target.removeItem(COLLAPSED_SECTIONS_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage errors (for example, private browsing restrictions).
+  }
+}
+
+export function clearCollapsedSections(storage?: StorageArea): void {
+  const target = getSessionStorage(storage);
+  if (!target) return;
+
+  try {
+    target.removeItem(COLLAPSED_SECTIONS_STORAGE_KEY);
+  } catch {
+    // Ignore storage errors.
+  }
+}
 
 export function getPrimaryCollapsibleHeadingLevel(
   markdown: string,

--- a/lib/notes/collapsible-sections.ts
+++ b/lib/notes/collapsible-sections.ts
@@ -1,5 +1,5 @@
-const FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
-const ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:[\t ]+|$)/;
+import type { Heading, Root, RootContent } from "mdast";
+
 const COLLAPSED_SECTIONS_STORAGE_KEY = "notes-collapsed-sections";
 
 type StorageArea = Pick<Storage, "getItem" | "setItem" | "removeItem">;
@@ -35,15 +35,13 @@ function loadState(storage: StorageArea): CollapsedSectionState {
   }
 }
 
-export function getCollapsibleSectionKey(level: number, heading: string): string {
-  return `${level}:${heading.trim().replace(/\s+/g, " ").toLocaleLowerCase()}`;
-}
-
-export function getMarkdownHeadingText(headingMarkdown: string): string {
-  return headingMarkdown
-    .replace(/^ {0,3}#{1,6}(?:[\t ]+|$)/, "")
-    .replace(/[\t ]+#+[\t ]*$/, "")
-    .trim();
+export function getCollapsibleSectionKey(
+  level: number,
+  heading: string,
+  occurrence = 1,
+): string {
+  const baseKey = `${level}:${heading.trim().replace(/\s+/g, " ").toLowerCase()}`;
+  return occurrence > 1 ? `${baseKey}:${occurrence}` : baseKey;
 }
 
 export function loadCollapsedSection(
@@ -97,116 +95,34 @@ export function clearCollapsedSections(storage?: StorageArea): void {
   }
 }
 
-export type CollapsibleMarkdownChunk =
-  | { type: "markdown"; markdown: string }
-  | {
-      type: "section";
-      level: number;
-      headingMarkdown: string;
-      bodyMarkdown: string;
-    };
-
-export function splitMarkdownIntoCollapsibleSections(
-  markdown: string,
-  targetLevel: number | null,
-): CollapsibleMarkdownChunk[] {
-  if (!targetLevel) return [{ type: "markdown", markdown }];
-
-  const lines = markdown.split("\n");
-  const boundaries: Array<{ index: number; level: number }> = [];
-  let activeFence: { marker: string; length: number } | null = null;
-
-  lines.forEach((line, index) => {
-    const fenceMatch = line.match(FENCE_PATTERN);
-    if (fenceMatch) {
-      const fence = fenceMatch[1];
-      const marker = fence[0];
-
-      if (!activeFence) activeFence = { marker, length: fence.length };
-      else if (marker === activeFence.marker && fence.length >= activeFence.length) {
-        activeFence = null;
-      }
-      return;
-    }
-
-    if (activeFence) return;
-
-    const headingMatch = line.match(ATX_HEADING_PATTERN);
-    if (headingMatch) {
-      boundaries.push({ index, level: headingMatch[1].length });
-    }
-  });
-
-  const chunks: CollapsibleMarkdownChunk[] = [];
-  let plainStart = 0;
-  let sectionStart: number | null = null;
-
-  const pushMarkdown = (start: number, end: number) => {
-    if (end > start) {
-      chunks.push({ type: "markdown", markdown: lines.slice(start, end).join("\n") });
-    }
+type CollapsibleSectionNode = {
+  type: "notesCollapsibleSection";
+  children: RootContent[];
+  data: {
+    hName: "section";
+    hProperties: Record<string, unknown>;
   };
+};
 
-  const pushSection = (start: number, end: number) => {
-    chunks.push({
-      type: "section",
-      level: targetLevel,
-      headingMarkdown: lines[start],
-      bodyMarkdown: lines.slice(start + 1, end).join("\n"),
-    });
-  };
+type TextBearingNode = {
+  type: string;
+  value?: string;
+  alt?: string | null;
+  children?: TextBearingNode[];
+};
 
-  for (const boundary of boundaries) {
-    if (boundary.level > targetLevel) continue;
-
-    if (sectionStart !== null) {
-      pushSection(sectionStart, boundary.index);
-      sectionStart = null;
-      plainStart = boundary.index;
-    }
-
-    if (boundary.level === targetLevel) {
-      pushMarkdown(plainStart, boundary.index);
-      sectionStart = boundary.index;
-    }
-  }
-
-  if (sectionStart !== null) pushSection(sectionStart, lines.length);
-  else pushMarkdown(plainStart, lines.length);
-
-  return chunks.length > 0 ? chunks : [{ type: "markdown", markdown }];
+function getNodeText(node: TextBearingNode): string {
+  if (typeof node.value === "string") return node.value;
+  if (typeof node.alt === "string") return node.alt;
+  return node.children?.map(getNodeText).join("") ?? "";
 }
 
-export function getPrimaryCollapsibleHeadingLevel(
-  markdown: string,
-): number | null {
+function getPrimaryCollapsibleHeadingLevel(children: RootContent[]): number | null {
   const headingCounts = new Map<number, number>();
-  let activeFence: { marker: string; length: number } | null = null;
 
-  for (const line of markdown.split("\n")) {
-    const fenceMatch = line.match(FENCE_PATTERN);
-    if (fenceMatch) {
-      const fence = fenceMatch[1];
-      const marker = fence[0];
-
-      if (!activeFence) {
-        activeFence = { marker, length: fence.length };
-      } else if (
-        marker === activeFence.marker &&
-        fence.length >= activeFence.length
-      ) {
-        activeFence = null;
-      }
-      continue;
-    }
-
-    if (activeFence) continue;
-
-    const headingMatch = line.match(ATX_HEADING_PATTERN);
-    if (!headingMatch) continue;
-
-    const level = headingMatch[1].length;
-    headingCounts.set(level, (headingCounts.get(level) ?? 0) + 1);
+  for (const child of children) {
+    if (child.type !== "heading") continue;
+    headingCounts.set(child.depth, (headingCounts.get(child.depth) ?? 0) + 1);
   }
 
   for (let level = 1; level <= 6; level += 1) {
@@ -218,4 +134,91 @@ export function getPrimaryCollapsibleHeadingLevel(
   }
 
   return null;
+}
+
+function withCollapsibleHeadingData(heading: Heading): Heading {
+  const existingProperties =
+    heading.data?.hProperties && typeof heading.data.hProperties === "object"
+      ? heading.data.hProperties
+      : {};
+
+  return {
+    ...heading,
+    data: {
+      ...heading.data,
+      hProperties: {
+        ...existingProperties,
+        "data-collapsible-heading": "",
+        "data-heading-level": String(heading.depth),
+      },
+    },
+  };
+}
+
+/**
+ * Groups root-level Markdown sections in one syntax tree so document-scoped
+ * constructs, including reference links and footnotes, keep their semantics.
+ */
+export function remarkCollapsibleSections() {
+  return (tree: Root): void => {
+    const targetLevel = getPrimaryCollapsibleHeadingLevel(tree.children);
+    if (!targetLevel) return;
+
+    const output: RootContent[] = [];
+    const occurrences = new Map<string, number>();
+    let activeSection: {
+      heading: Heading;
+      sectionKey: string;
+      children: RootContent[];
+    } | null = null;
+
+    const closeSection = () => {
+      if (!activeSection) return;
+
+      const sectionNode: CollapsibleSectionNode = {
+        type: "notesCollapsibleSection",
+        children: [
+          withCollapsibleHeadingData(activeSection.heading),
+          ...activeSection.children,
+        ],
+        data: {
+          hName: "section",
+          hProperties: {
+            "data-collapsible-section": "",
+            "data-section-key": activeSection.sectionKey,
+          },
+        },
+      };
+
+      output.push(sectionNode as unknown as RootContent);
+      activeSection = null;
+    };
+
+    for (const child of tree.children) {
+      if (child.type === "heading" && child.depth <= targetLevel) {
+        closeSection();
+
+        if (child.depth === targetLevel) {
+          const headingText = getNodeText(child as TextBearingNode).trim() || "section";
+          const baseKey = getCollapsibleSectionKey(child.depth, headingText);
+          const occurrence = (occurrences.get(baseKey) ?? 0) + 1;
+          occurrences.set(baseKey, occurrence);
+          activeSection = {
+            heading: child,
+            sectionKey: getCollapsibleSectionKey(child.depth, headingText, occurrence),
+            children: [],
+          };
+        } else {
+          output.push(child);
+        }
+        continue;
+      }
+
+      if (activeSection) activeSection.children.push(child);
+      else output.push(child);
+    }
+
+    closeSection();
+    tree.children = output;
+  };
 }

--- a/lib/notes/collapsible-sections.ts
+++ b/lib/notes/collapsible-sections.ts
@@ -39,6 +39,13 @@ export function getCollapsibleSectionKey(level: number, heading: string): string
   return `${level}:${heading.trim().replace(/\s+/g, " ").toLocaleLowerCase()}`;
 }
 
+export function getMarkdownHeadingText(headingMarkdown: string): string {
+  return headingMarkdown
+    .replace(/^ {0,3}#{1,6}(?:[\t ]+|$)/, "")
+    .replace(/[\t ]+#+[\t ]*$/, "")
+    .trim();
+}
+
 export function loadCollapsedSection(
   noteId: string,
   sectionKey: string,
@@ -88,6 +95,86 @@ export function clearCollapsedSections(storage?: StorageArea): void {
   } catch {
     // Ignore storage errors.
   }
+}
+
+export type CollapsibleMarkdownChunk =
+  | { type: "markdown"; markdown: string }
+  | {
+      type: "section";
+      level: number;
+      headingMarkdown: string;
+      bodyMarkdown: string;
+    };
+
+export function splitMarkdownIntoCollapsibleSections(
+  markdown: string,
+  targetLevel: number | null,
+): CollapsibleMarkdownChunk[] {
+  if (!targetLevel) return [{ type: "markdown", markdown }];
+
+  const lines = markdown.split("\n");
+  const boundaries: Array<{ index: number; level: number }> = [];
+  let activeFence: { marker: string; length: number } | null = null;
+
+  lines.forEach((line, index) => {
+    const fenceMatch = line.match(FENCE_PATTERN);
+    if (fenceMatch) {
+      const fence = fenceMatch[1];
+      const marker = fence[0];
+
+      if (!activeFence) activeFence = { marker, length: fence.length };
+      else if (marker === activeFence.marker && fence.length >= activeFence.length) {
+        activeFence = null;
+      }
+      return;
+    }
+
+    if (activeFence) return;
+
+    const headingMatch = line.match(ATX_HEADING_PATTERN);
+    if (headingMatch) {
+      boundaries.push({ index, level: headingMatch[1].length });
+    }
+  });
+
+  const chunks: CollapsibleMarkdownChunk[] = [];
+  let plainStart = 0;
+  let sectionStart: number | null = null;
+
+  const pushMarkdown = (start: number, end: number) => {
+    if (end > start) {
+      chunks.push({ type: "markdown", markdown: lines.slice(start, end).join("\n") });
+    }
+  };
+
+  const pushSection = (start: number, end: number) => {
+    chunks.push({
+      type: "section",
+      level: targetLevel,
+      headingMarkdown: lines[start],
+      bodyMarkdown: lines.slice(start + 1, end).join("\n"),
+    });
+  };
+
+  for (const boundary of boundaries) {
+    if (boundary.level > targetLevel) continue;
+
+    if (sectionStart !== null) {
+      pushSection(sectionStart, boundary.index);
+      sectionStart = null;
+      plainStart = boundary.index;
+    }
+
+    if (boundary.level === targetLevel) {
+      pushMarkdown(plainStart, boundary.index);
+      sectionStart = boundary.index;
+    }
+  }
+
+  if (sectionStart !== null) pushSection(sectionStart, lines.length);
+  else pushMarkdown(plainStart, lines.length);
+
+  return chunks.length > 0 ? chunks : [{ type: "markdown", markdown }];
 }
 
 export function getPrimaryCollapsibleHeadingLevel(

--- a/lib/notes/collapsible-sections.ts
+++ b/lib/notes/collapsible-sections.ts
@@ -1,0 +1,45 @@
+const FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+const ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:[\t ]+|$)/;
+
+export function getPrimaryCollapsibleHeadingLevel(
+  markdown: string,
+): number | null {
+  const headingCounts = new Map<number, number>();
+  let activeFence: { marker: string; length: number } | null = null;
+
+  for (const line of markdown.split("\n")) {
+    const fenceMatch = line.match(FENCE_PATTERN);
+    if (fenceMatch) {
+      const fence = fenceMatch[1];
+      const marker = fence[0];
+
+      if (!activeFence) {
+        activeFence = { marker, length: fence.length };
+      } else if (
+        marker === activeFence.marker &&
+        fence.length >= activeFence.length
+      ) {
+        activeFence = null;
+      }
+      continue;
+    }
+
+    if (activeFence) continue;
+
+    const headingMatch = line.match(ATX_HEADING_PATTERN);
+    if (!headingMatch) continue;
+
+    const level = headingMatch[1].length;
+    headingCounts.set(level, (headingCounts.get(level) ?? 0) + 1);
+  }
+
+  for (let level = 1; level <= 6; level += 1) {
+    if ((headingCounts.get(level) ?? 0) >= 2) return level;
+  }
+
+  for (let level = 1; level <= 6; level += 1) {
+    if (headingCounts.has(level)) return level;
+  }
+
+  return null;
+}

--- a/lib/sidebar-persistence.ts
+++ b/lib/sidebar-persistence.ts
@@ -397,6 +397,7 @@ export function clearCalendarState(): void {
 import type { MusicView } from "@/components/apps/music/types";
 import { clearItermStorage } from "@/components/apps/iterm/terminal";
 import { clearNotesDisplayPreferences } from "@/lib/notes/display-preferences";
+import { clearCollapsedSections } from "@/lib/notes/collapsible-sections";
 import { clearNotesSelectedSlugMemory } from "@/lib/notes/selection-state";
 
 // Valid views for validation - must match MusicView type
@@ -521,6 +522,7 @@ export function clearNotesState(): void {
   try {
     sessionStorage.removeItem(STORAGE_KEYS.NOTES_SELECTED);
     clearNotesDisplayPreferences(sessionStorage);
+    clearCollapsedSections(sessionStorage);
   } catch {
     // Ignore storage errors
   }

--- a/tests/notes-collapsible-sections.test.ts
+++ b/tests/notes-collapsible-sections.test.ts
@@ -4,9 +4,11 @@ import test from "node:test";
 import {
   clearCollapsedSections,
   getCollapsibleSectionKey,
+  getMarkdownHeadingText,
   getPrimaryCollapsibleHeadingLevel,
   loadCollapsedSection,
   saveCollapsedSection,
+  splitMarkdownIntoCollapsibleSections,
 } from "../lib/notes/collapsible-sections";
 
 class MemoryStorage {
@@ -106,4 +108,48 @@ test("ignores malformed persisted collapse state", () => {
   storage.setItem("notes-collapsed-sections", "{bad json");
 
   assert.equal(loadCollapsedSection("about", "3:currently", storage), false);
+});
+
+test("uses rendered heading text for persisted section keys", () => {
+  assert.equal(getMarkdownHeadingText("### currently"), "currently");
+  assert.equal(getMarkdownHeadingText("  ## Heading ##  "), "Heading");
+});
+
+test("splits peer sections into independently rendered bodies", () => {
+  assert.deepEqual(
+    splitMarkdownIntoCollapsibleSections(
+      "Intro\n\n## First\nA\n\n### Nested\nB\n\n# Interlude\nC\n\n## Second\nD",
+      2,
+    ),
+    [
+      { type: "markdown", markdown: "Intro\n" },
+      {
+        type: "section",
+        level: 2,
+        headingMarkdown: "## First",
+        bodyMarkdown: "A\n\n### Nested\nB\n",
+      },
+      { type: "markdown", markdown: "# Interlude\nC\n" },
+      {
+        type: "section",
+        level: 2,
+        headingMarkdown: "## Second",
+        bodyMarkdown: "D",
+      },
+    ],
+  );
+});
+
+test("does not split section-looking headings inside fenced code", () => {
+  const markdown = "```md\n## Code heading\n```\n\n### Real section\nBody";
+
+  assert.deepEqual(splitMarkdownIntoCollapsibleSections(markdown, 3), [
+    { type: "markdown", markdown: "```md\n## Code heading\n```\n" },
+    {
+      type: "section",
+      level: 3,
+      headingMarkdown: "### Real section",
+      bodyMarkdown: "Body",
+    },
+  ]);
 });

--- a/tests/notes-collapsible-sections.test.ts
+++ b/tests/notes-collapsible-sections.test.ts
@@ -1,7 +1,29 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getPrimaryCollapsibleHeadingLevel } from "../lib/notes/collapsible-sections";
+import {
+  clearCollapsedSections,
+  getCollapsibleSectionKey,
+  getPrimaryCollapsibleHeadingLevel,
+  loadCollapsedSection,
+  saveCollapsedSection,
+} from "../lib/notes/collapsible-sections";
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
 
 test("uses the most prominent repeated heading level", () => {
   assert.equal(
@@ -45,4 +67,43 @@ Content
 
 test("returns null when the note has no headings", () => {
   assert.equal(getPrimaryCollapsibleHeadingLevel("Just a paragraph."), null);
+});
+
+test("normalizes heading identity for stable restoration", () => {
+  assert.equal(getCollapsibleSectionKey(3, "  Currently\n now  "), "3:currently now");
+});
+
+test("restores collapsed sections independently for each note", () => {
+  const storage = new MemoryStorage();
+  const current = getCollapsibleSectionKey(3, "currently");
+  const previous = getCollapsibleSectionKey(3, "previously");
+
+  saveCollapsedSection("about", current, true, storage);
+  saveCollapsedSection("about", previous, true, storage);
+
+  assert.equal(loadCollapsedSection("about", current, storage), true);
+  assert.equal(loadCollapsedSection("about", previous, storage), true);
+  assert.equal(loadCollapsedSection("another-note", current, storage), false);
+
+  saveCollapsedSection("about", current, false, storage);
+  assert.equal(loadCollapsedSection("about", current, storage), false);
+  assert.equal(loadCollapsedSection("about", previous, storage), true);
+});
+
+test("clears persisted collapse state with the Notes view state", () => {
+  const storage = new MemoryStorage();
+  const section = getCollapsibleSectionKey(3, "currently");
+
+  saveCollapsedSection("about", section, true, storage);
+  clearCollapsedSections(storage);
+
+  assert.equal(loadCollapsedSection("about", section, storage), false);
+  assert.equal(storage.values.size, 0);
+});
+
+test("ignores malformed persisted collapse state", () => {
+  const storage = new MemoryStorage();
+  storage.setItem("notes-collapsed-sections", "{bad json");
+
+  assert.equal(loadCollapsedSection("about", "3:currently", storage), false);
 });

--- a/tests/notes-collapsible-sections.test.ts
+++ b/tests/notes-collapsible-sections.test.ts
@@ -1,14 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import {
   clearCollapsedSections,
   getCollapsibleSectionKey,
-  getMarkdownHeadingText,
-  getPrimaryCollapsibleHeadingLevel,
   loadCollapsedSection,
+  remarkCollapsibleSections,
   saveCollapsedSection,
-  splitMarkdownIntoCollapsibleSections,
 } from "../lib/notes/collapsible-sections";
 
 class MemoryStorage {
@@ -27,9 +29,22 @@ class MemoryStorage {
   }
 }
 
-test("uses the most prominent repeated heading level", () => {
-  assert.equal(
-    getPrimaryCollapsibleHeadingLevel(`
+function renderMarkdown(markdown: string): string {
+  return renderToStaticMarkup(
+    React.createElement(
+      ReactMarkdown,
+      { remarkPlugins: [remarkGfm, remarkCollapsibleSections] },
+      markdown,
+    ),
+  );
+}
+
+function countSections(html: string): number {
+  return html.match(/data-collapsible-section=""/g)?.length ?? 0;
+}
+
+test("groups the most prominent repeated heading level", () => {
+  const html = renderMarkdown(`
 # Note title
 
 ## First section
@@ -40,39 +55,95 @@ More content
 
 ## Second section
 Content
-`),
-    2,
-  );
+`);
+
+  assert.equal(countSections(html), 2);
+  assert.match(html, /^<h1>Note title<\/h1>\s*<section/);
+  assert.match(html, /<section[^>]*><h2 data-collapsible-heading=""/);
+  assert.match(html, /<h3>Nested detail<\/h3>/);
 });
 
 test("falls back to a single heading when no level repeats", () => {
-  assert.equal(
-    getPrimaryCollapsibleHeadingLevel("Intro\n\n### One section\nContent"),
-    3,
-  );
+  const html = renderMarkdown("Intro\n\n### One section\nContent");
+
+  assert.equal(countSections(html), 1);
+  assert.match(html, /data-section-key="3:one section"/);
 });
 
 test("ignores heading-like text inside fenced code blocks", () => {
-  assert.equal(
-    getPrimaryCollapsibleHeadingLevel(`
-\`\`\`markdown
-## Not a section
-## Still code
-\`\`\`
-
-### Real section
-Content
-`),
-    3,
+  const html = renderMarkdown(
+    [
+      "```markdown",
+      "## Not a section",
+      "## Still code",
+      "```",
+      "",
+      "### Real section",
+      "Content",
+    ].join("\n"),
   );
+
+  assert.equal(countSections(html), 1);
+  assert.match(html, /data-section-key="3:real section"/);
+  assert.match(html, /<code class="language-markdown">## Not a section/);
 });
 
-test("returns null when the note has no headings", () => {
-  assert.equal(getPrimaryCollapsibleHeadingLevel("Just a paragraph."), null);
+test("leaves notes without headings unchanged", () => {
+  const html = renderMarkdown("Just a paragraph.");
+
+  assert.equal(countSections(html), 0);
+  assert.equal(html, "<p>Just a paragraph.</p>");
+});
+
+test("keeps reference links available across collapsible sections", () => {
+  const html = renderMarkdown(`
+## First
+See [Basecase][base].
+
+## Second
+Other text.
+
+[base]: https://basecase.vc
+`);
+
+  assert.match(html, /<a href="https:\/\/basecase\.vc">Basecase<\/a>/);
+  assert.doesNotMatch(html, /\[Basecase\]\[base\]/);
+});
+
+test("assigns duplicate headings independent persisted keys", () => {
+  const html = renderMarkdown(`
+## Update
+First body
+
+## Update
+Second body
+`);
+
+  assert.match(html, /data-section-key="2:update"/);
+  assert.match(html, /data-section-key="2:update:2"/);
+});
+
+test("ends a section at a more prominent heading", () => {
+  const html = renderMarkdown(`
+## First
+First body
+
+# Interlude
+Outside body
+
+## Second
+Second body
+`);
+
+  assert.match(
+    html,
+    /First body<\/p><\/section>\s*<h1>Interlude<\/h1>\s*<p>Outside body<\/p>\s*<section/,
+  );
 });
 
 test("normalizes heading identity for stable restoration", () => {
   assert.equal(getCollapsibleSectionKey(3, "  Currently\n now  "), "3:currently now");
+  assert.equal(getCollapsibleSectionKey(3, "Currently now", 2), "3:currently now:2");
 });
 
 test("restores collapsed sections independently for each note", () => {
@@ -108,48 +179,4 @@ test("ignores malformed persisted collapse state", () => {
   storage.setItem("notes-collapsed-sections", "{bad json");
 
   assert.equal(loadCollapsedSection("about", "3:currently", storage), false);
-});
-
-test("uses rendered heading text for persisted section keys", () => {
-  assert.equal(getMarkdownHeadingText("### currently"), "currently");
-  assert.equal(getMarkdownHeadingText("  ## Heading ##  "), "Heading");
-});
-
-test("splits peer sections into independently rendered bodies", () => {
-  assert.deepEqual(
-    splitMarkdownIntoCollapsibleSections(
-      "Intro\n\n## First\nA\n\n### Nested\nB\n\n# Interlude\nC\n\n## Second\nD",
-      2,
-    ),
-    [
-      { type: "markdown", markdown: "Intro\n" },
-      {
-        type: "section",
-        level: 2,
-        headingMarkdown: "## First",
-        bodyMarkdown: "A\n\n### Nested\nB\n",
-      },
-      { type: "markdown", markdown: "# Interlude\nC\n" },
-      {
-        type: "section",
-        level: 2,
-        headingMarkdown: "## Second",
-        bodyMarkdown: "D",
-      },
-    ],
-  );
-});
-
-test("does not split section-looking headings inside fenced code", () => {
-  const markdown = "```md\n## Code heading\n```\n\n### Real section\nBody";
-
-  assert.deepEqual(splitMarkdownIntoCollapsibleSections(markdown, 3), [
-    { type: "markdown", markdown: "```md\n## Code heading\n```\n" },
-    {
-      type: "section",
-      level: 3,
-      headingMarkdown: "### Real section",
-      bodyMarkdown: "Body",
-    },
-  ]);
 });

--- a/tests/notes-collapsible-sections.test.ts
+++ b/tests/notes-collapsible-sections.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getPrimaryCollapsibleHeadingLevel } from "../lib/notes/collapsible-sections";
+
+test("uses the most prominent repeated heading level", () => {
+  assert.equal(
+    getPrimaryCollapsibleHeadingLevel(`
+# Note title
+
+## First section
+Content
+
+### Nested detail
+More content
+
+## Second section
+Content
+`),
+    2,
+  );
+});
+
+test("falls back to a single heading when no level repeats", () => {
+  assert.equal(
+    getPrimaryCollapsibleHeadingLevel("Intro\n\n### One section\nContent"),
+    3,
+  );
+});
+
+test("ignores heading-like text inside fenced code blocks", () => {
+  assert.equal(
+    getPrimaryCollapsibleHeadingLevel(`
+\`\`\`markdown
+## Not a section
+## Still code
+\`\`\`
+
+### Real section
+Content
+`),
+    3,
+  );
+});
+
+test("returns null when the note has no headings", () => {
+  assert.equal(getPrimaryCollapsibleHeadingLevel("Just a paragraph."), null);
+});


### PR DESCRIPTION
## Today's delight

Notes now supports macOS-style collapsible document sections. Each prominent repeated Markdown heading is a full-width disclosure row, and collapsed sections remain collapsed when the reader changes notes or refreshes the tab.

## Baseline and delta

- Before: headings such as **currently** and **previously** were static and every section body was always visible.
- Now: clicking or tapping anywhere on a section heading collapses or expands that section independently, with its state restored per note for the life of the tab.
- Preserved: note selection, document-wide Markdown links, task checkboxes, explicit editing controls, sibling sections, search/list behavior, and mobile Back navigation.
- Final review cleanup: Notes is parsed once as one Markdown document, disclosure components stay stable during state changes, and repeated same-text headings receive independent saved-state keys.

## Built result — desktop

Verified on the deployed preview at exact head `bbb63908`. Clicking the visible **currently** row removes its body while **previously** stays intact. The same disclosure button keeps keyboard focus and changes from **Collapse currently** to **Expand currently**; expanding retains focus too.

Preview: https://alanagoyal-git-codex-daily-delight-2026-08-19-c01085-basecasevc.vercel.app/notes/about-me

## Built result — mobile

The same accessible full-row button serves mobile with a persistent 28×28 disclosure target. Prior true-touch verification at 390×844 CSS pixels / DPR 3 covered collapse, expand, and Back navigation; the review cleanup changes Markdown parsing and component identity without changing that mobile control or layout.

## macOS inspiration

Apple's current [View your notes in Notes on Mac](https://support.apple.com/en-ie/guide/notes/apd8b73d28be/mac) guide documents collapsible sections: hover over a section title, then use its Expand or Collapse button. This implementation maps that behavior to the note's prominent repeated Markdown heading level.

## Why this one

Notes had not been the primary surface of a shipped daily delight since 2026-07-25; its last merged visible touch was 2026-08-11. The feature uses the site's existing personal notes without inventing content and does not overlap the recent Calendar, Notification Center, Games, or Music work.

## Verification

- Full repository-environment `npm run check`: lint with zero errors and six pre-existing warnings, all 125 Node tests, typecheck, and all 41 production routes
- Focused collapsible-section suite: 11 tests covering document-wide reference links, duplicate heading keys, fenced code, section boundaries, persistence, and malformed storage
- Live deployed desktop at exact head `bbb63908`: collapse and expansion structurally update the section while the disclosure button retains focus and accessible state
- GitGuardian, Vercel, and Vercel Preview Comments pass on exact head `bbb639085d9cfd8a839e849de6d8be6d06b377c5`
- Per-note collapsed state persists through note-away/back navigation and refresh

## Scope

Small and contained to Notes: four files relative to `main`, 612 additions and 14 deletions. The final review cleanup replaces the split-document parser rather than layering another interaction workaround onto it.
