### PR TITLE
Daily delight: Wrap TextEdit to page

### DIFF
--- a/components/apps/textedit/textedit-window.tsx
+++ b/components/apps/textedit/textedit-window.tsx
@@ -31,6 +31,7 @@ interface TextEditWindowProps {
   isFocused: boolean;
   isMaximized: boolean;
   isDirty: boolean;
+  wrapToPage: boolean;
   onFocus: () => void;
   onClose: () => void;
   onMinimize: () => void;
@@ -50,6 +51,7 @@ export function TextEditWindow({
   isFocused,
   isMaximized,
   isDirty,
+  wrapToPage,
   onFocus,
   onClose,
   onMinimize,
@@ -321,13 +323,27 @@ export function TextEditWindow({
         )}
 
         {/* Content */}
-        <div className="flex-1 min-h-0">
+        <div
+          data-testid="textedit-document-area"
+          data-wrap-mode={wrapToPage ? "page" : "window"}
+          className={cn(
+            "flex-1 min-h-0",
+            wrapToPage
+              ? "overflow-auto bg-zinc-200/70 p-6 dark:bg-zinc-950"
+              : "overflow-hidden"
+          )}
+        >
           <textarea
             ref={textareaRef}
             aria-label={`Document contents for ${fileName}`}
             value={content}
             onChange={(e) => onContentChange(e.target.value)}
-            className="w-full h-full bg-transparent resize-none outline-none font-mono text-sm leading-relaxed p-4 overflow-auto text-zinc-900 dark:text-white"
+            className={cn(
+              "resize-none outline-none font-mono text-sm leading-relaxed text-zinc-900 dark:text-white",
+              wrapToPage
+                ? "mx-auto block h-[792px] w-[612px] bg-white px-[72px] py-[72px] shadow-[0_1px_4px_rgba(0,0,0,0.24)] dark:bg-zinc-900"
+                : "h-full w-full overflow-auto bg-transparent p-4"
+            )}
             spellCheck={false}
           />
         </div>

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -683,6 +683,10 @@ function DesktopContent({
     return null;
   }, [renameRecent, state.windows, updateWindowMetadata]);
 
+  const handleTextEditWrapToPageChange = useCallback((windowId: string, wrapToPage: boolean) => {
+    updateWindowMetadata(windowId, { wrapToPage });
+  }, [updateWindowMetadata]);
+
   // Handler for opening apps from Finder
   const handleOpenApp = useCallback((appId: string) => {
     if (appId === "textedit" || appId === "preview") {
@@ -954,6 +958,7 @@ function DesktopContent({
         onTextEditSave={handleTextEditSave}
         onTextEditDuplicate={handleTextEditDuplicate}
         onTextEditRename={handleTextEditRename}
+        onTextEditWrapToPageChange={handleTextEditWrapToPageChange}
         onPreviewOpen={handlePreviewOpen}
         onPreviewClose={handlePreviewClose}
       />
@@ -1064,6 +1069,7 @@ function DesktopContent({
                   isFocused={state.focusedWindowId === windowState.id}
                   isMaximized={windowState.isMaximized}
                   isDirty={windowState.metadata?.isDirty === true}
+                  wrapToPage={windowState.metadata?.wrapToPage === true}
                   onFocus={() => focusMultiWindow(windowState.id)}
                   onClose={() => closeMultiWindow(windowState.id)}
                   onMinimize={() => minimizeMultiWindow(windowState.id)}

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -16,6 +16,7 @@ import { FileMenu } from "./file-menu";
 import { FinderViewMenu } from "./finder-view-menu";
 import { CalendarViewMenu } from "./calendar-view-menu";
 import { TextEditEditMenu } from "./textedit-edit-menu";
+import { TextEditFormatMenu } from "./textedit-format-menu";
 import { TextEditFileMenu, TextEditRenameDialog } from "./textedit-file-menu";
 import { PreviewFileMenu } from "./preview-file-menu";
 import { AboutDialog } from "./about-dialog";
@@ -30,7 +31,7 @@ import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 import type { FinderViewMode } from "@/components/apps/finder/view-mode";
 import { TEXTEDIT_OPEN_FIND_EVENT } from "@/lib/textedit-find";
 
-type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "previewFileMenu" | "finderViewMenu" | "calendarViewMenu" | "textEditEditMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
+type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "previewFileMenu" | "finderViewMenu" | "calendarViewMenu" | "textEditEditMenu" | "textEditFormatMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
 
 const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
 
@@ -75,6 +76,7 @@ interface MenuBarProps {
   onTextEditSave?: (windowId: string) => void;
   onTextEditDuplicate?: (windowId: string) => void;
   onTextEditRename?: (windowId: string, fileName: string) => string | null;
+  onTextEditWrapToPageChange?: (windowId: string, wrapToPage: boolean) => void;
   onPreviewOpen?: () => void;
   onPreviewClose?: (windowId: string) => void;
 }
@@ -105,6 +107,7 @@ export function MenuBar({
   onTextEditSave,
   onTextEditDuplicate,
   onTextEditRename,
+  onTextEditWrapToPageChange,
   onPreviewOpen,
   onPreviewClose,
 }: MenuBarProps) {
@@ -151,6 +154,9 @@ export function MenuBar({
     ? String(state.windows[focusedWindowId]?.metadata?.filePath ?? "")
     : "";
   const focusedTextEditFileName = focusedTextEditFilePath.split("/").pop() || "Untitled.txt";
+  const focusedTextEditWrapToPage = focusedAppId === "textedit" && focusedWindowId
+    ? state.windows[focusedWindowId]?.metadata?.wrapToPage === true
+    : false;
   const activeFocus =
     focusMode === "off" ? null : FOCUS_STATUS_CONFIG[focusMode];
 
@@ -364,6 +370,19 @@ export function MenuBar({
               Edit
             </button>
           )}
+          {focusedAppId === "textedit" && (
+            <button
+              onClick={() => toggleMenu("textEditFormatMenu")}
+              className={cn(
+                "rounded px-2 py-0.5 text-sm transition-colors",
+                openMenu === "textEditFormatMenu"
+                  ? "bg-blue-500 text-white"
+                  : "text-black can-hover:hover:bg-white/10 dark:text-white"
+              )}
+            >
+              Format
+            </button>
+          )}
         </div>
       </div>
 
@@ -546,6 +565,17 @@ export function MenuBar({
               detail: { windowId: focusedWindowId },
             })
           );
+        }}
+      />
+
+      <TextEditFormatMenu
+        isOpen={openMenu === "textEditFormatMenu"}
+        onClose={closeMenu}
+        wrapToPage={focusedTextEditWrapToPage}
+        onWrapToPageChange={(wrapToPage) => {
+          if (focusedWindowId) {
+            onTextEditWrapToPageChange?.(focusedWindowId, wrapToPage);
+          }
         }}
       />
 

--- a/components/desktop/textedit-format-menu.tsx
+++ b/components/desktop/textedit-format-menu.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRef } from "react";
+import { useClickOutside } from "@/lib/hooks/use-click-outside";
+
+interface TextEditFormatMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  wrapToPage: boolean;
+  onWrapToPageChange: (wrapToPage: boolean) => void;
+}
+
+export function TextEditFormatMenu({
+  isOpen,
+  onClose,
+  wrapToPage,
+  onWrapToPageChange,
+}: TextEditFormatMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(menuRef, onClose, isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      data-testid="textedit-format-menu"
+      className="absolute left-[218px] top-7 z-[70] w-48 overflow-hidden rounded-lg border border-black/10 bg-white/95 py-1 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+    >
+      <button
+        type="button"
+        onClick={() => {
+          onWrapToPageChange(!wrapToPage);
+          onClose();
+        }}
+        className="w-full px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+      >
+        {wrapToPage ? "Wrap to Window" : "Wrap to Page"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Today's delight

TextEdit now offers a native-style **Format → Wrap to Page** command. It switches the focused document from window-width editing to a centered US Letter–proportioned page canvas with familiar margins, then changes to **Wrap to Window** so the choice is reversible. The setting stays scoped to each TextEdit window and persists with that window's existing metadata.

## Baseline and delta

- Before: TextEdit provided File and Edit menus, find/replace, document commands, and a full-window text area, but no Format menu or page-width editing mode.
- Now: Reviewers can choose **Format → Wrap to Page** and see the document reflow inside a centered 612×792 paper canvas with 72px margins; choosing **Wrap to Window** restores the original editor.
- Preserved: File and Edit commands, find/replace, save state, document contents, window focus, drag/resize behavior, and the existing unsupported-mobile redirect to Notes remain intact.

## Built result — desktop

![TextEdit Wrap to Page with the Format menu open](https://github.com/user-attachments/assets/a4ba1641-4be8-43f9-830f-984c7f3b1e3d)

At 1440×900, the page canvas measured 612×792 with 72px content margins. Both menu directions, find-in-page, window-width restoration, and reload persistence were exercised.

## Built result — mobile

![Shared Notes mobile fallback used by unsupported desktop apps](https://github.com/user-attachments/assets/59ae650f-b4b3-466b-8526-58b6d8007f60)

TextEdit remains intentionally desktop-only on mobile and continues to route into the shared Notes shell. This is the stable hosted capture of that same shared fallback from merged PR #301. The owner explicitly waived repeating touch/coarse-pointer emulation for this publication; the current mobile-support matrix test still verifies that TextEdit resolves to Notes.

## macOS inspiration

Apple's current [TextEdit guide](https://support.apple.com/en-mide/guide/textedit/txte3ab65427/mac) documents **Format → Wrap to Page** for wrapping text within page margins based on paper size, and **Wrap to Window** for returning to window-width wrapping. This implementation maps those commands to a reversible, per-window editing mode without adding keyboard shortcuts.

## Why this one

TextEdit was a neglected registered app: its last daily delight was 2026-08-02 and its last merged visible touch was 2026-08-12. It scored 33/35 and avoided the two most recent daily primary surfaces, Preview and Music, as well as in-flight Games and menu-bar work.

## Verification

- `NEXT_TURBOPACK_USE_WORKER=0 npm run check` — lint completed with six pre-existing warnings and zero errors; all 134 tests, typecheck, and all 41 production routes passed after updating to the latest `main`.
- Desktop: 1440×900; Wrap to Page/Window toggling, exact canvas/margin metrics, find-in-page, and reload persistence.
- Mobile: existing TextEdit → Notes routing contract retained and covered by the mobile-support matrix; repeat touch/coarse-pointer emulation was explicitly waived by the owner for publication.
- `git diff --check`

## Scope

Micro: four intended product files, 98 additions and 3 deletions relative to the original selection baseline. The branch is updated through merged PR #301; open PR overlap was checked against Games and menu-bar work.
