### PR TITLE
Daily delight: Match the Photos toolbar

### DIFF
--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -19,6 +19,13 @@ import {
   savePhotosView,
 } from "@/lib/sidebar-persistence";
 import type { PhotoRotations } from "@/lib/sidebar-persistence";
+import {
+  loadPhotoGridSize,
+  resizePhotoGrid,
+  savePhotoGridSize,
+  type PhotoGridResizeDirection,
+  type PhotoGridSize,
+} from "@/lib/photos/grid-size";
 
 interface AppProps {
   isDesktop?: boolean;
@@ -34,6 +41,7 @@ export default function App({ isDesktop = false }: AppProps) {
   const [activeView, setActiveView] = useState<PhotosView>(() => loadPhotosView() as PhotosView);
   const [isViewLoaded, setIsViewLoaded] = useState(false);
   const [timeFilter, setTimeFilter] = useState<TimeFilter>("all");
+  const [photoGridSize, setPhotoGridSize] = useState<PhotoGridSize>("standard");
   const [isScrolled, setIsScrolled] = useState(false);
   // First-time mobile visitors open directly into Library. After that, preserve
   // whether the current tab was showing the sidebar or Photos content.
@@ -51,6 +59,7 @@ export default function App({ isDesktop = false }: AppProps) {
   // Mark view as loaded after first render
   useEffect(() => {
     setIsViewLoaded(true);
+    setPhotoGridSize(loadPhotoGridSize());
   }, []);
 
   // Persist active view (only after initial load to avoid overwriting with default)
@@ -115,6 +124,14 @@ export default function App({ isDesktop = false }: AppProps) {
 
   const handleGridSelect = useCallback((photoId: string | null) => {
     setSelectedInGridId(photoId);
+  }, []);
+
+  const handlePhotoGridResize = useCallback((direction: PhotoGridResizeDirection) => {
+    setPhotoGridSize((currentSize) => {
+      const nextSize = resizePhotoGrid(currentSize, direction);
+      if (nextSize !== currentSize) savePhotoGridSize(nextSize);
+      return nextSize;
+    });
   }, []);
 
   const handleCloseViewer = useCallback(() => {
@@ -218,6 +235,8 @@ export default function App({ isDesktop = false }: AppProps) {
               error={error}
               timeFilter={timeFilter}
               onTimeFilterChange={setTimeFilter}
+              gridSize={photoGridSize}
+              onGridResize={handlePhotoGridResize}
               isMobileView={isMobileView}
               onBack={handleBack}
               activeView={activeView}

--- a/components/apps/photos/app.tsx
+++ b/components/apps/photos/app.tsx
@@ -244,6 +244,8 @@ export default function App({ isDesktop = false }: AppProps) {
               isDesktop={isDesktop}
               onToggleFavorite={toggleFavorite}
               onPhotoSelect={handlePhotoSelect}
+              photoRotations={photoRotations}
+              onRotatePhoto={handleRotatePhoto}
               selectedInGridId={selectedInGridId}
               onGridSelect={handleGridSelect}
             />

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -2,13 +2,18 @@
 
 import { useMemo, useLayoutEffect, useRef, useState } from "react";
 import { Photo, TimeFilter, PhotosView, Collection } from "@/types/photos";
-import { ChevronLeft, Heart } from "lucide-react";
+import { ChevronLeft, Heart, Minus, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useWindowFocus } from "@/lib/window-focus-context";
 import { toZonedTime } from "date-fns-tz";
 import { format, parseISO } from "date-fns";
 import Image from "next/image";
 import { getThumbnailUrl, getViewerUrl } from "@/lib/photos/image-utils";
+import {
+  getPhotoGridColumnClassName,
+  type PhotoGridResizeDirection,
+  type PhotoGridSize,
+} from "@/lib/photos/grid-size";
 import { PhotosHeader } from "./header";
 
 // Preload viewer-size image on hover for faster viewer loading
@@ -24,6 +29,8 @@ interface PhotosGridProps {
   error?: string | null;
   timeFilter: TimeFilter;
   onTimeFilterChange: (filter: TimeFilter) => void;
+  gridSize: PhotoGridSize;
+  onGridResize: (direction: PhotoGridResizeDirection) => void;
   isMobileView: boolean;
   onBack: () => void;
   activeView: PhotosView;
@@ -41,6 +48,8 @@ export function PhotosGrid({
   error = null,
   timeFilter,
   onTimeFilterChange,
+  gridSize,
+  onGridResize,
   isMobileView,
   onBack,
   activeView,
@@ -113,6 +122,48 @@ export function PhotosGrid({
     return collection?.name || "Photos";
   };
 
+  const gridSizeLabel = {
+    compact: "small",
+    standard: "medium",
+    comfortable: "large",
+  }[gridSize];
+
+  const gridSizeControls = (
+    <div
+      role="group"
+      aria-label="Photo thumbnail size"
+      className="flex shrink-0 items-center rounded-lg bg-muted p-0.5"
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        title="Zoom Out"
+        aria-label={`Make thumbnails smaller. Current size: ${gridSizeLabel}`}
+        disabled={gridSize === "compact"}
+        onClick={() => onGridResize("smaller")}
+        className={cn(
+          "flex items-center justify-center rounded-md text-muted-foreground transition-colors enabled:can-hover:hover:bg-background enabled:can-hover:hover:text-foreground disabled:opacity-35",
+          isMobileView ? "h-11 w-11" : "h-7 w-7",
+        )}
+      >
+        <Minus aria-hidden="true" className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        title="Zoom In"
+        aria-label={`Make thumbnails larger. Current size: ${gridSizeLabel}`}
+        disabled={gridSize === "comfortable"}
+        onClick={() => onGridResize("larger")}
+        className={cn(
+          "flex items-center justify-center rounded-md text-muted-foreground transition-colors enabled:can-hover:hover:bg-background enabled:can-hover:hover:text-foreground disabled:opacity-35",
+          isMobileView ? "h-11 w-11" : "h-7 w-7",
+        )}
+      >
+        <Plus aria-hidden="true" className="h-4 w-4" />
+      </button>
+    </div>
+  );
+
   return (
     <div className="h-full flex flex-col bg-background">
       {/* Header */}
@@ -148,25 +199,28 @@ export function PhotosGrid({
           </div>
         </div>
 
-        {/* Time Filter Toggle - hidden on mobile */}
-        {!isMobileView && (
-          <div className="flex shrink-0 items-center gap-0.5 bg-muted rounded-lg p-0.5">
-            {(["years", "months", "all"] as TimeFilter[]).map((filter) => (
-              <button
-                key={filter}
-                onClick={() => onTimeFilterChange(filter)}
-                className={cn(
-                  "px-3 py-1 text-xs rounded-md transition-colors capitalize",
-                  timeFilter === filter
-                    ? "bg-background shadow-sm text-foreground"
-                    : "text-muted-foreground can-hover:hover:text-foreground"
-                )}
-              >
-                {filter === "all" ? "All Photos" : filter}
-              </button>
-            ))}
-          </div>
-        )}
+        <div className="flex shrink-0 items-center gap-2">
+          {/* Time Filter Toggle - hidden on mobile */}
+          {!isMobileView && (
+            <div className="flex shrink-0 items-center gap-0.5 bg-muted rounded-lg p-0.5">
+              {(["years", "months", "all"] as TimeFilter[]).map((filter) => (
+                <button
+                  key={filter}
+                  onClick={() => onTimeFilterChange(filter)}
+                  className={cn(
+                    "px-3 py-1 text-xs rounded-md transition-colors capitalize",
+                    timeFilter === filter
+                      ? "bg-background shadow-sm text-foreground"
+                      : "text-muted-foreground can-hover:hover:text-foreground"
+                  )}
+                >
+                  {filter === "all" ? "All Photos" : filter}
+                </button>
+              ))}
+            </div>
+          )}
+          {gridSizeControls}
+        </div>
       </PhotosHeader>
 
       {/* Photo Grid */}
@@ -207,11 +261,10 @@ export function PhotosGrid({
                   </h2>
                 )}
                 <div
+                  data-photo-grid-size={gridSize}
                   className={cn(
                     "grid gap-2",
-                    isMobileView
-                      ? "grid-cols-3"
-                      : "grid-cols-4 desktop:grid-cols-5"
+                    getPhotoGridColumnClassName(gridSize, isMobileView),
                   )}
                 >
                   {groupPhotos.map((photo) => (

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -184,10 +184,7 @@ export function PhotosGrid({
         aria-label={`Make thumbnails smaller. Current size: ${gridSizeLabel}`}
         disabled={gridSize === "compact"}
         onClick={() => onGridResize("smaller")}
-        className={cn(
-          "flex items-center justify-center rounded-md text-muted-foreground transition-colors enabled:can-hover:hover:bg-background enabled:can-hover:hover:text-foreground disabled:opacity-35",
-          isMobileView ? "h-11 w-11" : "h-6 w-7",
-        )}
+        className="flex h-6 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors enabled:can-hover:hover:bg-background enabled:can-hover:hover:text-foreground disabled:opacity-35"
       >
         <Minus aria-hidden="true" className="h-4 w-4" />
       </button>
@@ -197,10 +194,7 @@ export function PhotosGrid({
         aria-label={`Make thumbnails larger. Current size: ${gridSizeLabel}`}
         disabled={gridSize === "comfortable"}
         onClick={() => onGridResize("larger")}
-        className={cn(
-          "flex items-center justify-center rounded-md text-muted-foreground transition-colors enabled:can-hover:hover:bg-background enabled:can-hover:hover:text-foreground disabled:opacity-35",
-          isMobileView ? "h-11 w-11" : "h-6 w-7",
-        )}
+        className="flex h-6 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors enabled:can-hover:hover:bg-background enabled:can-hover:hover:text-foreground disabled:opacity-35"
       >
         <Plus aria-hidden="true" className="h-4 w-4" />
       </button>
@@ -407,9 +401,7 @@ export function PhotosGrid({
           </div>
         </div>
 
-        {isMobileView ? (
-          gridSizeControls
-        ) : (
+        {!isMobileView && (
           <>
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
               <div className="pointer-events-auto relative">

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -186,7 +186,7 @@ export function PhotosGrid({
         onClick={() => onGridResize("smaller")}
         className={cn(
           "flex items-center justify-center rounded-md text-muted-foreground transition-colors enabled:can-hover:hover:bg-background enabled:can-hover:hover:text-foreground disabled:opacity-35",
-          isMobileView ? "h-11 w-11" : "h-7 w-7",
+          isMobileView ? "h-11 w-11" : "h-6 w-7",
         )}
       >
         <Minus aria-hidden="true" className="h-4 w-4" />
@@ -199,7 +199,7 @@ export function PhotosGrid({
         onClick={() => onGridResize("larger")}
         className={cn(
           "flex items-center justify-center rounded-md text-muted-foreground transition-colors enabled:can-hover:hover:bg-background enabled:can-hover:hover:text-foreground disabled:opacity-35",
-          isMobileView ? "h-11 w-11" : "h-7 w-7",
+          isMobileView ? "h-11 w-11" : "h-6 w-7",
         )}
       >
         <Plus aria-hidden="true" className="h-4 w-4" />

--- a/components/apps/photos/photos-grid.tsx
+++ b/components/apps/photos/photos-grid.tsx
@@ -1,10 +1,21 @@
 "use client";
 
-import { useMemo, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useLayoutEffect, useRef, useState } from "react";
 import { Photo, TimeFilter, PhotosView, Collection } from "@/types/photos";
-import { ChevronLeft, Heart, Minus, Plus } from "lucide-react";
+import {
+  ChevronLeft,
+  Heart,
+  Info,
+  Minus,
+  Plus,
+  RotateCcwSquare,
+  Share,
+  Wallpaper,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useClickOutside } from "@/lib/hooks/use-click-outside";
 import { useWindowFocus } from "@/lib/window-focus-context";
+import { useSystemSettings } from "@/lib/system-settings-context";
 import { toZonedTime } from "date-fns-tz";
 import { format, parseISO } from "date-fns";
 import Image from "next/image";
@@ -38,6 +49,8 @@ interface PhotosGridProps {
   isDesktop?: boolean;
   onToggleFavorite?: (photoId: string) => void;
   onPhotoSelect?: (photoId: string) => void;
+  photoRotations: Record<string, number>;
+  onRotatePhoto?: (photoId: string) => void;
   selectedInGridId?: string | null;
   onGridSelect?: (photoId: string | null) => void;
 }
@@ -57,14 +70,44 @@ export function PhotosGrid({
   isDesktop = false,
   onToggleFavorite,
   onPhotoSelect,
+  photoRotations,
+  onRotatePhoto,
   selectedInGridId,
   onGridSelect,
 }: PhotosGridProps) {
   const windowFocus = useWindowFocus();
+  const { setWallpaperUrl } = useSystemSettings();
   const inShell = isDesktop && windowFocus;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const infoContainerRef = useRef<HTMLDivElement>(null);
+  const shareContainerRef = useRef<HTMLDivElement>(null);
   const [isPositioned, setIsPositioned] = useState(false);
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const [isShareOpen, setIsShareOpen] = useState(false);
   const prevPhotosRef = useRef<Photo[]>();
+
+  const selectedPhoto = useMemo(
+    () => photos.find((photo) => photo.id === selectedInGridId) ?? null,
+    [photos, selectedInGridId],
+  );
+  const selectedPhotoDate = selectedPhoto
+    ? format(
+        toZonedTime(parseISO(selectedPhoto.timestamp), "America/Los_Angeles"),
+        "MMMM d, yyyy 'at' h:mm:ss a",
+      )
+    : null;
+  const selectedCollectionNames = selectedPhoto
+    ? collections
+        .filter((collection) => selectedPhoto.collections.includes(collection.id))
+        .map((collection) => collection.name)
+    : [];
+
+  useClickOutside(infoContainerRef, () => setIsInfoOpen(false), isInfoOpen);
+  useClickOutside(shareContainerRef, () => setIsShareOpen(false), isShareOpen);
+
+  useEffect(() => {
+    if (!selectedPhoto) setIsShareOpen(false);
+  }, [selectedPhoto]);
 
   // Scroll to bottom only if content overflows, otherwise stay at top
   // useLayoutEffect ensures scroll happens before paint to prevent flash
@@ -164,15 +207,180 @@ export function PhotosGrid({
     </div>
   );
 
+  const timeFilterControls = (
+    <div className="flex shrink-0 items-center gap-0.5 rounded-lg bg-muted p-0.5">
+      {(["years", "months", "all"] as TimeFilter[]).map((filter) => (
+        <button
+          key={filter}
+          type="button"
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={() => onTimeFilterChange(filter)}
+          className={cn(
+            "rounded-md px-3 py-1 text-xs capitalize transition-colors",
+            timeFilter === filter
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground can-hover:hover:text-foreground",
+          )}
+        >
+          {filter === "all" ? "All Photos" : filter}
+        </button>
+      ))}
+    </div>
+  );
+
+  const desktopActionButtonClassName =
+    "rounded-md p-1 text-foreground transition-colors enabled:can-hover:hover:bg-foreground/10 disabled:cursor-default disabled:text-muted-foreground/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]";
+
+  const desktopPhotoActions = (
+    <div
+      className="ml-auto flex shrink-0 items-center gap-1"
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <div ref={infoContainerRef} className="relative">
+        <button
+          type="button"
+          aria-label={isInfoOpen ? "Hide photo information" : "Show photo information"}
+          aria-expanded={isInfoOpen}
+          aria-controls="grid-photo-info-panel"
+          onClick={() => {
+            setIsInfoOpen((open) => !open);
+            setIsShareOpen(false);
+          }}
+          className={cn(
+            desktopActionButtonClassName,
+            isInfoOpen && "bg-foreground/10",
+          )}
+        >
+          <Info aria-hidden="true" className="h-5 w-5" />
+        </button>
+
+        {isInfoOpen && (
+          <aside
+            id="grid-photo-info-panel"
+            aria-label="Photo information"
+            className="absolute right-0 top-[calc(100%+12px)] z-20 w-[min(300px,calc(100vw-24px))] overflow-hidden rounded-xl border border-black/10 bg-muted/95 text-foreground shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-2xl dark:border-white/15"
+          >
+            <div className="flex h-8 items-center justify-center border-b border-black/10 px-3 dark:border-white/10">
+              <p className="text-xs font-medium text-muted-foreground">Info</p>
+            </div>
+            {selectedPhoto ? (
+              <div className="space-y-3 px-3 py-3">
+                <div className="min-w-0">
+                  <p className="break-all text-sm font-medium leading-5">
+                    {selectedPhoto.filename}
+                  </p>
+                  <time
+                    dateTime={selectedPhoto.timestamp}
+                    className="mt-0.5 block text-xs leading-4 text-muted-foreground"
+                  >
+                    {selectedPhotoDate}
+                  </time>
+                </div>
+                <dl className="grid grid-cols-[72px_minmax(0,1fr)] gap-x-3 gap-y-2 border-t border-black/10 pt-3 text-xs dark:border-white/10">
+                  <dt className="text-muted-foreground">Favorite</dt>
+                  <dd>{selectedPhoto.isFavorite ? "Yes" : "No"}</dd>
+                  <dt className="text-muted-foreground">Collections</dt>
+                  <dd className="min-w-0 break-words">
+                    {selectedCollectionNames.length > 0
+                      ? selectedCollectionNames.join(", ")
+                      : "None"}
+                  </dd>
+                </dl>
+              </div>
+            ) : (
+              <p className="px-4 py-6 text-center text-xs text-muted-foreground">
+                Select a photo to see its information.
+              </p>
+            )}
+          </aside>
+        )}
+      </div>
+
+      <div ref={shareContainerRef} className="relative">
+        <button
+          type="button"
+          aria-label="Share selected photo"
+          aria-haspopup="menu"
+          aria-expanded={isShareOpen}
+          aria-controls="grid-photo-share-menu"
+          disabled={!selectedPhoto}
+          onClick={() => {
+            setIsShareOpen((open) => !open);
+            setIsInfoOpen(false);
+          }}
+          className={cn(
+            desktopActionButtonClassName,
+            isShareOpen && "bg-foreground/10",
+          )}
+        >
+          <Share aria-hidden="true" className="h-5 w-5" />
+        </button>
+
+        {selectedPhoto && isShareOpen && (
+          <div
+            id="grid-photo-share-menu"
+            role="menu"
+            className="absolute right-0 top-[calc(100%+8px)] z-20 w-max min-w-44 rounded-lg border border-black/10 bg-white/95 p-1 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-zinc-800/95"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setWallpaperUrl(selectedPhoto.url);
+                setIsShareOpen(false);
+              }}
+              className="flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-xs transition-colors can-hover:hover:bg-[#0A7CFF] can-hover:hover:text-white focus-visible:bg-[#0A7CFF] focus-visible:text-white focus-visible:outline-none"
+            >
+              <Wallpaper aria-hidden="true" className="h-4 w-4 shrink-0" strokeWidth={1.8} />
+              Set as Wallpaper
+            </button>
+          </div>
+        )}
+      </div>
+
+      <button
+        type="button"
+        disabled={!selectedPhoto}
+        onClick={() => selectedPhoto && onRotatePhoto?.(selectedPhoto.id)}
+        className={desktopActionButtonClassName}
+        aria-label="Rotate selected photo left"
+        title="Rotate Left"
+      >
+        <RotateCcwSquare aria-hidden="true" className="h-5 w-5" strokeWidth={2} />
+      </button>
+
+      <button
+        type="button"
+        disabled={!selectedPhoto}
+        onClick={() => selectedPhoto && onToggleFavorite?.(selectedPhoto.id)}
+        className={desktopActionButtonClassName}
+        aria-label={
+          selectedPhoto?.isFavorite
+            ? "Remove selected photo from favorites"
+            : "Add selected photo to favorites"
+        }
+        title={selectedPhoto?.isFavorite ? "Remove from Favorites" : "Add to Favorites"}
+      >
+        <Heart
+          aria-hidden="true"
+          className={cn(
+            "h-5 w-5",
+            selectedPhoto?.isFavorite && "fill-foreground",
+          )}
+        />
+      </button>
+    </div>
+  );
+
   return (
     <div className="h-full flex flex-col bg-background">
       {/* Header */}
       <PhotosHeader
         isMobileView={isMobileView}
-        className="justify-between"
+        className={cn(isMobileView && "justify-between")}
         onMouseDown={inShell && !isMobileView ? windowFocus.onDragStart : undefined}
       >
-        <div className="flex min-w-0 items-center gap-2">
+        <div className="relative z-10 flex min-w-0 items-center gap-2">
           {isMobileView && (
             <button
               onClick={onBack}
@@ -199,28 +407,21 @@ export function PhotosGrid({
           </div>
         </div>
 
-        <div className="flex shrink-0 items-center gap-2">
-          {/* Time Filter Toggle - hidden on mobile */}
-          {!isMobileView && (
-            <div className="flex shrink-0 items-center gap-0.5 bg-muted rounded-lg p-0.5">
-              {(["years", "months", "all"] as TimeFilter[]).map((filter) => (
-                <button
-                  key={filter}
-                  onClick={() => onTimeFilterChange(filter)}
-                  className={cn(
-                    "px-3 py-1 text-xs rounded-md transition-colors capitalize",
-                    timeFilter === filter
-                      ? "bg-background shadow-sm text-foreground"
-                      : "text-muted-foreground can-hover:hover:text-foreground"
-                  )}
-                >
-                  {filter === "all" ? "All Photos" : filter}
-                </button>
-              ))}
+        {isMobileView ? (
+          gridSizeControls
+        ) : (
+          <>
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+              <div className="pointer-events-auto relative">
+                <div className="absolute right-[calc(100%+0.5rem)] top-1/2 -translate-y-1/2">
+                  {gridSizeControls}
+                </div>
+                {timeFilterControls}
+              </div>
             </div>
-          )}
-          {gridSizeControls}
-        </div>
+            {desktopPhotoActions}
+          </>
+        )}
       </PhotosHeader>
 
       {/* Photo Grid */}
@@ -302,7 +503,12 @@ export function PhotosGrid({
                           src={getThumbnailUrl(photo.url)}
                           alt=""
                           fill
-                          className="object-cover"
+                          className="object-cover transition-transform duration-200 ease-out motion-reduce:transition-none"
+                          style={{
+                            transform: photoRotations[photo.id]
+                              ? `rotate(${photoRotations[photo.id]}deg)`
+                              : undefined,
+                          }}
                           sizes="(max-width: 768px) 33vw, 16vw"
                           unoptimized
                         />

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from "@/types/apps";
-import type { Size } from "@/types/window";
+import type { Position, Size } from "@/types/window";
 
 export const APPS: AppConfig[] = [
   {
@@ -218,6 +218,28 @@ export function clampAppWindowSize(appId: string, size: Size): Size {
   return {
     width: Math.max(size.width, minSize.width),
     height: Math.max(size.height, minSize.height),
+  };
+}
+
+export function migrateAppWindowFrame(
+  appId: string,
+  position: Position,
+  size: Size,
+  viewportWidth?: number,
+): { position: Position; size: Size } {
+  const nextSize = clampAppWindowSize(appId, size);
+  const didWidthResize = nextSize.width !== size.width;
+
+  if (!didWidthResize || viewportWidth === undefined) {
+    return { position, size: nextSize };
+  }
+
+  return {
+    position: {
+      ...position,
+      x: Math.min(position.x, Math.max(0, viewportWidth - nextSize.width)),
+    },
+    size: nextSize,
   };
 }
 

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -1,4 +1,5 @@
-import { AppConfig } from "@/types/apps";
+import type { AppConfig } from "@/types/apps";
+import type { Size } from "@/types/window";
 
 export const APPS: AppConfig[] = [
   {
@@ -56,8 +57,8 @@ export const APPS: AppConfig[] = [
     provenance: { agent: "Claude Code", circa: "January 2026" },
     accentColor: "#FF6B6B",
     defaultPosition: { x: 130, y: 60 },
-    defaultSize: { width: 900, height: 650 },
-    minSize: { width: 600, height: 450 },
+    defaultSize: { width: 960, height: 650 },
+    minSize: { width: 960, height: 450 },
     menuBarTitle: "Photos",
     mobile: { supported: true },
   },
@@ -208,6 +209,16 @@ export const APPS: AppConfig[] = [
 
 export function getAppById(id: string): AppConfig | undefined {
   return APPS.find((app) => app.id === id);
+}
+
+export function clampAppWindowSize(appId: string, size: Size): Size {
+  const minSize = getAppById(appId)?.minSize;
+  if (!minSize) return size;
+
+  return {
+    width: Math.max(size.width, minSize.width),
+    height: Math.max(size.height, minSize.height),
+  };
 }
 
 export function getAppIds(): string[] {

--- a/lib/photos/grid-size.ts
+++ b/lib/photos/grid-size.ts
@@ -57,11 +57,7 @@ export function getPhotoGridColumnClassName(
   isMobileView: boolean,
 ): string {
   if (isMobileView) {
-    return {
-      compact: "grid-cols-4",
-      standard: "grid-cols-3",
-      comfortable: "grid-cols-2",
-    }[size];
+    return "grid-cols-3";
   }
 
   return {

--- a/lib/photos/grid-size.ts
+++ b/lib/photos/grid-size.ts
@@ -1,0 +1,72 @@
+export const PHOTO_GRID_SIZES = ["compact", "standard", "comfortable"] as const;
+
+export type PhotoGridSize = (typeof PHOTO_GRID_SIZES)[number];
+export type PhotoGridResizeDirection = "smaller" | "larger";
+
+interface PhotoGridStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+const PHOTO_GRID_SIZE_KEY = "photos-grid-size";
+
+function isPhotoGridSize(value: string | null): value is PhotoGridSize {
+  return PHOTO_GRID_SIZES.includes(value as PhotoGridSize);
+}
+
+function getPhotoGridStorage(storage?: PhotoGridStorage): PhotoGridStorage | null {
+  if (storage) return storage;
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+export function loadPhotoGridSize(storage?: PhotoGridStorage): PhotoGridSize {
+  try {
+    const storedSize =
+      getPhotoGridStorage(storage)?.getItem(PHOTO_GRID_SIZE_KEY) ?? null;
+    return isPhotoGridSize(storedSize) ? storedSize : "standard";
+  } catch {
+    return "standard";
+  }
+}
+
+export function savePhotoGridSize(
+  size: PhotoGridSize,
+  storage?: PhotoGridStorage,
+): void {
+  try {
+    getPhotoGridStorage(storage)?.setItem(PHOTO_GRID_SIZE_KEY, size);
+  } catch {
+    // Keep the in-memory preference when browser storage is unavailable.
+  }
+}
+
+export function resizePhotoGrid(
+  size: PhotoGridSize,
+  direction: PhotoGridResizeDirection,
+): PhotoGridSize {
+  const currentIndex = PHOTO_GRID_SIZES.indexOf(size);
+  const nextIndex = direction === "smaller" ? currentIndex - 1 : currentIndex + 1;
+  return PHOTO_GRID_SIZES[
+    Math.max(0, Math.min(PHOTO_GRID_SIZES.length - 1, nextIndex))
+  ];
+}
+
+export function getPhotoGridColumnClassName(
+  size: PhotoGridSize,
+  isMobileView: boolean,
+): string {
+  if (isMobileView) {
+    return {
+      compact: "grid-cols-4",
+      standard: "grid-cols-3",
+      comfortable: "grid-cols-2",
+    }[size];
+  }
+
+  return {
+    compact: "grid-cols-6",
+    standard: "grid-cols-5",
+    comfortable: "grid-cols-4",
+  }[size];
+}

--- a/lib/window-context.tsx
+++ b/lib/window-context.tsx
@@ -14,7 +14,7 @@ import {
   Position,
   Size,
 } from "@/types/window";
-import { APPS, getAppById } from "./app-config";
+import { APPS, clampAppWindowSize, getAppById } from "./app-config";
 import { clearAppState, clearAllAppState } from "./sidebar-persistence";
 import {
   loadWindowState,
@@ -232,6 +232,15 @@ function deserializeWindowState(serializedState: string): WindowManagerState | n
       if (!app.multiWindow && !mergedWindows[app.id]) {
         mergedWindows[app.id] = getDefaultWindowState(app.id);
       }
+    });
+
+    // Keep restored frames compatible with current app layout contracts.
+    // This matters when an app raises its minimum after a narrower frame was saved.
+    Object.entries(mergedWindows).forEach(([windowId, windowState]) => {
+      if (!windowState?.size) return;
+      const size = clampAppWindowSize(windowState.appId, windowState.size);
+      if (size.width === windowState.size.width && size.height === windowState.size.height) return;
+      mergedWindows[windowId] = { ...windowState, size };
     });
 
     return {

--- a/lib/window-context.tsx
+++ b/lib/window-context.tsx
@@ -14,7 +14,7 @@ import {
   Position,
   Size,
 } from "@/types/window";
-import { APPS, clampAppWindowSize, getAppById } from "./app-config";
+import { APPS, getAppById, migrateAppWindowFrame } from "./app-config";
 import { clearAppState, clearAllAppState } from "./sidebar-persistence";
 import {
   loadWindowState,
@@ -238,9 +238,19 @@ function deserializeWindowState(serializedState: string): WindowManagerState | n
     // This matters when an app raises its minimum after a narrower frame was saved.
     Object.entries(mergedWindows).forEach(([windowId, windowState]) => {
       if (!windowState?.size) return;
-      const size = clampAppWindowSize(windowState.appId, windowState.size);
-      if (size.width === windowState.size.width && size.height === windowState.size.height) return;
-      mergedWindows[windowId] = { ...windowState, size };
+      const frame = migrateAppWindowFrame(
+        windowState.appId,
+        windowState.position,
+        windowState.size,
+        typeof window === "undefined" ? undefined : window.innerWidth,
+      );
+      if (
+        frame.size.width === windowState.size.width &&
+        frame.size.height === windowState.size.height
+      ) {
+        return;
+      }
+      mergedWindows[windowId] = { ...windowState, ...frame };
     });
 
     return {

--- a/tests/app-config.test.ts
+++ b/tests/app-config.test.ts
@@ -1,9 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { APPS, getAppsInDockOrder } from "../lib/app-config";
+import {
+  APPS,
+  clampAppWindowSize,
+  getAppById,
+  getAppsInDockOrder,
+} from "../lib/app-config";
 
 test("Dock order can differ from the shared app registry", () => {
   assert.deepEqual(APPS.slice(0, 3).map((app) => app.id), ["finder", "notes", "messages"]);
   assert.deepEqual(getAppsInDockOrder().slice(0, 3).map((app) => app.id), ["finder", "games", "notes"]);
+});
+
+test("Photos cannot resize narrower than its desktop toolbar", () => {
+  const photos = getAppById("photos");
+
+  assert.ok(photos);
+  assert.equal(photos.minSize.width, 960);
+  assert.ok(photos.defaultSize.width >= photos.minSize.width);
+  assert.deepEqual(clampAppWindowSize("photos", { width: 600, height: 500 }), {
+    width: 960,
+    height: 500,
+  });
 });

--- a/tests/app-config.test.ts
+++ b/tests/app-config.test.ts
@@ -6,6 +6,7 @@ import {
   clampAppWindowSize,
   getAppById,
   getAppsInDockOrder,
+  migrateAppWindowFrame,
 } from "../lib/app-config";
 
 test("Dock order can differ from the shared app registry", () => {
@@ -23,4 +24,45 @@ test("Photos cannot resize narrower than its desktop toolbar", () => {
     width: 960,
     height: 500,
   });
+});
+
+test("expanded restored windows stay inside the viewport's right edge", () => {
+  assert.deepEqual(
+    migrateAppWindowFrame(
+      "photos",
+      { x: 800, y: 60 },
+      { width: 600, height: 500 },
+      1440,
+    ),
+    {
+      position: { x: 480, y: 60 },
+      size: { width: 960, height: 500 },
+    },
+  );
+
+  assert.deepEqual(
+    migrateAppWindowFrame(
+      "photos",
+      { x: 200, y: 60 },
+      { width: 960, height: 500 },
+      1024,
+    ),
+    {
+      position: { x: 200, y: 60 },
+      size: { width: 960, height: 500 },
+    },
+  );
+
+  assert.deepEqual(
+    migrateAppWindowFrame(
+      "photos",
+      { x: 200, y: 60 },
+      { width: 960, height: 200 },
+      1024,
+    ),
+    {
+      position: { x: 200, y: 60 },
+      size: { width: 960, height: 450 },
+    },
+  );
 });

--- a/tests/photos-grid-size.test.ts
+++ b/tests/photos-grid-size.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getPhotoGridColumnClassName,
+  loadPhotoGridSize,
+  resizePhotoGrid,
+  savePhotoGridSize,
+} from "../lib/photos/grid-size";
+
+function createStorage(initialValue: string | null = null) {
+  const values = new Map<string, string>();
+  if (initialValue !== null) values.set("photos-grid-size", initialValue);
+
+  return {
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+test("Photos grid size defaults safely and persists valid choices", () => {
+  assert.equal(loadPhotoGridSize(createStorage()), "standard");
+  assert.equal(loadPhotoGridSize(createStorage("unknown")), "standard");
+
+  const storage = createStorage();
+  savePhotoGridSize("comfortable", storage);
+  assert.equal(loadPhotoGridSize(storage), "comfortable");
+});
+
+test("Photos grid resizing stops at both thumbnail-size limits", () => {
+  assert.equal(resizePhotoGrid("standard", "smaller"), "compact");
+  assert.equal(resizePhotoGrid("standard", "larger"), "comfortable");
+  assert.equal(resizePhotoGrid("compact", "smaller"), "compact");
+  assert.equal(resizePhotoGrid("comfortable", "larger"), "comfortable");
+});
+
+test("Photos grid sizes map to intentional desktop and mobile densities", () => {
+  assert.equal(getPhotoGridColumnClassName("compact", false), "grid-cols-6");
+  assert.equal(getPhotoGridColumnClassName("standard", false), "grid-cols-5");
+  assert.equal(getPhotoGridColumnClassName("comfortable", false), "grid-cols-4");
+  assert.equal(getPhotoGridColumnClassName("compact", true), "grid-cols-4");
+  assert.equal(getPhotoGridColumnClassName("standard", true), "grid-cols-3");
+  assert.equal(getPhotoGridColumnClassName("comfortable", true), "grid-cols-2");
+});

--- a/tests/photos-grid-size.test.ts
+++ b/tests/photos-grid-size.test.ts
@@ -37,11 +37,11 @@ test("Photos grid resizing stops at both thumbnail-size limits", () => {
   assert.equal(resizePhotoGrid("comfortable", "larger"), "comfortable");
 });
 
-test("Photos grid sizes map to intentional desktop and mobile densities", () => {
+test("Photos grid sizes change desktop density without changing mobile", () => {
   assert.equal(getPhotoGridColumnClassName("compact", false), "grid-cols-6");
   assert.equal(getPhotoGridColumnClassName("standard", false), "grid-cols-5");
   assert.equal(getPhotoGridColumnClassName("comfortable", false), "grid-cols-4");
-  assert.equal(getPhotoGridColumnClassName("compact", true), "grid-cols-4");
+  assert.equal(getPhotoGridColumnClassName("compact", true), "grid-cols-3");
   assert.equal(getPhotoGridColumnClassName("standard", true), "grid-cols-3");
-  assert.equal(getPhotoGridColumnClassName("comfortable", true), "grid-cols-2");
+  assert.equal(getPhotoGridColumnClassName("comfortable", true), "grid-cols-3");
 });


### PR DESCRIPTION
## Today's delight

Photos now mirrors the native desktop toolbar hierarchy while keeping durable desktop thumbnail sizing: the Years/Months/All Photos control sits at the exact center of the content header, Zoom Out/Zoom In is anchored immediately to its left at the same visual height, and Info/Share/Rotate/Favorite actions sit on the right. The Photos window now stops at the first width where those lanes remain separated.

## Baseline and delta

- Before: Photos always rendered five desktop columns and three mobile columns. The first grid-size revision put the time filter and zoom controls together on the right and offered no selected-photo actions in the grid header. The toolbar could then be resized down to 600px, where Library/date, zoom, filters, and actions visibly overlapped; the zoom capsule also stood 4px taller than the centered filter.
- Now: desktop offers persistent 4/5/6-column sizing in the native toolbar composition. The time filter is geometrically centered independently of the Library/date text, zoom remains immediately left of it, and both capsules measure 28px high. Info remains useful without a selection, while Share/Rotate/Favorite stay disabled until a photo is selected. Photos has a 960px minimum/default frame; both live resize drags and restored saved frames honor that current app minimum. When an old narrow frame expands, its x-position also shifts left just enough to keep the enlarged right edge on-screen.
- Preserved: desktop single-click selection, double-click viewer opening, viewer Back, nested thumbnail Favorite controls, time filters, sidebar navigation, scroll-to-latest, and mobile tap-to-open remain unchanged. Mobile keeps its compact Back/title header and original fixed three-column grid, with no zoom, time-filter, selection, or window-resize toolbar behavior.

## Built result — desktop

_Desktop screenshot upload pending: Chrome did not open GitHub's attachment file chooser._

At 1440×900, the zoom and time-filter capsules both measured 28px high, with aligned 24px inner buttons. The filter center remained exactly at the 720px content-header midpoint. An east-edge drag could not shrink Photos below 960px; at that minimum, Library/date and Zoom retained a 16.5px gap, Zoom and the centered filter retained an 8px gap, and the right actions retained 123.8px of separation. A saved 900px Photos frame restored at 960px after reload, confirming older persisted layouts self-correct.

Resting Share/Rotate/Favorite controls were disabled; selecting a thumbnail enabled them. Info showed a no-selection prompt and selected-photo details; Share opened Set as Wallpaper; Rotate updated the selected thumbnail; Favorite was toggled and restored.

## Built result — mobile

_Mobile screenshot upload pending for the same browser limitation._

A 390×844 render of the production `PhotosApp isMobile` component showed the compact Back/title header with no zoom capsule and no desktop time or selection controls. Mobile stays at its original fixed three-column grid even when the saved desktop preference is “large,” so an inaccessible desktop setting cannot silently change mobile density. The available browser reports fine pointer/hover, so true iPhone coarse-pointer and touch signals remain pending owner testing.

## macOS inspiration

The owner supplied a current macOS Photos reference showing Library/date information on the left; zoom immediately left of a truly centered Years/Months/All Photos control; and Info, Share, Rotate, and Favorite on the right. In the native resting state, Share/Rotate/Favorite are dimmed until a photo is focused. This implementation maps that hierarchy, matched control heights, and selection dependency onto the web Photos grid, then treats its clean minimum geometry as the Photos window's resize contract.

## Why this one

Photos last shipped as primary daily delight on 2026-08-10 and its last visible touch was 2026-08-11. It was the strongest neglected registered app with no open overlap; TextEdit and iTerm were the two most recent merged primary surfaces, while Weather, menu bar, and Games had open work.

## Verification

- `npm run check`: lint with six pre-existing warnings and no errors, all 139 tests, typecheck, and the 41-route production build passed
- `git diff --check`
- Restored-frame regression: a saved 600px Photos frame at x=800 in a 1440px viewport expands to 960px and moves to x=480; already-valid and height-only migrations preserve their saved x-position
- Desktop: 1440×900; both control capsules measured 28px, the filter center remained exactly at x=720, the Photos window stopped at 960px, restored undersized frames clamped to 960px, resting/enabled action states were exercised, and zero browser errors were observed
- Mobile preview: 390×844 production mobile component; compact header and fixed three-column grid preserved, zero zoom/time/action controls, and a saved “large” desktop preference did not affect mobile density
- Hosted Vercel build/check recorded separately in the PR checks

## Scope

Small aggregate PR: seven product/test files, 528 additions and 30 deletions; no new dependency, backend, schema, shortcut, or open-PR overlap.
