### PR TITLE
Add eyes to the menu bar

### DIFF
--- a/components/desktop/menu-bar-eyes.tsx
+++ b/components/desktop/menu-bar-eyes.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  EYE_STYLE_STORAGE_KEY,
+  getEyeStyle,
+  nextEyeStyle,
+  parseStoredEyeStyle,
+  pupilOffset,
+  type EyeStyleId,
+} from "@/lib/menu-bar-eyes";
+
+const VIEWBOX_WIDTH = 36;
+const VIEWBOX_HEIGHT = 20;
+const EYE_RADIUS = 7.6;
+const EYE_CENTERS = [
+  { x: 10, y: 11 },
+  { x: 26, y: 11 },
+];
+const BLINK_MS = 130;
+const IDLE_BLINK_MIN_MS = 4_000;
+const IDLE_BLINK_MAX_MS = 8_000;
+
+const prefersReducedMotion = () =>
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/**
+ * Eyes in the menu bar that follow the pointer and blink when you click.
+ *
+ * One pointermove listener feeds a single animation frame, so a fast pointer
+ * costs one paint per frame rather than one per event, and a still pointer
+ * costs nothing. Pupil positions are written straight to the DOM because React
+ * has no reason to re-render for two transforms.
+ */
+export function MenuBarEyes() {
+  const [styleId, setStyleId] = useState<EyeStyleId>("googly");
+  const [blinking, setBlinking] = useState(false);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const pupilRefs = useRef<(SVGGElement | null)[]>([]);
+  const frameRef = useRef<number | null>(null);
+  const pointerRef = useRef<{ x: number; y: number } | null>(null);
+  const blinkTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const drawRef = useRef<() => void>(() => {});
+
+  const style = getEyeStyle(styleId);
+
+  // Read after mount so the server render and the first client render agree.
+  useEffect(() => {
+    const stored = parseStoredEyeStyle(window.localStorage.getItem(EYE_STYLE_STORAGE_KEY));
+    if (stored) setStyleId(stored);
+  }, []);
+
+  const blink = useCallback(() => {
+    if (prefersReducedMotion()) return;
+    setBlinking(true);
+    if (blinkTimeoutRef.current) clearTimeout(blinkTimeoutRef.current);
+    blinkTimeoutRef.current = setTimeout(() => setBlinking(false), BLINK_MS);
+  }, []);
+
+  const drawPupils = useCallback(() => {
+    frameRef.current = null;
+    const svg = svgRef.current;
+    const pointer = pointerRef.current;
+    if (!svg || !pointer) return;
+
+    const rect = svg.getBoundingClientRect();
+    if (rect.width === 0) return;
+    const scale = rect.width / VIEWBOX_WIDTH;
+    const maxOffset = EYE_RADIUS - style.pupilRadius - 0.4;
+
+    EYE_CENTERS.forEach((center, index) => {
+      const pupil = pupilRefs.current[index];
+      if (!pupil) return;
+      const offset = pupilOffset(
+        { x: rect.left + center.x * scale, y: rect.top + center.y * scale },
+        pointer,
+        maxOffset * scale
+      );
+      pupil.setAttribute(
+        "transform",
+        `translate(${(offset.x / scale).toFixed(2)} ${(offset.y / scale).toFixed(2)})`
+      );
+    });
+  }, [style.pupilRadius]);
+
+  // Kept in a ref so switching style does not tear down the listeners below.
+  drawRef.current = drawPupils;
+
+  useEffect(() => {
+    if (prefersReducedMotion()) return;
+
+    const schedule = () => {
+      if (frameRef.current !== null) return;
+      frameRef.current = window.requestAnimationFrame(() => drawRef.current());
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      pointerRef.current = { x: event.clientX, y: event.clientY };
+      schedule();
+    };
+
+    window.addEventListener("pointermove", onPointerMove, { passive: true });
+    window.addEventListener("pointerdown", blink);
+
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerdown", blink);
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, [blink]);
+
+  // A new style renders fresh pupils with no transform on them, so put them
+  // back where the pointer left them instead of waiting for the next move.
+  useEffect(() => {
+    drawPupils();
+  }, [drawPupils]);
+
+  // An occasional blink with nobody clicking is what makes them read as alive
+  // rather than as a widget.
+  useEffect(() => {
+    if (prefersReducedMotion()) return;
+    let timeout: ReturnType<typeof setTimeout>;
+    const schedule = () => {
+      const delay = IDLE_BLINK_MIN_MS + Math.random() * (IDLE_BLINK_MAX_MS - IDLE_BLINK_MIN_MS);
+      timeout = setTimeout(() => {
+        if (!document.hidden) blink();
+        schedule();
+      }, delay);
+    };
+    schedule();
+    return () => clearTimeout(timeout);
+  }, [blink]);
+
+  useEffect(() => {
+    return () => {
+      if (blinkTimeoutRef.current) clearTimeout(blinkTimeoutRef.current);
+    };
+  }, []);
+
+  const cycleStyle = () => {
+    const next = nextEyeStyle(styleId);
+    setStyleId(next);
+    window.localStorage.setItem(EYE_STYLE_STORAGE_KEY, next);
+    blink();
+  };
+
+  return (
+    <button
+      onClick={cycleStyle}
+      aria-label={`${style.label}, click to change`}
+      title={style.label}
+      className="flex items-center justify-center w-11 h-6 rounded transition-colors can-hover:hover:bg-white/10"
+    >
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+        className="w-10 h-[22px]"
+        aria-hidden="true"
+      >
+        {EYE_CENTERS.map((center, index) => (
+          <g
+            key={center.x}
+            style={{
+              transform: blinking ? "scaleY(0.08)" : "scaleY(1)",
+              transformOrigin: `${center.x}px ${center.y}px`,
+              transition: `transform ${BLINK_MS}ms ease-in-out`,
+            }}
+          >
+            <circle
+              cx={center.x}
+              cy={center.y}
+              r={EYE_RADIUS}
+              fill={style.sclera}
+              stroke="rgba(0,0,0,0.35)"
+              strokeWidth={0.6}
+            />
+            <g
+              ref={(node) => {
+                pupilRefs.current[index] = node;
+              }}
+            >
+              {style.iris && (
+                <circle cx={center.x} cy={center.y} r={style.irisRadius} fill={style.iris} />
+              )}
+              {style.pupilShape === "round" ? (
+                <circle cx={center.x} cy={center.y} r={style.pupilRadius} fill={style.pupil} />
+              ) : (
+                <ellipse
+                  cx={center.x}
+                  cy={center.y}
+                  rx={style.pupilRadius * 0.34}
+                  ry={style.pupilRadius}
+                  fill={style.pupil}
+                />
+              )}
+            </g>
+            {style.brow && (
+              <path
+                d={`M ${center.x - EYE_RADIUS} ${center.y - EYE_RADIUS - 0.7} q ${EYE_RADIUS} -2.4 ${EYE_RADIUS * 2} 0`}
+                stroke={style.brow}
+                strokeWidth={1.1}
+                strokeLinecap="round"
+                fill="none"
+              />
+            )}
+          </g>
+        ))}
+      </svg>
+    </button>
+  );
+}

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -19,6 +19,7 @@ import { TextEditEditMenu } from "./textedit-edit-menu";
 import { TextEditFileMenu, TextEditRenameDialog } from "./textedit-file-menu";
 import { PreviewFileMenu } from "./preview-file-menu";
 import { AboutDialog } from "./about-dialog";
+import { MenuBarEyes } from "./menu-bar-eyes";
 import { FocusMenu, FOCUS_STATUS_CONFIG } from "./focus-menu";
 import { useFileMenuActions } from "@/lib/file-menu-context";
 import { useSystemSettings } from "@/lib/system-settings-context";
@@ -368,6 +369,9 @@ export function MenuBar({
       </div>
 
       <div className="flex items-center gap-1">
+        {/* Eyes */}
+        <MenuBarEyes />
+
         {/* Battery */}
         <button
           onClick={() => toggleMenu("battery")}

--- a/lib/menu-bar-eyes.ts
+++ b/lib/menu-bar-eyes.ts
@@ -1,0 +1,87 @@
+export type EyeStyleId = "googly" | "cat" | "dragon";
+
+export interface EyeStyle {
+  id: EyeStyleId;
+  /** Shown in the button's accessible name, e.g. "Googly eyes". */
+  label: string;
+  sclera: string;
+  iris: string | null;
+  irisRadius: number;
+  pupil: string;
+  /** Round pupils read as googly; a slit reads as cat or dragon. */
+  pupilShape: "round" | "slit";
+  pupilRadius: number;
+  /** A brow line above each eye, drawn only when set. */
+  brow: string | null;
+}
+
+export const EYE_STYLES: readonly EyeStyle[] = [
+  {
+    id: "googly",
+    label: "Googly eyes",
+    sclera: "#ffffff",
+    iris: null,
+    irisRadius: 0,
+    pupil: "#111111",
+    pupilShape: "round",
+    pupilRadius: 3.1,
+    brow: null,
+  },
+  {
+    id: "cat",
+    label: "Cat eyes",
+    sclera: "#fde68a",
+    iris: "#f59e0b",
+    irisRadius: 5.0,
+    pupil: "#1c1917",
+    pupilShape: "slit",
+    pupilRadius: 3.8,
+    brow: null,
+  },
+  {
+    id: "dragon",
+    label: "Dragon eyes",
+    sclera: "#fca5a5",
+    iris: "#dc2626",
+    irisRadius: 5.0,
+    pupil: "#18181b",
+    pupilShape: "slit",
+    pupilRadius: 3.8,
+    brow: "#7f1d1d",
+  },
+];
+
+export const EYE_STYLE_STORAGE_KEY = "desktop-menu-bar-eyes-style";
+
+export function getEyeStyle(id: EyeStyleId): EyeStyle {
+  return EYE_STYLES.find((style) => style.id === id) ?? EYE_STYLES[0];
+}
+
+export function nextEyeStyle(id: EyeStyleId): EyeStyleId {
+  const index = EYE_STYLES.findIndex((style) => style.id === id);
+  return EYE_STYLES[(index + 1) % EYE_STYLES.length].id;
+}
+
+export function parseStoredEyeStyle(value: string | null): EyeStyleId | null {
+  if (!value) return null;
+  return EYE_STYLES.some((style) => style.id === value) ? (value as EyeStyleId) : null;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * How far the pupil sits from the centre of its socket, given where the
+ * pointer is. The pupil tracks direction exactly but its distance is capped,
+ * so it slides to the edge of the eye and stays there rather than escaping.
+ */
+export function pupilOffset(eyeCenter: Point, pointer: Point, maxOffset: number): Point {
+  const dx = pointer.x - eyeCenter.x;
+  const dy = pointer.y - eyeCenter.y;
+  const distance = Math.hypot(dx, dy);
+  if (distance === 0 || maxOffset <= 0) return { x: 0, y: 0 };
+  const scale = Math.min(distance, maxOffset) / distance;
+  return { x: dx * scale, y: dy * scale };
+}

--- a/tests/menu-bar-eyes.test.ts
+++ b/tests/menu-bar-eyes.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  EYE_STYLES,
+  getEyeStyle,
+  nextEyeStyle,
+  parseStoredEyeStyle,
+  pupilOffset,
+} from "../lib/menu-bar-eyes";
+
+test("cycles through every style and returns to the first", () => {
+  const seen = [EYE_STYLES[0].id];
+  let current = EYE_STYLES[0].id;
+  for (let i = 0; i < EYE_STYLES.length - 1; i += 1) {
+    current = nextEyeStyle(current);
+    seen.push(current);
+  }
+  assert.deepEqual(seen, EYE_STYLES.map((style) => style.id));
+  assert.equal(nextEyeStyle(current), EYE_STYLES[0].id);
+});
+
+test("only restores a style it recognises", () => {
+  assert.equal(parseStoredEyeStyle("dragon"), "dragon");
+  assert.equal(parseStoredEyeStyle("wizard"), null);
+  assert.equal(parseStoredEyeStyle(null), null);
+  assert.equal(getEyeStyle("googly").id, "googly");
+});
+
+test("pupil points at the cursor without leaving the eye", () => {
+  const center = { x: 100, y: 100 };
+
+  const far = pupilOffset(center, { x: 400, y: 100 }, 3);
+  assert.deepEqual(far, { x: 3, y: 0 });
+
+  const near = pupilOffset(center, { x: 101, y: 100 }, 3);
+  assert.deepEqual(near, { x: 1, y: 0 });
+
+  const diagonal = pupilOffset(center, { x: 200, y: 200 }, 10);
+  assert.ok(Math.abs(Math.hypot(diagonal.x, diagonal.y) - 10) < 1e-9);
+  assert.ok(Math.abs(diagonal.x - diagonal.y) < 1e-9);
+});
+
+test("stays put when there is nowhere to go", () => {
+  assert.deepEqual(pupilOffset({ x: 5, y: 5 }, { x: 5, y: 5 }, 4), { x: 0, y: 0 });
+  assert.deepEqual(pupilOffset({ x: 5, y: 5 }, { x: 50, y: 5 }, 0), { x: 0, y: 0 });
+});


### PR DESCRIPTION
Eyes in the status cluster that follow the cursor and blink when you click. Clicking them cycles googly, cat and dragon, and the choice persists.

No new dependencies. `npm run check` passes.