### PR TITLE
Dismiss context menus on outside pointer input

### DIFF
--- a/lib/hooks/use-click-outside.ts
+++ b/lib/hooks/use-click-outside.ts
@@ -1,35 +1,34 @@
 "use client";
 
-import { useEffect, RefObject } from "react";
+import { RefObject, useEffect, useRef } from "react";
 
 /**
- * Hook to detect clicks outside a referenced element
- * Uses capture phase to catch events before they can be stopped
+ * Dismisses an open surface when a pointer interaction starts outside it.
+ * Capture phase catches interactions before window dragging or menu controls
+ * can stop propagation.
  */
 export function useClickOutside(
   ref: RefObject<HTMLElement | null>,
   onClose: () => void,
   isOpen: boolean
 ) {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     if (!isOpen) return;
 
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (ref.current && !ref.current.contains(target)) {
-        onClose();
+    const handlePointerDownOutside = (event: PointerEvent) => {
+      const container = ref.current;
+      if (container && !event.composedPath().includes(container)) {
+        onCloseRef.current();
       }
     };
 
-    // Small delay to prevent the opening click from immediately closing
-    const timeoutId = setTimeout(() => {
-      // Use capture phase to catch events before they can be stopped
-      document.addEventListener("mousedown", handleClickOutside, true);
-    }, 10);
+    document.addEventListener("pointerdown", handlePointerDownOutside, true);
 
     return () => {
-      clearTimeout(timeoutId);
-      document.removeEventListener("mousedown", handleClickOutside, true);
+      document.removeEventListener("pointerdown", handlePointerDownOutside, true);
     };
-  }, [isOpen, onClose, ref]);
+  }, [isOpen, ref]);
 }


### PR DESCRIPTION
## Summary

- dismiss shared transient menus and popovers when pointer input begins outside their surface
- support mouse, trackpad, touch, and pen through pointer events
- keep the active close callback stable without re-registering the listener on every render

## Verification

- npm run check (146 tests, typecheck, production build)
- verified Photos Info and Share outside-click dismissal in the grid and full-photo viewer
- verified shared menu-bar dismissal