### PR TITLE
Daily delight: Toggle Dock indicators

### DIFF
--- a/components/apps/settings/content.tsx
+++ b/components/apps/settings/content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Settings, Paintbrush, Bluetooth, Wifi, Moon, PanelTop, ImageIcon } from "lucide-react";
+import { Settings, Paintbrush, Bluetooth, Wifi, Moon, PanelBottom, PanelTop, ImageIcon } from "lucide-react";
 import { SettingsCategory, SettingsPanel } from "./settings-app";
 import { GeneralPanel } from "./panels/general";
 import { AboutPanel } from "./panels/about";
@@ -12,6 +12,7 @@ import { StoragePanel } from "./panels/storage";
 import { FocusPanel } from "./panels/focus";
 import { MenuBarPanel } from "./panels/menu-bar";
 import { WallpaperPanel } from "./panels/wallpaper";
+import { DesktopDockPanel } from "./panels/desktop-dock";
 
 interface ContentProps {
   selectedCategory: SettingsCategory;
@@ -55,6 +56,11 @@ const categoryInfo: Record<
     icon: <Moon className="w-8 h-8 fill-current" />,
     title: "Focus",
     description: "Choose when notifications and interruptions are allowed.",
+  },
+  "desktop-dock": {
+    icon: <PanelBottom className="w-8 h-8" />,
+    title: "Desktop & Dock",
+    description: "Choose how items appear on the desktop and in the Dock.",
   },
   "menu-bar": {
     icon: <PanelTop className="w-8 h-8" />,
@@ -110,6 +116,14 @@ export function Content({
     return (
       <div className="flex-1 overflow-y-auto bg-background">
         <MenuBarPanel />
+      </div>
+    );
+  }
+
+  if (selectedCategory === "desktop-dock") {
+    return (
+      <div className="flex-1 overflow-y-auto bg-background">
+        <DesktopDockPanel />
       </div>
     );
   }

--- a/components/apps/settings/panels/desktop-dock.tsx
+++ b/components/apps/settings/panels/desktop-dock.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useSystemSettings } from "@/lib/system-settings-context";
+import { SettingsSwitch } from "../settings-switch";
+
+export function DesktopDockPanel() {
+  const { showDockIndicators, setShowDockIndicators } = useSystemSettings();
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-3 p-6">
+      <h2 className="text-sm font-semibold">Dock</h2>
+      <div className="rounded-xl bg-muted/60 text-sm">
+        <div className="flex min-h-11 items-center justify-between gap-4 px-4 py-2.5">
+          <span>Show indicators for open applications</span>
+          <SettingsSwitch
+            aria-label="Show indicators for open applications"
+            checked={showDockIndicators}
+            onCheckedChange={setShowDockIndicators}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/apps/settings/settings-app.tsx
+++ b/components/apps/settings/settings-app.tsx
@@ -6,7 +6,7 @@ import { Sidebar } from "./sidebar";
 import { Content } from "./content";
 import { loadSettingsState, saveSettingsState } from "@/lib/sidebar-persistence";
 
-export type SettingsCategory = "general" | "appearance" | "wallpaper" | "wifi" | "bluetooth" | "focus" | "menu-bar";
+export type SettingsCategory = "general" | "appearance" | "wallpaper" | "wifi" | "bluetooth" | "focus" | "desktop-dock" | "menu-bar";
 export type SettingsPanel = "about" | "personal-info" | "storage" | null;
 
 interface HistoryEntry {
@@ -116,6 +116,7 @@ export function SettingsApp({ inShell = false, initialPanel, initialCategory, na
     if (selectedCategory === "wifi") return "Wi-Fi";
     if (selectedCategory === "bluetooth") return "Bluetooth";
     if (selectedCategory === "focus") return "Focus";
+    if (selectedCategory === "desktop-dock") return "Desktop & Dock";
     if (selectedCategory === "menu-bar") return "Menu Bar";
     return undefined;
   };

--- a/components/apps/settings/sidebar.tsx
+++ b/components/apps/settings/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { Settings, Paintbrush, Search, X, Wifi, Bluetooth, Moon, PanelTop, ImageIcon } from "lucide-react";
+import { Settings, Paintbrush, Search, X, Wifi, Bluetooth, Moon, PanelBottom, PanelTop, ImageIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettingsCategory, SettingsPanel } from "./settings-app";
 import { SidebarNav } from "./sidebar-nav";
@@ -51,6 +51,13 @@ const categories: { id: SettingsCategory; name: string; icon: React.ReactNode; i
     icon: <ImageIcon className="w-5 h-5 text-white" />,
     iconBg: "bg-gradient-to-b from-cyan-400 to-blue-500",
     keywords: ["wallpaper", "background", "desktop", "photo", "photos", "theme"],
+  },
+  {
+    id: "desktop-dock",
+    name: "Desktop & Dock",
+    icon: <PanelBottom className="w-5 h-5 text-white" />,
+    iconBg: "bg-gray-500",
+    keywords: ["desktop", "dock", "open", "applications", "indicators", "dots"],
   },
   {
     id: "menu-bar",

--- a/components/desktop/dock.tsx
+++ b/components/desktop/dock.tsx
@@ -15,6 +15,7 @@ import {
   setAppKeptInDock,
 } from "@/lib/dock-preferences";
 import type { DockKeepOverrides } from "@/lib/dock-preferences";
+import { useSystemSettings } from "@/lib/system-settings-context";
 import {
   getDockSubmenuSide,
   type DockSubmenuSide,
@@ -140,6 +141,7 @@ export function Dock({
   onClosedDocumentAppClick,
   appBadges = {},
 }: DockProps) {
+  const { showDockIndicators } = useSystemSettings();
   const {
     closeApp,
     openWindow,
@@ -796,7 +798,7 @@ export function Dock({
                 className={cn(
                   "rounded-full mt-1 transition-opacity",
                   // Finder always shows dot (can be closed but not quit)
-                  isOpen || app.id === "finder"
+                  showDockIndicators && (isOpen || app.id === "finder")
                     ? "bg-black/60 dark:bg-white/60 opacity-100"
                     : "opacity-0"
                 )}

--- a/lib/dock-preferences.ts
+++ b/lib/dock-preferences.ts
@@ -1,8 +1,13 @@
 import type { AppConfig } from "@/types/apps";
 
 export const DOCK_KEEP_OVERRIDES_STORAGE_KEY = "desktopDockKeepOverrides";
+export const DOCK_SHOW_OPEN_INDICATORS_STORAGE_KEY = "dock-show-open-indicators";
 
 export type DockKeepOverrides = Record<string, boolean>;
+
+export function parseShowDockIndicators(value: string | null): boolean {
+  return value !== "false";
+}
 
 export function parseDockKeepOverrides(value: string | null): DockKeepOverrides {
   if (!value) return {};

--- a/lib/sidebar-persistence.ts
+++ b/lib/sidebar-persistence.ts
@@ -314,7 +314,7 @@ export function clearPhotosState(storage?: StorageArea): void {
 
 // Note: SettingsCategory and SettingsPanel types are defined in settings-app.tsx.
 // These arrays must match those types.
-const SETTINGS_CATEGORIES = ["general", "appearance", "wallpaper", "wifi", "bluetooth", "focus", "menu-bar"] as const;
+const SETTINGS_CATEGORIES = ["general", "appearance", "wallpaper", "wifi", "bluetooth", "focus", "desktop-dock", "menu-bar"] as const;
 const SETTINGS_PANELS = ["about", "personal-info", "storage"] as const;
 
 type SettingsCategory = (typeof SETTINGS_CATEGORIES)[number];

--- a/lib/system-settings-context.tsx
+++ b/lib/system-settings-context.tsx
@@ -3,6 +3,10 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from "react";
 import { soundEffects } from "@/lib/messages/sound-effects";
 import { OSVersion, getOSVersion, DEFAULT_OS_VERSION_ID } from "@/lib/os-versions";
+import {
+  DOCK_SHOW_OPEN_INDICATORS_STORAGE_KEY,
+  parseShowDockIndicators,
+} from "@/lib/dock-preferences";
 
 export type AirdropMode = "contacts" | "everyone";
 export type FocusMode = "off" | "doNotDisturb" | "sleep" | "reduceInterruptions";
@@ -37,6 +41,8 @@ interface SystemSettingsContextValue {
   setClockFlashSeparators: (flash: boolean) => void;
   clockShowSeconds: boolean;
   setClockShowSeconds: (show: boolean) => void;
+  showDockIndicators: boolean;
+  setShowDockIndicators: (show: boolean) => void;
   wallpaperUrl: string | null;
   setWallpaperUrl: (url: string | null) => void;
   osVersionId: string;
@@ -79,6 +85,7 @@ function getInitialSettings() {
       clockShowAmPm: true,
       clockFlashSeparators: false,
       clockShowSeconds: false,
+      showDockIndicators: true,
       wallpaperUrl: null,
       osVersionId: DEFAULT_OS_VERSION_ID,
     };
@@ -115,6 +122,9 @@ function getInitialSettings() {
     clockShowAmPm: localStorage.getItem(CLOCK_SHOW_AM_PM_KEY) !== "false",
     clockFlashSeparators: localStorage.getItem(CLOCK_FLASH_SEPARATORS_KEY) === "true",
     clockShowSeconds: storedClockShowSeconds === "true",
+    showDockIndicators: parseShowDockIndicators(
+      localStorage.getItem(DOCK_SHOW_OPEN_INDICATORS_STORAGE_KEY)
+    ),
     wallpaperUrl: storedWallpaperUrl || null,
     osVersionId: storedOSVersion || DEFAULT_OS_VERSION_ID,
   };
@@ -154,6 +164,9 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
   );
   const [clockShowSeconds, setClockShowSecondsState] = useState(
     initial.clockShowSeconds
+  );
+  const [showDockIndicators, setShowDockIndicatorsState] = useState(
+    initial.showDockIndicators
   );
   const [wallpaperUrl, setWallpaperUrlState] = useState<string | null>(
     initial.wallpaperUrl
@@ -284,6 +297,13 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
     }
   }, []);
 
+  const setShowDockIndicators = useCallback((show: boolean) => {
+    setShowDockIndicatorsState(show);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(DOCK_SHOW_OPEN_INDICATORS_STORAGE_KEY, String(show));
+    }
+  }, []);
+
   const setMenuBarBackground = useCallback((show: boolean) => {
     setMenuBarBackgroundState(show);
     localStorage.setItem(MENU_BAR_BACKGROUND_KEY, String(show));
@@ -317,7 +337,7 @@ export function SystemSettingsProvider({ children }: { children: React.ReactNode
   const currentOS = useMemo(() => getOSVersion(osVersionId), [osVersionId]);
 
   return (
-    <SystemSettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, wifiEnabled, setWifiEnabled, bluetoothEnabled, setBluetoothEnabled, airdropMode, setAirdropMode, focusMode, setFocusMode, focusEndsAt, scheduleFocusEnd, menuBarBackground, setMenuBarBackground, clockShowDate, setClockShowDate, clockShowDayOfWeek, setClockShowDayOfWeek, clockStyle, setClockStyle, clockShowAmPm, setClockShowAmPm, clockFlashSeparators, setClockFlashSeparators, clockShowSeconds, setClockShowSeconds, wallpaperUrl, setWallpaperUrl, osVersionId, setOSVersionId, currentOS }}>
+    <SystemSettingsContext.Provider value={{ brightness, setBrightness, volume, setVolume, wifiEnabled, setWifiEnabled, bluetoothEnabled, setBluetoothEnabled, airdropMode, setAirdropMode, focusMode, setFocusMode, focusEndsAt, scheduleFocusEnd, menuBarBackground, setMenuBarBackground, clockShowDate, setClockShowDate, clockShowDayOfWeek, setClockShowDayOfWeek, clockStyle, setClockStyle, clockShowAmPm, setClockShowAmPm, clockFlashSeparators, setClockFlashSeparators, clockShowSeconds, setClockShowSeconds, showDockIndicators, setShowDockIndicators, wallpaperUrl, setWallpaperUrl, osVersionId, setOSVersionId, currentOS }}>
       {children}
       {/* Brightness overlay - dims everything below system overlays */}
       {brightness < 100 && (
@@ -368,6 +388,8 @@ const defaultSettings: SystemSettingsContextValue = {
   setClockFlashSeparators: () => {},
   clockShowSeconds: false,
   setClockShowSeconds: () => {},
+  showDockIndicators: true,
+  setShowDockIndicators: () => {},
   wallpaperUrl: null,
   setWallpaperUrl: () => {},
   osVersionId: DEFAULT_OS_VERSION_ID,

--- a/tests/dock-preferences.test.ts
+++ b/tests/dock-preferences.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   isAppKeptInDock,
   parseDockKeepOverrides,
+  parseShowDockIndicators,
   setAppKeptInDock,
 } from "../lib/dock-preferences";
 import { getDockSubmenuSide } from "../lib/desktop/dock-menu";
@@ -16,6 +17,13 @@ test("Dock keep overrides recover from malformed storage", () => {
     parseDockKeepOverrides(JSON.stringify({ weather: true, music: false, bad: "yes", empty: null })),
     { weather: true, music: false }
   );
+});
+
+test("Dock open indicators default on and honor an explicit off preference", () => {
+  assert.equal(parseShowDockIndicators(null), true);
+  assert.equal(parseShowDockIndicators("true"), true);
+  assert.equal(parseShowDockIndicators("false"), false);
+  assert.equal(parseShowDockIndicators("malformed"), true);
 });
 
 test("registered Dock defaults apply until a user overrides them", () => {


### PR DESCRIPTION
## Today's delight

System Settings now includes a native-style **Desktop & Dock** pane with a durable **Show indicators for open applications** switch. Turning it off immediately removes only the small open-app dots from the Dock; turning it back on restores them.

## Baseline and delta

- Before: every open Dock app always showed a dot, and System Settings had no Desktop & Dock category or indicator preference.
- Now: the owner can hide or show open-app indicators immediately, with the choice preserved across reloads.
- Preserved: Dock app launch/focus, badges, Keep in Dock, contextual menus, separator behavior, and the default-on experience all remain unchanged.

## Built result — desktop

<!-- Desktop screenshot pending GitHub attachment upload. -->

At 1440×900, the new Desktop & Dock pane was exercised off, on, and through reload persistence. With indicators hidden, the Messages unread badge and Music contextual menu remained functional; newly opened apps also respected the setting.

## Built result — mobile

<!-- Mobile screenshot pending GitHub attachment upload. -->

System Settings is intentionally unavailable on mobile. At an iPhone-sized 390×844 viewport with Chrome device emulation reporting coarse pointer and no hover, `/settings` continued to redirect to the unchanged, usable Notes fallback.

## macOS inspiration

Apple's current Desktop & Dock guide documents **Show indicators for open applications** as the setting that places a small dot below open apps in the Dock: https://support.apple.com/en-mide/guide/mac-help/mchlp1119/mac. This implementation maps that behavior directly into the site's existing Dock preference and System Settings patterns.

## Why this one

Settings was a neglected registered app: its last daily delight shipped on 2026-07-31 and its last merged visible touch was 2026-08-12. The last two daily primary surfaces were Photos and Weather, and the menu bar already has open work, so this bounded native preference improves coverage without overlapping recent or in-flight changes.

## Verification

- `npm run check` — six pre-existing lint warnings, 147 tests passed, typecheck passed, and all 41 production routes built
- Focused Dock preference tests and typecheck
- `git diff --check`
- Desktop: 1440×900; off/on switching, reload persistence, newly opened app, badge preservation, and contextual menu preservation
- Mobile: Chrome device emulation at 390×844; `pointer: coarse`, `any-pointer: coarse`, no hover, `/settings` → `/notes`, and the Notes fallback visually verified

## Scope

Small: one contained Dock/System Settings preference spanning existing state, persistence, Dock rendering, and a focused test. No dependency, backend, schema, personal-data, shortcut, or mobile-policy changes.
