### PR TITLE
Daily delight: Open iTerm directories in Finder

### DIFF
--- a/components/apps/iterm/iterm-app.tsx
+++ b/components/apps/iterm/iterm-app.tsx
@@ -8,6 +8,7 @@ const HOME_DIR = "/Users/alanagoyal";
 
 interface ITermAppProps {
   inShell?: boolean;
+  onOpenDirectory?: (directoryPath: string) => void;
   onOpenTextFile?: (filePath: string, content: string) => void;
 }
 
@@ -19,7 +20,11 @@ function formatWorkingDirectory(directory: string): string {
   return directory;
 }
 
-export function ITermApp({ inShell = false, onOpenTextFile }: ITermAppProps) {
+export function ITermApp({
+  inShell = false,
+  onOpenDirectory,
+  onOpenTextFile,
+}: ITermAppProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentDirectory, setCurrentDirectory] = useState(HOME_DIR);
   const sessionTitle = formatWorkingDirectory(currentDirectory);
@@ -35,6 +40,7 @@ export function ITermApp({ inShell = false, onOpenTextFile }: ITermAppProps) {
       <Nav isDesktop={inShell} sessionTitle={sessionTitle} />
       <div className="flex-1 min-h-0 overflow-hidden bg-background">
         <Terminal
+          onOpenDirectory={onOpenDirectory}
           onOpenTextFile={onOpenTextFile}
           onCurrentDirectoryChange={setCurrentDirectory}
         />

--- a/components/apps/iterm/terminal.tsx
+++ b/components/apps/iterm/terminal.tsx
@@ -9,6 +9,10 @@ import {
   fetchGitHubRepoTree,
   fetchGitHubRepos,
 } from "@/lib/github-client";
+import {
+  getFinderOpenDirectoryTarget,
+  getFinderProjectRootTarget,
+} from "@/lib/finder-path";
 
 const USERNAME = "alanagoyal";
 const HOSTNAME = "Alanas-MacBook-Air";
@@ -502,22 +506,36 @@ export function Terminal({
 
         const staticNode = fileSystem[path];
         const parsed = parseGitHubPath(path);
-        let isDirectory = staticNode?.type === "dir" || path === PROJECTS_DIR;
+        let finderDirectoryTarget = staticNode?.type === "dir"
+          ? getFinderOpenDirectoryTarget(path)
+          : null;
 
-        if (!isDirectory && parsed) {
+        if (staticNode?.type === "dir" && !finderDirectoryTarget) {
+          output = `open: ${args[0]}: Finder cannot display this folder`;
+          break;
+        }
+
+        if (!finderDirectoryTarget && parsed) {
           if (!parsed.filePath) {
-            isDirectory = true;
+            const repos = await fetchGitHubRepos();
+            const projectRootTarget = getFinderProjectRootTarget(path, repos);
+            if (!projectRootTarget) {
+              output = `open: ${args[0]}: No such file or directory`;
+              break;
+            }
+            finderDirectoryTarget = projectRootTarget;
           } else {
             const tree = await fetchGitHubRepoTree(parsed.repo);
-            isDirectory = tree.some(
+            const isDirectory = tree.some(
               (item) => item.type === "dir" && item.path === parsed.filePath
             );
+            if (isDirectory) finderDirectoryTarget = path;
           }
         }
 
-        if (isDirectory) {
+        if (finderDirectoryTarget) {
           if (onOpenDirectory) {
-            onOpenDirectory(path);
+            onOpenDirectory(finderDirectoryTarget);
           } else {
             output = "open: Finder is not available";
           }

--- a/components/apps/iterm/terminal.tsx
+++ b/components/apps/iterm/terminal.tsx
@@ -153,11 +153,13 @@ function isTextFile(filename: string): boolean {
 }
 
 interface TerminalProps {
+  onOpenDirectory?: (directoryPath: string) => void;
   onOpenTextFile?: (filePath: string, content: string) => void;
   onCurrentDirectoryChange?: (directory: string) => void;
 }
 
 export function Terminal({
+  onOpenDirectory,
   onOpenTextFile,
   onCurrentDirectoryChange,
 }: TerminalProps) {
@@ -288,7 +290,7 @@ export function Terminal({
   cd <dir>      - Change directory
   ls [dir]      - List directory contents
   cat <file>    - Display file contents
-  open <file>   - Open file in TextEdit
+  open <path>   - Open a file or folder
   echo <text>   - Print text to terminal
   whoami        - Display current user
   hostname      - Display hostname
@@ -498,6 +500,30 @@ export function Terminal({
 
         const path = resolvePath(args[0]);
 
+        const staticNode = fileSystem[path];
+        const parsed = parseGitHubPath(path);
+        let isDirectory = staticNode?.type === "dir" || path === PROJECTS_DIR;
+
+        if (!isDirectory && parsed) {
+          if (!parsed.filePath) {
+            isDirectory = true;
+          } else {
+            const tree = await fetchGitHubRepoTree(parsed.repo);
+            isDirectory = tree.some(
+              (item) => item.type === "dir" && item.path === parsed.filePath
+            );
+          }
+        }
+
+        if (isDirectory) {
+          if (onOpenDirectory) {
+            onOpenDirectory(path);
+          } else {
+            output = "open: Finder is not available";
+          }
+          break;
+        }
+
         // Check if it's a text file
         const fileName = path.split("/").pop() || "";
         if (!isTextFile(fileName)) {
@@ -509,7 +535,7 @@ export function Terminal({
         let content = "";
 
         // Check static file system first
-        const staticFile = fileSystem[path];
+        const staticFile = staticNode;
         if (staticFile?.type === "file" && staticFile.content) {
           content = staticFile.content;
         } else if (staticFile?.type === "dir") {
@@ -517,7 +543,6 @@ export function Terminal({
           break;
         } else {
           // Check GitHub
-          const parsed = parseGitHubPath(path);
           if (parsed && parsed.filePath) {
             try {
               content = await fetchGitHubFileContent(parsed.repo, parsed.filePath);
@@ -552,7 +577,7 @@ export function Terminal({
       { type: "input", content: input, prompt },
       ...(output ? [{ type: "output" as const, content: output }] : []),
     ]);
-  }, [currentDir, commandHistory, getPrompt, resolvePath, fileSystem, isGitHubPath, parseGitHubPath, currentOS, addRecent, onOpenTextFile]);
+  }, [currentDir, commandHistory, getPrompt, resolvePath, fileSystem, isGitHubPath, parseGitHubPath, currentOS, addRecent, onOpenDirectory, onOpenTextFile]);
 
   const handleKeyDown = useCallback(async (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && !isExecuting) {

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -319,6 +319,21 @@ function DesktopContent({
   ) => {
     openFinderWindow(initialPath, options);
   }, [openFinderWindow]);
+  const handleOpenFinderDirectory = useCallback((directoryPath: string) => {
+    const existingWindow = [...finderWindows]
+      .filter(
+        (windowState) =>
+          windowState.isOpen && windowState.metadata?.currentPath === directoryPath
+      )
+      .sort((left, right) => right.zIndex - left.zIndex)[0];
+
+    if (existingWindow) {
+      focusMultiWindow(existingWindow.id);
+      return;
+    }
+
+    openDedicatedFinderWindow(directoryPath);
+  }, [finderWindows, focusMultiWindow, openDedicatedFinderWindow]);
   const focusFinderApp = useCallback(() => {
     if (finderWindows.some((windowState) => windowState.isOpen)) {
       bringAppToFront("finder");
@@ -985,7 +1000,11 @@ function DesktopContent({
           </Window>
 
           <Window appId="iterm">
-            <ITermApp inShell={true} onOpenTextFile={handleOpenTextFile} />
+            <ITermApp
+              inShell={true}
+              onOpenDirectory={handleOpenFinderDirectory}
+              onOpenTextFile={handleOpenTextFile}
+            />
           </Window>
 
           <Window appId="photos">

--- a/lib/finder-path.ts
+++ b/lib/finder-path.ts
@@ -12,6 +12,31 @@ const FINDER_ROOTS = [
   { label: "Projects", path: PROJECTS_DIR },
 ];
 
+const FINDER_OPEN_DIRECTORY_TARGETS = new Map<string, string>([
+  [HOME_DIR, HOME_DIR],
+  [`${HOME_DIR}/Desktop`, `${HOME_DIR}/Desktop`],
+  [`${HOME_DIR}/Documents`, `${HOME_DIR}/Documents`],
+  [`${HOME_DIR}/Downloads`, `${HOME_DIR}/Downloads`],
+  [PROJECTS_DIR, PROJECTS_DIR],
+  ["/Applications", "applications"],
+]);
+
+export function getFinderOpenDirectoryTarget(path: string): string | null {
+  return FINDER_OPEN_DIRECTORY_TARGETS.get(path) ?? null;
+}
+
+export function getFinderProjectRootTarget(
+  path: string,
+  repositories: readonly string[]
+): string | null {
+  const prefix = `${PROJECTS_DIR}/`;
+  if (!path.startsWith(prefix)) return null;
+
+  const relativePath = path.slice(prefix.length);
+  if (!relativePath || relativePath.includes("/")) return null;
+  return repositories.includes(relativePath) ? path : null;
+}
+
 export function getFinderPathSegments(path: string): FinderPathSegment[] {
   if (path === "recents") return [{ label: "Recents", path }];
   if (path === "applications") return [{ label: "Applications", path }];

--- a/tests/finder-path.test.ts
+++ b/tests/finder-path.test.ts
@@ -1,6 +1,44 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { getFinderPathSegments } from "../lib/finder-path";
+import {
+  getFinderOpenDirectoryTarget,
+  getFinderPathSegments,
+  getFinderProjectRootTarget,
+} from "../lib/finder-path";
+
+test("maps only Finder-supported terminal directories", () => {
+  assert.equal(
+    getFinderOpenDirectoryTarget("/Users/alanagoyal/Desktop"),
+    "/Users/alanagoyal/Desktop"
+  );
+  assert.equal(getFinderOpenDirectoryTarget("/Applications"), "applications");
+  assert.equal(getFinderOpenDirectoryTarget("/"), null);
+  assert.equal(getFinderOpenDirectoryTarget("/System"), null);
+});
+
+test("opens only existing GitHub project roots", () => {
+  assert.equal(
+    getFinderProjectRootTarget(
+      "/Users/alanagoyal/Projects/alanagoyal",
+      ["alanagoyal", "cli-crm"]
+    ),
+    "/Users/alanagoyal/Projects/alanagoyal"
+  );
+  assert.equal(
+    getFinderProjectRootTarget(
+      "/Users/alanagoyal/Projects/not-a-repo",
+      ["alanagoyal", "cli-crm"]
+    ),
+    null
+  );
+  assert.equal(
+    getFinderProjectRootTarget(
+      "/Users/alanagoyal/Projects/alanagoyal/components",
+      ["alanagoyal"]
+    ),
+    null
+  );
+});
 
 test("builds clickable segments from the Finder section root", () => {
   assert.deepEqual(


### PR DESCRIPTION
## Today's delight

iTerm now treats `open .` and other valid directory paths like macOS Terminal: it opens Finder at the resolved directory. If Finder already has a matching window open, that window is focused instead of duplicated.

## Baseline and delta

- Before: iTerm's `open` command only opened text files; `open .` returned `Cannot open non-text files` and created no Finder window.
- Now: `open .` and valid relative or absolute directories resolve against the terminal's current directory and open Finder at that location.
- Preserved: `cd`, `pwd`, `ls`, terminal history, existing `open <text-file>` TextEdit behavior, and matching Finder-window reuse all continue to work.

## Built result — desktop

![Desktop screenshot of iTerm opening the current directory in Finder](https://github.com/user-attachments/assets/250a9ecb-39d2-42b5-b4d6-c8d199838a23)

At 1440×900, the capture shows iTerm after `cd Desktop`, `pwd`, and `open .`, alongside Finder opened at the exact resolved `/Users/alanagoyal/Desktop` location. Repeating `open .` focused the matching Finder window rather than creating a duplicate; `open hello.md` still launched TextEdit.

## Built result — mobile

![Mobile screenshot of the preserved Notes fallback](https://github.com/user-attachments/assets/59ae650f-b4b3-466b-8526-58b6d8007f60)

At an iPhone 390×844 viewport with DPR 3, five touch points, coarse pointer, and no hover, the desktop-only iTerm route still redirects to the supported Notes shell. A real touch opened the About Me note, preserving the intentional mobile experience.

## macOS inspiration

The installed macOS 26.5.1 `open(1)` manual defines `open` as opening files and directories relative to the current shell directory and states that directories open in Finder. This implementation maps that native contract directly: directory resolution stays in iTerm, while Finder owns the resulting folder presentation.

## Why this one

iTerm was a neglected registered app: its last daily delight was 2026-07-28 and its last merged visible touch was 2026-08-12. The change scored 34/35 in the daily-delight rubric and won on authenticity, coverage, finishability, and low regression risk. The two most recent daily primary surfaces—Preview and Music—were excluded.

## Verification

- `NEXT_TURBOPACK_USE_WORKER=0 npm run check` — passed lint with six pre-existing warnings and zero errors, all 134 tests, typecheck, and all 41 production routes
- Desktop: 1440×900; verified `cd Desktop`, `pwd`, first and repeated `open .`, exact Finder path metadata, matching-window reuse, preserved `open hello.md`, `/Applications` routing to Finder Applications, unsupported-root rejection, nonexistent-project rejection, terminal history, and zero console/runtime errors
- Mobile: iPhone 390×844 at DPR 3 with touch/coarse-pointer emulation; verified Notes fallback and a real touch opening About Me with zero errors
- Focused regression tests cover Finder-supported directory mapping and GitHub project-root validation

## Scope

Micro: five files, 138 additions and 7 deletions, including focused regression coverage. The change does not overlap open PR #298 (menu-bar eyes) or #293 (Games Memory Match levels), and adds no dependency, backend, schema, secret, production data, or keyboard navigation.