### PR TITLE
Add Recently Played to Music Home

### DIFF
--- a/components/apps/music/content-views/home-view.tsx
+++ b/components/apps/music/content-views/home-view.tsx
@@ -19,12 +19,7 @@ export function HomeView({
   onPlaylistSelect,
   isMobileView,
 }: HomeViewProps) {
-  const { playbackState, recentlyPlayedTrackIds, play, pause } = useAudio();
-  const songsById = new Map(songs.map((song) => [song.id, song]));
-  const recentlyPlayed = recentlyPlayedTrackIds.flatMap((trackId) => {
-    const song = songsById.get(trackId);
-    return song ? [song] : [];
-  });
+  const { playbackState, recentlyPlayedTracks, play, pause, resume } = useAudio();
 
   const handlePlayPlaylist = (playlist: Playlist, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -41,6 +36,16 @@ export function HomeView({
       if (firstPlayable) {
         play(firstPlayable, playlist.tracks);
       }
+    }
+  };
+
+  const handleRecentTrackPlay = (track: PlaylistTrack) => {
+    if (playbackState.currentTrack?.id === track.id && playbackState.isPlaying) {
+      pause();
+    } else if (playbackState.currentTrack?.id === track.id) {
+      resume();
+    } else {
+      play(track, recentlyPlayedTracks);
     }
   };
 
@@ -83,23 +88,28 @@ export function HomeView({
           </a>
         </div>
 
-        {recentlyPlayed.length > 0 && (
+        {recentlyPlayedTracks.length > 0 && (
           <section className="mb-8" aria-labelledby="recently-played-heading">
             <h2 id="recently-played-heading" className="mb-4 text-lg font-semibold">
               Recently Played
             </h2>
             <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-hide">
-              {recentlyPlayed.map((song, index) => {
+              {recentlyPlayedTracks.map((song, index) => {
                 const isPlaying =
                   playbackState.isPlaying && playbackState.currentTrack?.id === song.id;
+                const action = isPlaying
+                  ? "Pause"
+                  : playbackState.currentTrack?.id === song.id
+                    ? "Resume"
+                    : "Play";
 
                 return (
                   <button
                     key={song.id}
                     type="button"
-                    onClick={() => song.previewUrl && play(song, songs)}
+                    onClick={() => handleRecentTrackPlay(song)}
                     disabled={!song.previewUrl}
-                    aria-label={`Play ${song.name} by ${song.artist}`}
+                    aria-label={`${action} ${song.name} by ${song.artist}`}
                     className={cn(
                       "group w-32 flex-shrink-0 text-left disabled:cursor-default",
                       song.previewUrl && "cursor-pointer"

--- a/components/apps/music/content-views/home-view.tsx
+++ b/components/apps/music/content-views/home-view.tsx
@@ -19,7 +19,12 @@ export function HomeView({
   onPlaylistSelect,
   isMobileView,
 }: HomeViewProps) {
-  const { playbackState, play, pause } = useAudio();
+  const { playbackState, recentlyPlayedTrackIds, play, pause } = useAudio();
+  const songsById = new Map(songs.map((song) => [song.id, song]));
+  const recentlyPlayed = recentlyPlayedTrackIds.flatMap((trackId) => {
+    const song = songsById.get(trackId);
+    return song ? [song] : [];
+  });
 
   const handlePlayPlaylist = (playlist: Playlist, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -77,6 +82,58 @@ export function HomeView({
             </div>
           </a>
         </div>
+
+        {recentlyPlayed.length > 0 && (
+          <section className="mb-8" aria-labelledby="recently-played-heading">
+            <h2 id="recently-played-heading" className="mb-4 text-lg font-semibold">
+              Recently Played
+            </h2>
+            <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-hide">
+              {recentlyPlayed.map((song, index) => {
+                const isPlaying =
+                  playbackState.isPlaying && playbackState.currentTrack?.id === song.id;
+
+                return (
+                  <button
+                    key={song.id}
+                    type="button"
+                    onClick={() => song.previewUrl && play(song, songs)}
+                    disabled={!song.previewUrl}
+                    aria-label={`Play ${song.name} by ${song.artist}`}
+                    className={cn(
+                      "group w-32 flex-shrink-0 text-left disabled:cursor-default",
+                      song.previewUrl && "cursor-pointer"
+                    )}
+                  >
+                    <div className="relative mb-2 aspect-square overflow-hidden rounded-lg bg-muted">
+                      <Image
+                        src={song.albumArt}
+                        alt={song.album}
+                        fill
+                        className="object-cover"
+                        unoptimized
+                        loading={index === 0 ? "eager" : "lazy"}
+                      />
+                      {song.previewUrl && (
+                        <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors can-hover:group-hover:bg-black/40">
+                          {isPlaying ? (
+                            <Pause className="h-10 w-10 text-white opacity-0 transition-opacity can-hover:group-hover:opacity-100" />
+                          ) : (
+                            <Play className="h-10 w-10 text-white opacity-0 transition-opacity can-hover:group-hover:opacity-100" />
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <p data-recent-track-name className="truncate text-sm font-medium">
+                      {song.name}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">{song.artist}</p>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        )}
 
         {/* Your Playlists - Horizontal Scroll */}
         <div className="mb-8">

--- a/lib/music/audio-context.tsx
+++ b/lib/music/audio-context.tsx
@@ -13,14 +13,14 @@ import { PlaylistTrack, RepeatMode, PlaybackState } from "@/components/apps/musi
 import { useSystemSettingsSafe } from "@/lib/system-settings-context";
 import {
   MUSIC_RECENTLY_PLAYED_STORAGE_KEY,
-  parseRecentlyPlayedTrackIds,
+  parseRecentlyPlayedTracks,
   recordRecentlyPlayedTrack,
-  serializeRecentlyPlayedTrackIds,
+  serializeRecentlyPlayedTracks,
 } from "@/lib/music/recently-played";
 
 interface AudioContextValue {
   playbackState: PlaybackState;
-  recentlyPlayedTrackIds: string[];
+  recentlyPlayedTracks: PlaylistTrack[];
   play: (track: PlaylistTrack, queue: PlaylistTrack[]) => void;
   pause: () => void;
   resume: () => void;
@@ -38,10 +38,10 @@ const AudioContext = createContext<AudioContextValue | null>(null);
 
 const STORAGE_KEY = "music-playback-state";
 
-function loadRecentlyPlayedTrackIds(): string[] {
+function loadRecentlyPlayedTracks(): PlaylistTrack[] {
   if (typeof window === "undefined") return [];
   try {
-    return parseRecentlyPlayedTrackIds(
+    return parseRecentlyPlayedTracks(
       localStorage.getItem(MUSIC_RECENTLY_PLAYED_STORAGE_KEY)
     );
   } catch {
@@ -125,38 +125,36 @@ export function AudioProvider({ children }: { children: ReactNode }) {
     ...defaultState,
     ...loadStoredState(),
   }));
-  const [recentlyPlayedTrackIds, setRecentlyPlayedTrackIds] = useState(
-    loadRecentlyPlayedTrackIds
+  const [recentlyPlayedTracks, setRecentlyPlayedTracks] = useState(
+    loadRecentlyPlayedTracks
   );
 
   // Keep a ref to the latest state for callbacks that need fresh values
   const stateRef = useRef(playbackState);
   stateRef.current = playbackState;
   const systemVolumeRef = useRef(systemVolume);
-  const lastTrackedTrackIdRef = useRef(playbackState.currentTrack?.id ?? null);
+  const playbackTrackRef = useRef(playbackState.currentTrack);
 
   useEffect(() => {
     systemVolumeRef.current = systemVolume;
   }, [systemVolume]);
 
-  useEffect(() => {
-    const trackId = playbackState.currentTrack?.id;
-    if (!trackId || trackId === lastTrackedTrackIdRef.current) return;
+  const recordRecentlyPlayed = useCallback((track: PlaylistTrack | null) => {
+    if (!track) return;
 
-    lastTrackedTrackIdRef.current = trackId;
-    setRecentlyPlayedTrackIds((current) => {
-      const next = recordRecentlyPlayedTrack(current, trackId);
+    setRecentlyPlayedTracks((current) => {
+      const next = recordRecentlyPlayedTrack(current, track);
       try {
         localStorage.setItem(
           MUSIC_RECENTLY_PLAYED_STORAGE_KEY,
-          serializeRecentlyPlayedTrackIds(next)
+          serializeRecentlyPlayedTracks(next)
         );
       } catch {
         // Keep listening history available for this render when storage is unavailable.
       }
       return next;
     });
-  }, [playbackState.currentTrack?.id]);
+  }, []);
 
   // Debounced save - only saves after 1 second of no changes
   const debouncedSave = useCallback((state: PlaybackState) => {
@@ -224,8 +222,13 @@ export function AudioProvider({ children }: { children: ReactNode }) {
         }));
       };
 
+      const handlePlaying = () => {
+        recordRecentlyPlayed(playbackTrackRef.current);
+      };
+
       audio.addEventListener("loadedmetadata", handleLoadedMetadata);
       audio.addEventListener("error", handleError);
+      audio.addEventListener("playing", handlePlaying);
 
       // Restore track from persisted state (but don't auto-play)
       if (initialState.currentTrack?.previewUrl) {
@@ -237,6 +240,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       return () => {
         audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
         audio.removeEventListener("error", handleError);
+        audio.removeEventListener("playing", handlePlaying);
       };
     }
 
@@ -246,7 +250,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
         audioRef.current = null;
       }
     };
-  }, []);
+  }, [recordRecentlyPlayed]);
 
   // Cleanup save timeout on unmount
   useEffect(() => {
@@ -336,6 +340,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       if (nextIndex < queue.length) {
         const nextTrack = queue[nextIndex];
         if (nextTrack.previewUrl) {
+          playbackTrackRef.current = nextTrack;
           audio.src = nextTrack.previewUrl;
           audio.play().catch(() => {});
           setPlaybackState((prev) => ({
@@ -354,6 +359,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       } else if (repeatMode === "all" && queue.length > 0) {
         const firstTrack = queue[0];
         if (firstTrack.previewUrl) {
+          playbackTrackRef.current = firstTrack;
           audio.src = firstTrack.previewUrl;
           audio.play().catch(() => {});
           setPlaybackState((prev) => ({
@@ -387,6 +393,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    playbackTrackRef.current = track;
     audio.src = track.previewUrl;
     audio.play().catch(console.error);
 
@@ -436,6 +443,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
     if (audioRef.current) {
       audioRef.current.pause();
       audioRef.current.currentTime = 0;
+      playbackTrackRef.current = null;
       setPlaybackState((prev) => ({
         ...prev,
         isPlaying: false,
@@ -464,6 +472,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
 
     const nextTrack = queue[nextIndex];
     if (nextTrack && nextTrack.previewUrl && audioRef.current) {
+      playbackTrackRef.current = nextTrack;
       audioRef.current.src = nextTrack.previewUrl;
       // Only auto-play if we were already playing
       if (isPlaying) {
@@ -494,6 +503,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
     if (prevIndex >= 0) {
       const prevTrack = queue[prevIndex];
       if (prevTrack && prevTrack.previewUrl) {
+        playbackTrackRef.current = prevTrack;
         audio.src = prevTrack.previewUrl;
         // Only auto-play if we were already playing
         if (isPlaying) {
@@ -596,7 +606,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
     <AudioContext.Provider
       value={{
         playbackState,
-        recentlyPlayedTrackIds,
+        recentlyPlayedTracks,
         play,
         pause,
         resume,

--- a/lib/music/audio-context.tsx
+++ b/lib/music/audio-context.tsx
@@ -11,9 +11,16 @@ import {
 } from "react";
 import { PlaylistTrack, RepeatMode, PlaybackState } from "@/components/apps/music/types";
 import { useSystemSettingsSafe } from "@/lib/system-settings-context";
+import {
+  MUSIC_RECENTLY_PLAYED_STORAGE_KEY,
+  parseRecentlyPlayedTrackIds,
+  recordRecentlyPlayedTrack,
+  serializeRecentlyPlayedTrackIds,
+} from "@/lib/music/recently-played";
 
 interface AudioContextValue {
   playbackState: PlaybackState;
+  recentlyPlayedTrackIds: string[];
   play: (track: PlaylistTrack, queue: PlaylistTrack[]) => void;
   pause: () => void;
   resume: () => void;
@@ -30,6 +37,17 @@ interface AudioContextValue {
 const AudioContext = createContext<AudioContextValue | null>(null);
 
 const STORAGE_KEY = "music-playback-state";
+
+function loadRecentlyPlayedTrackIds(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return parseRecentlyPlayedTrackIds(
+      localStorage.getItem(MUSIC_RECENTLY_PLAYED_STORAGE_KEY)
+    );
+  } catch {
+    return [];
+  }
+}
 
 // Persist playback state including queue for next/previous to work after refresh
 interface PersistedState {
@@ -107,15 +125,38 @@ export function AudioProvider({ children }: { children: ReactNode }) {
     ...defaultState,
     ...loadStoredState(),
   }));
+  const [recentlyPlayedTrackIds, setRecentlyPlayedTrackIds] = useState(
+    loadRecentlyPlayedTrackIds
+  );
 
   // Keep a ref to the latest state for callbacks that need fresh values
   const stateRef = useRef(playbackState);
   stateRef.current = playbackState;
   const systemVolumeRef = useRef(systemVolume);
+  const lastTrackedTrackIdRef = useRef(playbackState.currentTrack?.id ?? null);
 
   useEffect(() => {
     systemVolumeRef.current = systemVolume;
   }, [systemVolume]);
+
+  useEffect(() => {
+    const trackId = playbackState.currentTrack?.id;
+    if (!trackId || trackId === lastTrackedTrackIdRef.current) return;
+
+    lastTrackedTrackIdRef.current = trackId;
+    setRecentlyPlayedTrackIds((current) => {
+      const next = recordRecentlyPlayedTrack(current, trackId);
+      try {
+        localStorage.setItem(
+          MUSIC_RECENTLY_PLAYED_STORAGE_KEY,
+          serializeRecentlyPlayedTrackIds(next)
+        );
+      } catch {
+        // Keep listening history available for this render when storage is unavailable.
+      }
+      return next;
+    });
+  }, [playbackState.currentTrack?.id]);
 
   // Debounced save - only saves after 1 second of no changes
   const debouncedSave = useCallback((state: PlaybackState) => {
@@ -555,6 +596,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
     <AudioContext.Provider
       value={{
         playbackState,
+        recentlyPlayedTrackIds,
         play,
         pause,
         resume,

--- a/lib/music/recently-played.ts
+++ b/lib/music/recently-played.ts
@@ -1,0 +1,30 @@
+export const MUSIC_RECENTLY_PLAYED_STORAGE_KEY = "music-recently-played";
+
+const MAX_RECENT_TRACKS = 8;
+
+export function parseRecentlyPlayedTrackIds(value: string | null): string[] {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+
+    return Array.from(
+      new Set(parsed.filter((trackId): trackId is string => typeof trackId === "string" && trackId.length > 0))
+    ).slice(0, MAX_RECENT_TRACKS);
+  } catch {
+    return [];
+  }
+}
+
+export function recordRecentlyPlayedTrack(trackIds: string[], trackId: string): string[] {
+  if (!trackId) return trackIds.slice(0, MAX_RECENT_TRACKS);
+  return [trackId, ...trackIds.filter((existingId) => existingId !== trackId)].slice(
+    0,
+    MAX_RECENT_TRACKS
+  );
+}
+
+export function serializeRecentlyPlayedTrackIds(trackIds: string[]): string {
+  return JSON.stringify(trackIds.slice(0, MAX_RECENT_TRACKS));
+}

--- a/lib/music/recently-played.ts
+++ b/lib/music/recently-played.ts
@@ -1,30 +1,58 @@
+import type { PlaylistTrack } from "@/components/apps/music/types";
+
 export const MUSIC_RECENTLY_PLAYED_STORAGE_KEY = "music-recently-played";
 
 const MAX_RECENT_TRACKS = 8;
 
-export function parseRecentlyPlayedTrackIds(value: string | null): string[] {
+function isPlaylistTrack(value: unknown): value is PlaylistTrack {
+  if (!value || typeof value !== "object") return false;
+
+  const track = value as Record<string, unknown>;
+  return (
+    typeof track.id === "string" &&
+    track.id.length > 0 &&
+    typeof track.name === "string" &&
+    typeof track.artist === "string" &&
+    typeof track.album === "string" &&
+    typeof track.albumArt === "string" &&
+    (track.previewUrl === null || typeof track.previewUrl === "string") &&
+    typeof track.duration === "number" &&
+    Number.isFinite(track.duration) &&
+    track.duration >= 0
+  );
+}
+
+export function parseRecentlyPlayedTracks(value: string | null): PlaylistTrack[] {
   if (!value) return [];
 
   try {
     const parsed = JSON.parse(value);
     if (!Array.isArray(parsed)) return [];
 
-    return Array.from(
-      new Set(parsed.filter((trackId): trackId is string => typeof trackId === "string" && trackId.length > 0))
-    ).slice(0, MAX_RECENT_TRACKS);
+    const seenTrackIds = new Set<string>();
+    return parsed
+      .filter(isPlaylistTrack)
+      .filter((track) => {
+        if (seenTrackIds.has(track.id)) return false;
+        seenTrackIds.add(track.id);
+        return true;
+      })
+      .slice(0, MAX_RECENT_TRACKS);
   } catch {
     return [];
   }
 }
 
-export function recordRecentlyPlayedTrack(trackIds: string[], trackId: string): string[] {
-  if (!trackId) return trackIds.slice(0, MAX_RECENT_TRACKS);
-  return [trackId, ...trackIds.filter((existingId) => existingId !== trackId)].slice(
+export function recordRecentlyPlayedTrack(
+  tracks: PlaylistTrack[],
+  track: PlaylistTrack
+): PlaylistTrack[] {
+  return [track, ...tracks.filter((existingTrack) => existingTrack.id !== track.id)].slice(
     0,
     MAX_RECENT_TRACKS
   );
 }
 
-export function serializeRecentlyPlayedTrackIds(trackIds: string[]): string {
-  return JSON.stringify(trackIds.slice(0, MAX_RECENT_TRACKS));
+export function serializeRecentlyPlayedTracks(tracks: PlaylistTrack[]): string {
+  return JSON.stringify(tracks.slice(0, MAX_RECENT_TRACKS));
 }

--- a/tests/music-recently-played.test.ts
+++ b/tests/music-recently-played.test.ts
@@ -1,40 +1,71 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { PlaylistTrack } from "../components/apps/music/types";
 import {
-  parseRecentlyPlayedTrackIds,
+  parseRecentlyPlayedTracks,
   recordRecentlyPlayedTrack,
-  serializeRecentlyPlayedTrackIds,
+  serializeRecentlyPlayedTracks,
 } from "../lib/music/recently-played";
 
+function track(id: string, overrides: Partial<PlaylistTrack> = {}): PlaylistTrack {
+  return {
+    id,
+    name: `Track ${id}`,
+    artist: "Artist",
+    album: "Album",
+    albumArt: `https://example.com/${id}.jpg`,
+    previewUrl: `https://example.com/${id}.m4a`,
+    duration: 30,
+    ...overrides,
+  };
+}
+
 test("recent listening history is unique and ordered newest first", () => {
-  assert.deepEqual(recordRecentlyPlayedTrack(["first", "second"], "second"), [
-    "second",
-    "first",
+  const first = track("first");
+  const second = track("second");
+  const third = track("third");
+
+  assert.deepEqual(recordRecentlyPlayedTrack([first, second], second), [
+    second,
+    first,
   ]);
-  assert.deepEqual(recordRecentlyPlayedTrack(["second", "first"], "third"), [
-    "third",
-    "second",
-    "first",
+  assert.deepEqual(recordRecentlyPlayedTrack([second, first], third), [
+    third,
+    second,
+    first,
   ]);
 });
 
 test("recent listening history keeps the latest eight tracks", () => {
+  const tracks = ["2", "3", "4", "5", "6", "7", "8", "9"].map((id) =>
+    track(id)
+  );
   assert.deepEqual(
-    recordRecentlyPlayedTrack(
-      ["2", "3", "4", "5", "6", "7", "8", "9"],
-      "1"
-    ),
+    recordRecentlyPlayedTrack(tracks, track("1")).map(({ id }) => id),
     ["1", "2", "3", "4", "5", "6", "7", "8"]
   );
 });
 
-test("stored listening history recovers from malformed and duplicate values", () => {
-  assert.deepEqual(parseRecentlyPlayedTrackIds(null), []);
-  assert.deepEqual(parseRecentlyPlayedTrackIds("not-json"), []);
-  assert.deepEqual(parseRecentlyPlayedTrackIds(JSON.stringify({ track: "one" })), []);
+test("stored listening history recovers complete unique track records", () => {
+  const browseTrack = track("itunes-123", { name: "Browse result" });
+  const libraryTrack = track("library-1");
+  const serialized = serializeRecentlyPlayedTracks([browseTrack, libraryTrack]);
+
+  assert.deepEqual(parseRecentlyPlayedTracks(serialized), [browseTrack, libraryTrack]);
+});
+
+test("stored listening history rejects malformed, duplicate, and legacy entries", () => {
+  const first = track("one");
+  const updatedFirst = track("one", { name: "Duplicate" });
+  const second = track("two");
+
+  assert.deepEqual(parseRecentlyPlayedTracks(null), []);
+  assert.deepEqual(parseRecentlyPlayedTracks("not-json"), []);
+  assert.deepEqual(parseRecentlyPlayedTracks(JSON.stringify({ track: first })), []);
   assert.deepEqual(
-    parseRecentlyPlayedTrackIds(JSON.stringify(["one", "two", "one", null, 3, ""])),
-    ["one", "two"]
+    parseRecentlyPlayedTracks(
+      JSON.stringify([first, second, updatedFirst, null, 3, "legacy-id", {}])
+    ),
+    [first, second]
   );
-  assert.equal(serializeRecentlyPlayedTrackIds(["one", "two"]), '["one","two"]');
 });

--- a/tests/music-recently-played.test.ts
+++ b/tests/music-recently-played.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseRecentlyPlayedTrackIds,
+  recordRecentlyPlayedTrack,
+  serializeRecentlyPlayedTrackIds,
+} from "../lib/music/recently-played";
+
+test("recent listening history is unique and ordered newest first", () => {
+  assert.deepEqual(recordRecentlyPlayedTrack(["first", "second"], "second"), [
+    "second",
+    "first",
+  ]);
+  assert.deepEqual(recordRecentlyPlayedTrack(["second", "first"], "third"), [
+    "third",
+    "second",
+    "first",
+  ]);
+});
+
+test("recent listening history keeps the latest eight tracks", () => {
+  assert.deepEqual(
+    recordRecentlyPlayedTrack(
+      ["2", "3", "4", "5", "6", "7", "8", "9"],
+      "1"
+    ),
+    ["1", "2", "3", "4", "5", "6", "7", "8"]
+  );
+});
+
+test("stored listening history recovers from malformed and duplicate values", () => {
+  assert.deepEqual(parseRecentlyPlayedTrackIds(null), []);
+  assert.deepEqual(parseRecentlyPlayedTrackIds("not-json"), []);
+  assert.deepEqual(parseRecentlyPlayedTrackIds(JSON.stringify({ track: "one" })), []);
+  assert.deepEqual(
+    parseRecentlyPlayedTrackIds(JSON.stringify(["one", "two", "one", null, 3, ""])),
+    ["one", "two"]
+  );
+  assert.equal(serializeRecentlyPlayedTrackIds(["one", "two"]), '["one","two"]');
+});


### PR DESCRIPTION
## Today's delight

Music Home remembers the latest eight songs that actually begin playback and places a persistent, recent-first **Recently Played** shelf above Playlists. The shelf now retains complete track metadata, so songs discovered through Browse remain playable after returning Home or reloading.

## Baseline and delta

- Before: Home showed the featured album, Playlists, and Songs; starting a song only changed the player, and returning or reloading offered no listening-history view.
- Now: A playback event creates a persistent Recently Played entry that stays recent-first, deduplicates replays, and preserves library and dynamic Browse tracks across reloads.
- Preserved: Paused next/previous selection does not count as listening; the selected track is recorded only after resume. Song cards, playlist navigation, Home restoration, and the mobile Back control retain their existing behavior.

## Built result — desktop

![Desktop screenshot of Music Recently Played with a persisted Browse track](https://github.com/user-attachments/assets/fd735b08-550e-428f-8321-3bdea1a75d8b)

The 1440×900 desktop state shows a live Browse result, “Leave Me Behind,” retained beside library tracks after returning Home and reloading. The same recent card was verified to pause rather than restart and to resume from its current position.

## Built result — mobile

![Mobile screenshot of Music Recently Played under touch and coarse-pointer emulation](https://github.com/user-attachments/assets/05e0a0c3-6e8b-4c08-aebf-0353e23c6679)

The 390×844 iPhone state shows the same persistent history in a touch-friendly horizontal shelf. A real touch event resumed the restored Browse track and updated its card and player controls; the existing mobile layout and Back control remain intact.

## macOS inspiration

Apple documents Music Home as including music recently played in addition to recommendations. This implementation maps that native Home behavior onto the site's existing library: actual playback events create the history, recent tracks appear on Home, and the order persists locally. Source: [Apple Music User Guide — Stream recommended songs](https://support.apple.com/en-gb/guide/music/-mus02acedfe/mac).

## Why this one

Music's last shipped daily delight was 2026-08-04 and its last merged visible touch was 2026-08-12, so it was a neglected registered app with no overlap among open PRs. The result adds useful memory to an existing personal surface without changing its backend scope.

## Review fixes

- Persist complete `PlaylistTrack` records so dynamic `itunes-*` Browse results are not dropped on Home.
- Record history from the audio element's `playing` event, avoiding false entries from paused next/previous selection while capturing restored tracks when playback resumes.
- Give recent cards true pause/resume semantics instead of restarting the current track.

## Verification

- `node --import tsx --test tests/music-recently-played.test.ts` — 4 passing
- `npm run check` — 129 tests, typecheck, and production build passing; six pre-existing lint warnings and no errors
- Desktop: 1440×900; playback-event recording, pause/resume, paused next selection, resume recording, live Browse lookup, Home restoration, and reload persistence
- Mobile: iPhone 390×844 at DPR 3 with `maxTouchPoints: 5`, `(pointer: coarse)`, and `(hover: none)`; touch resume, persistent dynamic history, mobile layout, and Back control

## Scope

Micro: four Music files, 250 additions and two deletions relative to `main`. The last two daily primary surfaces (Calendar and Notification Center), recent non-delight work, and open Notes, Games, and menu-bar PRs were excluded from selection.
