### PR TITLE
Daily delight: Choose Weather temperature units

### DIFF
--- a/components/apps/weather/weather-app.tsx
+++ b/components/apps/weather/weather-app.tsx
@@ -23,20 +23,24 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { WeatherSceneEffects } from "@/components/apps/weather/weather-scene-effects";
 import {
   buildOpenMeteoForecastUrl,
+  formatWeatherTemperature,
   getWeatherDescription,
   getWeatherIconName,
   getWeatherCitySelectionAfterRemoval,
   type WeatherMood,
   getWeatherScene,
   type WeatherScene,
+  type WeatherTemperatureUnit,
 } from "@/lib/weather";
 import {
   loadWeatherCustomCities,
   loadWeatherDataCache,
   loadWeatherSelectedCity,
+  loadWeatherTemperatureUnit,
   saveWeatherCustomCities,
   saveWeatherDataCache,
   saveWeatherSelectedCity,
+  saveWeatherTemperatureUnit,
   type WeatherDataCache,
   type WeatherCustomCity,
 } from "@/lib/sidebar-persistence";
@@ -482,6 +486,7 @@ function SidebarCityItem({
   weather,
   scene,
   isSelected,
+  temperatureUnit,
   onSelect,
   onDelete,
 }: {
@@ -489,14 +494,17 @@ function SidebarCityItem({
   weather: CityWeather | null;
   scene: WeatherScene | null;
   isSelected: boolean;
+  temperatureUnit: WeatherTemperatureUnit;
   onSelect: () => void;
   onDelete?: () => void;
 }) {
   const timeLabel = weather ? formatCityClock(weather.currentTime) : "--:--";
   const descriptionLabel = weather ? getWeatherDescription(weather.weatherCode) : "Loading...";
-  const temperatureLabel = weather ? `${Math.round(weather.currentTemp)}°` : "--";
+  const temperatureLabel = weather
+    ? formatWeatherTemperature(weather.currentTemp, temperatureUnit)
+    : "--";
   const highLowLabel = weather
-    ? `H:${Math.round(weather.high)}° L:${Math.round(weather.low)}°`
+    ? `H:${formatWeatherTemperature(weather.high, temperatureUnit)} L:${formatWeatherTemperature(weather.low, temperatureUnit)}`
     : "H:-- L:--";
 
   const cityButton = (
@@ -562,6 +570,50 @@ function SidebarCityItem({
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
+  );
+}
+
+function TemperatureUnitControl({
+  value,
+  onChange,
+}: {
+  value: WeatherTemperatureUnit;
+  onChange: (value: WeatherTemperatureUnit) => void;
+}) {
+  return (
+    <section className="flex items-center justify-between gap-3 rounded-xl bg-white/[0.1] px-3 py-2 backdrop-blur-sm">
+      <div>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/72">
+          Temperature
+        </p>
+        <p className="mt-0.5 text-xs text-white/68">Display units</p>
+      </div>
+      <div
+        role="group"
+        aria-label="Temperature unit"
+        className="flex rounded-lg border border-white/16 bg-black/10 p-0.5"
+      >
+        {(["fahrenheit", "celsius"] as const).map((unit) => {
+          const active = value === unit;
+          return (
+            <button
+              key={unit}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onChange(unit)}
+              className={cn(
+                "min-w-9 rounded-md px-2 py-1 text-xs font-semibold transition-colors",
+                active
+                  ? "bg-white/24 text-white shadow-sm"
+                  : "text-white/68 can-hover:hover:bg-white/10 can-hover:hover:text-white"
+              )}
+            >
+              {unit === "fahrenheit" ? "°F" : "°C"}
+            </button>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 
@@ -652,6 +704,9 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
   const [selectedCityId, setSelectedCityId] = useState(
     () => loadWeatherSelectedCity() ?? DEFAULT_CITIES[0]?.id ?? "san-francisco"
   );
+  const [temperatureUnit, setTemperatureUnit] = useState<WeatherTemperatureUnit>(
+    () => loadWeatherTemperatureUnit()
+  );
   const [failed, setFailed] = useState(false);
   const [containerWidth, setContainerWidth] = useState(1200);
   const [searchQuery, setSearchQuery] = useState("");
@@ -686,6 +741,10 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
     if (!selectedCityId) return;
     saveWeatherSelectedCity(selectedCityId);
   }, [selectedCityId]);
+
+  useEffect(() => {
+    saveWeatherTemperatureUnit(temperatureUnit);
+  }, [temperatureUnit]);
 
   useEffect(() => {
     saveWeatherDataCache(serializeWeatherDataForCache(weatherByCity));
@@ -1132,6 +1191,10 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                         }
                       />
                     )}
+                    <TemperatureUnitControl
+                      value={temperatureUnit}
+                      onChange={setTemperatureUnit}
+                    />
                     {cityCards.map((city) => (
                       <SidebarCityItem
                         key={city.id}
@@ -1139,6 +1202,7 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                         weather={city.weather}
                         scene={city.scene}
                         isSelected={city.id === selectedCityId}
+                        temperatureUnit={temperatureUnit}
                         onSelect={() => setSelectedCityId(city.id)}
                         onDelete={
                           customCities.some((customCity) => customCity.id === city.id)
@@ -1181,13 +1245,13 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                                   : "text-[84px]"
                             )}
                           >
-                            {Math.round(selectedWeather.currentTemp)}°
+                            {formatWeatherTemperature(selectedWeather.currentTemp, temperatureUnit)}
                           </p>
                           <p className={cn("font-medium -mt-1", compactMainContent ? "text-xl" : "text-2xl")}>
                             {getWeatherDescription(selectedWeather.weatherCode)}
                           </p>
                           <p className={cn("font-semibold", compactMainContent ? "text-lg" : "text-xl")}>
-                            H:{Math.round(selectedWeather.high)}° L:{Math.round(selectedWeather.low)}°
+                            H:{formatWeatherTemperature(selectedWeather.high, temperatureUnit)} L:{formatWeatherTemperature(selectedWeather.low, temperatureUnit)}
                           </p>
                         </>
                       ) : (
@@ -1239,7 +1303,10 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                               className={cn("w-4 h-4 mx-auto mt-1", mutedTextClass)}
                             />
                             <p className="text-xl font-medium leading-none mt-1">
-                              {Math.round((hour as HourForecast).temperature)}°
+                              {formatWeatherTemperature(
+                                (hour as HourForecast).temperature,
+                                temperatureUnit
+                              )}
                             </p>
                             <p className={cn("text-[10px]", mutedTextClass)}>
                               {Math.round((hour as HourForecast).precipitationChance)}%
@@ -1302,7 +1369,7 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                               className={cn("w-4 h-4", mutedTextClass)}
                             />
                             <p className={cn(mutedTextClass, denseMainContent ? "text-xs" : "text-sm")}>
-                              {Math.round(day.low)}°
+                              {formatWeatherTemperature(day.low, temperatureUnit)}
                             </p>
                             <div className={cn("h-1.5 rounded-full relative overflow-hidden", innerCardClass)}>
                               <div
@@ -1314,7 +1381,7 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                               />
                             </div>
                             <p className={cn("text-right font-semibold", denseMainContent ? "text-xs" : "text-sm")}>
-                              {Math.round(day.high)}°
+                              {formatWeatherTemperature(day.high, temperatureUnit)}
                             </p>
                           </div>
                         );
@@ -1351,7 +1418,9 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                           <span className="text-xs">Feels Like</span>
                         </div>
                         <p className="mt-1 text-2xl font-semibold">
-                          {selectedWeather ? `${Math.round(selectedWeather.feelsLike)}°` : "--"}
+                          {selectedWeather
+                            ? formatWeatherTemperature(selectedWeather.feelsLike, temperatureUnit)
+                            : "--"}
                         </p>
                       </div>
                       <div className={cn("rounded-xl p-3", innerCardClass)}>

--- a/components/apps/weather/weather-app.tsx
+++ b/components/apps/weather/weather-app.tsx
@@ -36,11 +36,9 @@ import {
   loadWeatherCustomCities,
   loadWeatherDataCache,
   loadWeatherSelectedCity,
-  loadWeatherTemperatureUnit,
   saveWeatherCustomCities,
   saveWeatherDataCache,
   saveWeatherSelectedCity,
-  saveWeatherTemperatureUnit,
   type WeatherDataCache,
   type WeatherCustomCity,
 } from "@/lib/sidebar-persistence";
@@ -55,6 +53,7 @@ import {
 
 interface WeatherAppProps {
   inShell?: boolean;
+  temperatureUnit: WeatherTemperatureUnit;
 }
 
 interface OpenMeteoResponse {
@@ -573,50 +572,6 @@ function SidebarCityItem({
   );
 }
 
-function TemperatureUnitControl({
-  value,
-  onChange,
-}: {
-  value: WeatherTemperatureUnit;
-  onChange: (value: WeatherTemperatureUnit) => void;
-}) {
-  return (
-    <section className="flex items-center justify-between gap-3 rounded-xl bg-white/[0.1] px-3 py-2 backdrop-blur-sm">
-      <div>
-        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/72">
-          Temperature
-        </p>
-        <p className="mt-0.5 text-xs text-white/68">Display units</p>
-      </div>
-      <div
-        role="group"
-        aria-label="Temperature unit"
-        className="flex rounded-lg border border-white/16 bg-black/10 p-0.5"
-      >
-        {(["fahrenheit", "celsius"] as const).map((unit) => {
-          const active = value === unit;
-          return (
-            <button
-              key={unit}
-              type="button"
-              aria-pressed={active}
-              onClick={() => onChange(unit)}
-              className={cn(
-                "min-w-9 rounded-md px-2 py-1 text-xs font-semibold transition-colors",
-                active
-                  ? "bg-white/24 text-white shadow-sm"
-                  : "text-white/68 can-hover:hover:bg-white/10 can-hover:hover:text-white"
-              )}
-            >
-              {unit === "fahrenheit" ? "°F" : "°C"}
-            </button>
-          );
-        })}
-      </div>
-    </section>
-  );
-}
-
 function WeatherScenePreviewControls({
   value,
   onChange,
@@ -689,7 +644,10 @@ function WeatherScenePreviewControls({
   );
 }
 
-export function WeatherApp({ inShell = false }: WeatherAppProps) {
+export function WeatherApp({
+  inShell = false,
+  temperatureUnit,
+}: WeatherAppProps) {
   const windowFocus = useWindowFocus();
   const inDesktopShell = !!(inShell && windowFocus);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -703,9 +661,6 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
   );
   const [selectedCityId, setSelectedCityId] = useState(
     () => loadWeatherSelectedCity() ?? DEFAULT_CITIES[0]?.id ?? "san-francisco"
-  );
-  const [temperatureUnit, setTemperatureUnit] = useState<WeatherTemperatureUnit>(
-    () => loadWeatherTemperatureUnit()
   );
   const [failed, setFailed] = useState(false);
   const [containerWidth, setContainerWidth] = useState(1200);
@@ -741,10 +696,6 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
     if (!selectedCityId) return;
     saveWeatherSelectedCity(selectedCityId);
   }, [selectedCityId]);
-
-  useEffect(() => {
-    saveWeatherTemperatureUnit(temperatureUnit);
-  }, [temperatureUnit]);
 
   useEffect(() => {
     saveWeatherDataCache(serializeWeatherDataForCache(weatherByCity));
@@ -1191,10 +1142,6 @@ export function WeatherApp({ inShell = false }: WeatherAppProps) {
                         }
                       />
                     )}
-                    <TemperatureUnitControl
-                      value={temperatureUnit}
-                      onChange={setTemperatureUnit}
-                    />
                     {cityCards.map((city) => (
                       <SidebarCityItem
                         key={city.id}

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -43,7 +43,12 @@ import {
   getRenamedTextEditPath,
   getUntitledTextEditPath,
 } from "@/lib/textedit-documents";
-import { loadNotesSelectedSlug, saveMessagesConversation } from "@/lib/sidebar-persistence";
+import {
+  loadNotesSelectedSlug,
+  loadWeatherTemperatureUnit,
+  saveMessagesConversation,
+  saveWeatherTemperatureUnit,
+} from "@/lib/sidebar-persistence";
 import { getNotesSelectedSlugMemory } from "@/lib/notes/selection-state";
 import { setUrl } from "@/lib/set-url";
 import { getShellUrlForApp } from "@/lib/shell-routing";
@@ -58,6 +63,7 @@ import {
   isFinderViewMode,
   type FinderViewMode,
 } from "@/components/apps/finder/view-mode";
+import type { WeatherTemperatureUnit } from "@/lib/weather";
 
 const SettingsApp = dynamic(() => import("@/components/apps/settings/settings-app").then(m => ({ default: m.SettingsApp })));
 const ITermApp = dynamic(() => import("@/components/apps/iterm/iterm-app").then(m => ({ default: m.ITermApp })));
@@ -232,6 +238,8 @@ function DesktopContent({
   const [hasLoadedFinderPathBarPreference, setHasLoadedFinderPathBarPreference] = useState(false);
   const [calendarWeekNumbersVisible, setCalendarWeekNumbersVisible] = useState(false);
   const [hasLoadedCalendarWeekNumbersPreference, setHasLoadedCalendarWeekNumbersPreference] = useState(false);
+  const [weatherTemperatureUnit, setWeatherTemperatureUnit] =
+    useState<WeatherTemperatureUnit>(() => loadWeatherTemperatureUnit());
   const [finderRouteProcessed, setFinderRouteProcessed] = useState(initialAppId !== "finder");
   const initialDocumentRouteAppId =
     initialAppId === "textedit" || initialAppId === "preview" ? initialAppId : null;
@@ -274,6 +282,10 @@ function DesktopContent({
       String(calendarWeekNumbersVisible)
     );
   }, [calendarWeekNumbersVisible, hasLoadedCalendarWeekNumbersPreference]);
+
+  useEffect(() => {
+    saveWeatherTemperatureUnit(weatherTemperatureUnit);
+  }, [weatherTemperatureUnit]);
   const getNotesSlugForRouting = useCallback(
     () => getNotesSelectedSlugMemory() ?? loadNotesSelectedSlug() ?? undefined,
     []
@@ -967,6 +979,8 @@ function DesktopContent({
         onFinderPathBarVisibleChange={setFinderPathBarVisible}
         calendarWeekNumbersVisible={calendarWeekNumbersVisible}
         onCalendarWeekNumbersVisibleChange={setCalendarWeekNumbersVisible}
+        weatherTemperatureUnit={weatherTemperatureUnit}
+        onWeatherTemperatureUnitChange={setWeatherTemperatureUnit}
         onTextEditNew={handleTextEditNew}
         onTextEditOpen={handleTextEditOpen}
         onTextEditClose={handleTextEditClose}
@@ -1024,7 +1038,10 @@ function DesktopContent({
           </Window>
 
           <Window appId="weather">
-            <WeatherApp inShell={true} />
+            <WeatherApp
+              inShell={true}
+              temperatureUnit={weatherTemperatureUnit}
+            />
           </Window>
 
           <Window appId="music">

--- a/components/desktop/menu-bar.tsx
+++ b/components/desktop/menu-bar.tsx
@@ -15,6 +15,7 @@ import { AppMenu } from "./app-menu";
 import { FileMenu } from "./file-menu";
 import { FinderViewMenu } from "./finder-view-menu";
 import { CalendarViewMenu } from "./calendar-view-menu";
+import { WeatherViewMenu } from "./weather-view-menu";
 import { TextEditEditMenu } from "./textedit-edit-menu";
 import { TextEditFormatMenu } from "./textedit-format-menu";
 import { TextEditFileMenu, TextEditRenameDialog } from "./textedit-file-menu";
@@ -29,9 +30,10 @@ import {
 } from "@/lib/menu-bar-clock";
 import type { PodcastNotificationPayload } from "@/types/desktop-notification";
 import type { FinderViewMode } from "@/components/apps/finder/view-mode";
+import type { WeatherTemperatureUnit } from "@/lib/weather";
 import { TEXTEDIT_OPEN_FIND_EVENT } from "@/lib/textedit-find";
 
-type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "previewFileMenu" | "finderViewMenu" | "calendarViewMenu" | "textEditEditMenu" | "textEditFormatMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
+type OpenMenu = "apple" | "appMenu" | "fileMenu" | "textEditFileMenu" | "previewFileMenu" | "finderViewMenu" | "calendarViewMenu" | "weatherViewMenu" | "textEditEditMenu" | "textEditFormatMenu" | "battery" | "wifi" | "focusMenu" | "controlCenter" | "notificationCenter" | null;
 
 const LOW_POWER_MODE_STORAGE_KEY = "desktop-low-power-mode";
 
@@ -70,6 +72,8 @@ interface MenuBarProps {
   onFinderPathBarVisibleChange?: (visible: boolean) => void;
   calendarWeekNumbersVisible?: boolean;
   onCalendarWeekNumbersVisibleChange?: (visible: boolean) => void;
+  weatherTemperatureUnit?: WeatherTemperatureUnit;
+  onWeatherTemperatureUnitChange?: (unit: WeatherTemperatureUnit) => void;
   onTextEditNew?: () => void;
   onTextEditOpen?: () => void;
   onTextEditClose?: (windowId: string) => void;
@@ -101,6 +105,8 @@ export function MenuBar({
   onFinderPathBarVisibleChange,
   calendarWeekNumbersVisible = false,
   onCalendarWeekNumbersVisibleChange,
+  weatherTemperatureUnit = "fahrenheit",
+  onWeatherTemperatureUnitChange,
   onTextEditNew,
   onTextEditOpen,
   onTextEditClose,
@@ -357,6 +363,19 @@ export function MenuBar({
               View
             </button>
           )}
+          {focusedAppId === "weather" && (
+            <button
+              onClick={() => toggleMenu("weatherViewMenu")}
+              className={cn(
+                "rounded px-2 py-0.5 text-sm transition-colors",
+                openMenu === "weatherViewMenu"
+                  ? "bg-blue-500 text-white"
+                  : "text-black can-hover:hover:bg-white/10 dark:text-white"
+              )}
+            >
+              View
+            </button>
+          )}
           {focusedAppId === "textedit" && (
             <button
               onClick={() => toggleMenu("textEditEditMenu")}
@@ -553,6 +572,15 @@ export function MenuBar({
         weekNumbersVisible={calendarWeekNumbersVisible}
         onWeekNumbersVisibleChange={(visible) =>
           onCalendarWeekNumbersVisibleChange?.(visible)
+        }
+      />
+
+      <WeatherViewMenu
+        isOpen={openMenu === "weatherViewMenu"}
+        onClose={closeMenu}
+        temperatureUnit={weatherTemperatureUnit}
+        onTemperatureUnitChange={(unit) =>
+          onWeatherTemperatureUnitChange?.(unit)
         }
       />
 

--- a/components/desktop/weather-view-menu.tsx
+++ b/components/desktop/weather-view-menu.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useRef } from "react";
+import { Check } from "lucide-react";
+import { useClickOutside } from "@/lib/hooks/use-click-outside";
+import type { WeatherTemperatureUnit } from "@/lib/weather";
+
+interface WeatherViewMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  temperatureUnit: WeatherTemperatureUnit;
+  onTemperatureUnitChange: (unit: WeatherTemperatureUnit) => void;
+}
+
+const TEMPERATURE_UNITS: ReadonlyArray<{
+  value: WeatherTemperatureUnit;
+  symbol: string;
+  label: string;
+}> = [
+  { value: "fahrenheit", symbol: "°F", label: "Fahrenheit" },
+  { value: "celsius", symbol: "°C", label: "Celsius" },
+];
+
+export function WeatherViewMenu({
+  isOpen,
+  onClose,
+  temperatureUnit,
+  onTemperatureUnitChange,
+}: WeatherViewMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(menuRef, onClose, isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Weather view options"
+      className="absolute left-[120px] top-7 w-56 overflow-hidden rounded-lg border border-black/10 bg-white/95 py-1 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+    >
+      {TEMPERATURE_UNITS.map((unit) => {
+        const isSelected = temperatureUnit === unit.value;
+
+        return (
+          <button
+            key={unit.value}
+            type="button"
+            role="menuitemradio"
+            aria-checked={isSelected}
+            onClick={() => {
+              onTemperatureUnitChange(unit.value);
+              onClose();
+            }}
+            className="flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors can-hover:hover:bg-blue-500 can-hover:hover:text-white"
+          >
+            <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+              {isSelected && <Check className="h-4 w-4" strokeWidth={3} />}
+            </span>
+            <span className="ml-2 w-6 shrink-0 tabular-nums">{unit.symbol}</span>
+            <span>{unit.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/sidebar-persistence.ts
+++ b/lib/sidebar-persistence.ts
@@ -25,6 +25,8 @@
  *    - Guard saves until after first render to avoid overwriting with defaults
  */
 
+import type { WeatherTemperatureUnit } from "./weather";
+
 // ============================================================================
 // Storage Keys (centralized to avoid conflicts)
 // ============================================================================
@@ -49,6 +51,7 @@ const STORAGE_KEYS = {
   WEATHER_DATA_CACHE: "weather-data-cache",
   // Local storage (durable user content)
   WEATHER_CUSTOM_CITIES: "weather-custom-cities",
+  WEATHER_TEMPERATURE_UNIT: "weather-temperature-unit",
 } as const;
 
 type StorageArea = Pick<Storage, "getItem" | "setItem" | "removeItem">;
@@ -735,6 +738,26 @@ export function saveWeatherSelectedCity(cityId: string): void {
   if (typeof window === "undefined") return;
   try {
     sessionStorage.setItem(STORAGE_KEYS.WEATHER_SELECTED_CITY, cityId);
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function loadWeatherTemperatureUnit(): WeatherTemperatureUnit {
+  if (typeof window === "undefined") return "fahrenheit";
+  try {
+    return localStorage.getItem(STORAGE_KEYS.WEATHER_TEMPERATURE_UNIT) === "celsius"
+      ? "celsius"
+      : "fahrenheit";
+  } catch {
+    return "fahrenheit";
+  }
+}
+
+export function saveWeatherTemperatureUnit(unit: WeatherTemperatureUnit): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEYS.WEATHER_TEMPERATURE_UNIT, unit);
   } catch {
     // Ignore storage errors
   }

--- a/lib/weather.ts
+++ b/lib/weather.ts
@@ -1,4 +1,5 @@
 export type DayPhase = "night" | "dawn" | "day" | "dusk";
+export type WeatherTemperatureUnit = "fahrenheit" | "celsius";
 export type WeatherMood = "clear" | "cloudy" | "fog" | "rain" | "snow" | "thunder";
 export type WeatherSceneEffect =
   | "sunGlow"
@@ -37,6 +38,20 @@ export interface WeatherScene {
 
 interface WeatherCityIdentity {
   id: string;
+}
+
+export function convertWeatherTemperature(
+  fahrenheit: number,
+  unit: WeatherTemperatureUnit
+): number {
+  return unit === "celsius" ? ((fahrenheit - 32) * 5) / 9 : fahrenheit;
+}
+
+export function formatWeatherTemperature(
+  fahrenheit: number,
+  unit: WeatherTemperatureUnit
+): string {
+  return `${Math.round(convertWeatherTemperature(fahrenheit, unit))}°`;
 }
 
 export function getWeatherCitySelectionAfterRemoval(

--- a/tests/weather-temperature.test.ts
+++ b/tests/weather-temperature.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  convertWeatherTemperature,
+  formatWeatherTemperature,
+} from "../lib/weather";
+
+test("converts Fahrenheit weather data to Celsius", () => {
+  assert.equal(convertWeatherTemperature(32, "celsius"), 0);
+  assert.equal(convertWeatherTemperature(68, "celsius"), 20);
+  assert.equal(convertWeatherTemperature(68, "fahrenheit"), 68);
+});
+
+test("formats weather temperatures with native whole-degree labels", () => {
+  assert.equal(formatWeatherTemperature(58, "fahrenheit"), "58°");
+  assert.equal(formatWeatherTemperature(58, "celsius"), "14°");
+});

--- a/tests/weather-view-menu.test.ts
+++ b/tests/weather-view-menu.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { WeatherViewMenu } from "../components/desktop/weather-view-menu";
+
+test("Weather View menu presents native temperature unit choices", () => {
+  const markup = renderToStaticMarkup(
+    createElement(WeatherViewMenu, {
+      isOpen: true,
+      onClose: () => {},
+      temperatureUnit: "celsius",
+      onTemperatureUnitChange: () => {},
+    })
+  );
+
+  assert.match(markup, /aria-label="Weather view options"/);
+  assert.match(markup, /role="menuitemradio"/);
+  assert.match(markup, /°F/);
+  assert.match(markup, /Fahrenheit/);
+  assert.match(markup, /°C/);
+  assert.match(markup, /Celsius/);
+  assert.equal((markup.match(/aria-checked="true"/g) ?? []).length, 1);
+  assert.equal((markup.match(/aria-checked="false"/g) ?? []).length, 1);
+});


### PR DESCRIPTION
## Today's delight

Weather now matches macOS by placing its durable Fahrenheit/Celsius choice in the app's View menu. The previous sidebar settings card is gone; choosing a unit updates every temperature readout together: saved-city summaries, the current conditions hero, hourly forecast, ten-day highs and lows, and Feels Like.

## Baseline and delta

- Before: this PR exposed temperature units in a custom sidebar card that does not match the native Weather placement.
- Now: Weather's menu bar includes View with checked `°F Fahrenheit` and `°C Celsius` choices, matching the supplied current-macOS reference.
- Preserved: durable unit persistence, city search and selection, user-added-city deletion, forecast fetching and caching, scene selection, Background Only, and the registered unsupported-mobile redirect to Notes.

## Built result — desktop

![Weather View menu with Celsius selected](https://github.com/user-attachments/assets/e1a5e474-8576-46ac-a3e9-62a0ce71dac3)

The 1280×720 result shows the checked Celsius menu choice, the removed sidebar card, and Celsius applied consistently to the current, hourly, ten-day, and saved-city values. Desktop interaction checks covered both unit choices, menu dismissal, checked state, reload persistence, and restoration of the original test preference.

## Built result — mobile

![Established Notes fallback for unsupported mobile apps](https://github.com/user-attachments/assets/59ae650f-b4b3-466b-8526-58b6d8007f60)

Weather is intentionally unavailable on mobile under the central app-availability policy, so `/weather` redirects to the established Notes experience shown here. This PR does not add or modify a mobile Weather surface. The owner explicitly waived repeat touch/coarse-pointer verification for this unchanged fallback and requested publication.

## macOS inspiration

The owner supplied a current macOS Weather screenshot showing temperature units directly in View as two checked menu choices: `°F Fahrenheit` and `°C Celsius`. Apple's current [Weather User Guide](https://support.apple.com/en-ca/guide/weather-mac/apdw93f0ea3e/mac) also documents switching between Fahrenheit and Celsius from the View menu. The implementation now follows that placement and labeling instead of inventing an in-window card.

## Why this one

Weather's last daily delight and last visible touch were both 2026-08-14, making it a neglected registered app relative to the recent TextEdit and iTerm delights. Temperature units remain a small, authentic preference that improves every forecast without changing the app's underlying data or navigation.

## Verification

- `npm run check`: lint passed with six pre-existing warnings, all 137 tests passed, typecheck passed, and all 41 production routes built successfully
- Added a focused render test for the Weather View menu's labels, radio semantics, and single checked choice
- Desktop: 1280×720; menu placement, both unit choices, checked state, full-readout conversion, reload persistence, sidebar-card removal, and zero runtime errors
- Mobile: Weather remains unsupported and redirects to Notes; repeat touch/coarse-pointer verification was explicitly waived because this PR does not change that registered behavior
- Both GitHub-hosted images were independently opened and rendered at their expected dimensions

## Scope

Micro: the follow-up removes the custom sidebar control, adds one Weather View-menu component, and wires the existing durable preference through the desktop shell. No dependency, backend, schema, external-service, keyboard-navigation, or unrelated UI changes. Open menu-bar eyes and Games PRs do not overlap this app-specific command.
