### PR TITLE
Daily delight: Sort Finder list columns

### DIFF
--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -80,6 +80,8 @@ interface FinderAppProps {
   inShell?: boolean;
   viewMode?: FinderViewMode;
   onViewModeChange?: (mode: FinderViewMode) => void;
+  listSort?: FinderSort | null;
+  onListSortChange?: (sort: FinderSort) => void;
   showStatusBar?: boolean;
   showPathBar?: boolean;
   onOpenApp?: (appId: string) => void;
@@ -207,6 +209,8 @@ export function FinderApp({
   inShell = false,
   viewMode: controlledViewMode,
   onViewModeChange,
+  listSort: controlledListSort,
+  onListSortChange,
   showStatusBar = false,
   showPathBar = false,
   onOpenApp,
@@ -260,7 +264,8 @@ export function FinderApp({
   const [historyIndex, setHistoryIndex] = useState(0);
   const [selectedSidebar, setSelectedSidebar] = useState<SidebarItem>(() => getSidebarForPath(currentPath));
   const [files, setFiles] = useState<FileItem[]>([]);
-  const [listSort, setListSort] = useState<FinderSort | null>(null);
+  const [standaloneListSort, setStandaloneListSort] = useState<FinderSort | null>(null);
+  const listSort = controlledListSort === undefined ? standaloneListSort : controlledListSort;
   const activeListSort = listSort ?? getDefaultFinderSort(currentPath);
   const [loading, setLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
@@ -988,11 +993,15 @@ export function FinderApp({
         }
         aria-pressed={isActive}
         title={direction ? `${label}, ${direction}` : `Sort by ${label}`}
-        onClick={() =>
-          setListSort((current) =>
-            getNextFinderSort(current ?? getDefaultFinderSort(currentPath), key)
-          )
-        }
+        onClick={(event) => {
+          event.stopPropagation();
+          const nextSort = getNextFinderSort(activeListSort, key);
+          if (onListSortChange) {
+            onListSortChange(nextSort);
+          } else {
+            setStandaloneListSort(nextSort);
+          }
+        }}
         className={cn(
           "flex h-5 min-w-0 items-center justify-between gap-1 rounded-sm px-0.5 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-500",
           isActive && "font-medium text-zinc-700 dark:text-zinc-200",

--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -990,7 +990,7 @@ export function FinderApp({
           setListSort((current) => getNextFinderSort(current, key))
         }
         className={cn(
-          "flex h-5 min-w-0 items-center gap-1 rounded-sm px-0.5 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 can-hover:hover:bg-zinc-200/70 dark:can-hover:hover:bg-zinc-700/70",
+          "flex h-5 min-w-0 items-center justify-between gap-1 rounded-sm px-0.5 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-500",
           isActive && "font-medium text-zinc-700 dark:text-zinc-200",
           className
         )}

--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -1020,16 +1020,16 @@ export function FinderApp({
       {/* Skeleton rows */}
       <div className="flex-1 animate-pulse">
         {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="w-full flex items-center px-4 py-1">
+          <div key={i} className="h-7 w-full flex items-center px-4 py-1">
             <div className="flex-1 min-w-0 flex items-center gap-2">
               <div className="w-4 h-4 rounded bg-zinc-200 dark:bg-zinc-700 flex-shrink-0" />
-              <div className="h-4 rounded bg-zinc-200 dark:bg-zinc-700" style={{ width: `${120 + (i * 17) % 80}px` }} />
+              <div className="h-3 rounded bg-zinc-200 dark:bg-zinc-700" style={{ width: `${120 + (i * 17) % 80}px` }} />
             </div>
             <div className="w-32">
-              <div className="h-4 w-16 rounded bg-zinc-200 dark:bg-zinc-700" />
+              <div className="h-3 w-16 rounded bg-zinc-200 dark:bg-zinc-700" />
             </div>
             <div className="w-52">
-              <div className="h-4 w-32 rounded bg-zinc-200 dark:bg-zinc-700" />
+              <div className="h-3 w-32 rounded bg-zinc-200 dark:bg-zinc-700" />
             </div>
           </div>
         ))}

--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -1005,17 +1005,20 @@ export function FinderApp({
     );
   };
 
-  // Skeleton loading for desktop list view
+  const renderDesktopListHeader = () => (
+    <div className="flex items-center px-4 py-1 border-b border-zinc-200 dark:border-zinc-700 text-xs text-zinc-500 dark:text-zinc-400">
+      {renderSortHeader("name", "Name", "flex-1")}
+      {renderSortHeader("kind", "Kind", "w-32")}
+      {renderSortHeader("date", "Date Modified", "w-52")}
+    </div>
+  );
+
+  // Keep the header geometry and active sort stable while only the rows load.
   const renderDesktopListSkeleton = () => (
-    <div className="flex flex-col animate-pulse">
-      {/* Column headers */}
-      <div className="flex items-center px-4 py-1 border-b border-zinc-200 dark:border-zinc-700 text-xs text-zinc-500 dark:text-zinc-400">
-        <div className="flex-1 min-w-0">Name</div>
-        <div className="w-32 text-left">Kind</div>
-        <div className="w-52 text-left">Date Modified</div>
-      </div>
+    <div className="flex flex-col">
+      {renderDesktopListHeader()}
       {/* Skeleton rows */}
-      <div className="flex-1">
+      <div className="flex-1 animate-pulse">
         {Array.from({ length: 8 }).map((_, i) => (
           <div key={i} className="w-full flex items-center px-4 py-1">
             <div className="flex-1 min-w-0 flex items-center gap-2">
@@ -1091,12 +1094,7 @@ export function FinderApp({
 
     return (
       <div className="flex flex-col">
-        {/* Column headers */}
-        <div className="flex items-center px-4 py-1 border-b border-zinc-200 dark:border-zinc-700 text-xs text-zinc-500 dark:text-zinc-400">
-          {renderSortHeader("name", "Name", "flex-1")}
-          {renderSortHeader("kind", "Kind", "w-32")}
-          {renderSortHeader("date", "Date Modified", "w-52")}
-        </div>
+        {renderDesktopListHeader()}
         {/* File rows */}
         <div className="flex-1">
           {visibleFiles.map(file => (

--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -37,6 +37,7 @@ import { FinderSearchEngine, type EntryInput } from "./search-engine";
 import type { FinderViewMode } from "./view-mode";
 import { getFinderPathSegments } from "@/lib/finder-path";
 import {
+  getDefaultFinderSort,
   getNextFinderSort,
   sortFinderEntries,
   type FinderSort,
@@ -260,6 +261,7 @@ export function FinderApp({
   const [selectedSidebar, setSelectedSidebar] = useState<SidebarItem>(() => getSidebarForPath(currentPath));
   const [files, setFiles] = useState<FileItem[]>([]);
   const [listSort, setListSort] = useState<FinderSort | null>(null);
+  const activeListSort = listSort ?? getDefaultFinderSort(currentPath);
   const [loading, setLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [previewContent, setPreviewContent] = useState<string | null>(null);
@@ -972,8 +974,8 @@ export function FinderApp({
     label: string,
     className: string
   ) => {
-    const isActive = listSort?.key === key;
-    const direction = isActive ? listSort.direction : null;
+    const isActive = activeListSort.key === key;
+    const direction = isActive ? activeListSort.direction : null;
     const SortIcon = direction === "ascending" ? ChevronUp : ChevronDown;
 
     return (
@@ -987,7 +989,9 @@ export function FinderApp({
         aria-pressed={isActive}
         title={direction ? `${label}, ${direction}` : `Sort by ${label}`}
         onClick={() =>
-          setListSort((current) => getNextFinderSort(current, key))
+          setListSort((current) =>
+            getNextFinderSort(current ?? getDefaultFinderSort(currentPath), key)
+          )
         }
         className={cn(
           "flex h-5 min-w-0 items-center justify-between gap-1 rounded-sm px-0.5 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-500",
@@ -1076,16 +1080,14 @@ export function FinderApp({
 
   // Render desktop list view
   const renderDesktopListView = () => {
-    const visibleFiles = listSort
-      ? sortFinderEntries(
-          files.map((file) => ({
-            ...file,
-            kind: getFileKind(file),
-            modifiedAt: getFileTimestamp(file),
-          })),
-          listSort
-        )
-      : files;
+    const visibleFiles = sortFinderEntries(
+      files.map((file) => ({
+        ...file,
+        kind: getFileKind(file),
+        modifiedAt: getFileTimestamp(file),
+      })),
+      activeListSort
+    );
 
     return (
       <div className="flex flex-col">

--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import Image from "next/image";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useWindowFocus } from "@/lib/window-focus-context";
 import { useRecents } from "@/lib/recents-context";
 import { cn } from "@/lib/utils";
@@ -35,6 +36,12 @@ import { useRouter } from "next/navigation";
 import { FinderSearchEngine, type EntryInput } from "./search-engine";
 import type { FinderViewMode } from "./view-mode";
 import { getFinderPathSegments } from "@/lib/finder-path";
+import {
+  getNextFinderSort,
+  sortFinderEntries,
+  type FinderSort,
+  type FinderSortKey,
+} from "@/lib/finder-sort";
 
 const USERNAME = HOME_DIR.split("/").pop() ?? "alanagoyal";
 
@@ -252,6 +259,7 @@ export function FinderApp({
   const [historyIndex, setHistoryIndex] = useState(0);
   const [selectedSidebar, setSelectedSidebar] = useState<SidebarItem>(() => getSidebarForPath(currentPath));
   const [files, setFiles] = useState<FileItem[]>([]);
+  const [listSort, setListSort] = useState<FinderSort | null>(null);
   const [loading, setLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [previewContent, setPreviewContent] = useState<string | null>(null);
@@ -885,8 +893,8 @@ export function FinderApp({
     }
   };
 
-  // Get file date - uses real modified date if available, otherwise generates pseudo-random
-  const getFileDate = (file: FileItem): string => {
+  // Get file timestamp - uses real modified date if available, otherwise generates pseudo-random
+  const getFileTimestamp = (file: FileItem): number => {
     const textEditDate = getFileModifiedDate(file.path);
 
     // Check if this is a GitHub file
@@ -897,19 +905,19 @@ export function FinderApp({
 
     // Use most recent of TextEdit date or GitHub date
     if (textEditDate && githubDate) {
-      return formatDateString(new Date(Math.max(textEditDate, githubDate)));
+      return Math.max(textEditDate, githubDate);
     }
     if (textEditDate) {
-      return formatDateString(new Date(textEditDate));
+      return textEditDate;
     }
     if (githubDate) {
-      return formatDateString(new Date(githubDate));
+      return githubDate;
     }
 
     // Check local recents for accessedAt
     const recentFile = recents.find(r => r.path === file.path);
     if (recentFile) {
-      return formatDateString(new Date(recentFile.accessedAt));
+      return recentFile.accessedAt;
     }
 
     // Fall back to pseudo-random date based on filename (deterministic)
@@ -933,8 +941,11 @@ export function FinderApp({
     date.setDate(date.getDate() - daysAgo);
     date.setHours(hours24, minutes, 0, 0);
 
-    return formatDateString(date);
+    return date.getTime();
   };
+
+  const getFileDate = (file: FileItem): string =>
+    formatDateString(new Date(getFileTimestamp(file)));
 
   // Get file kind description
   const getFileKind = (file: FileItem): string => {
@@ -954,6 +965,40 @@ export function FinderApp({
       case "pdf": return "PDF Document";
       default: return "Document";
     }
+  };
+
+  const renderSortHeader = (
+    key: FinderSortKey,
+    label: string,
+    className: string
+  ) => {
+    const isActive = listSort?.key === key;
+    const direction = isActive ? listSort.direction : null;
+    const SortIcon = direction === "ascending" ? ChevronUp : ChevronDown;
+
+    return (
+      <button
+        type="button"
+        aria-label={
+          direction
+            ? `Sort by ${label}, ${direction}`
+            : `Sort by ${label}`
+        }
+        aria-pressed={isActive}
+        title={direction ? `${label}, ${direction}` : `Sort by ${label}`}
+        onClick={() =>
+          setListSort((current) => getNextFinderSort(current, key))
+        }
+        className={cn(
+          "flex h-5 min-w-0 items-center gap-1 rounded-sm px-0.5 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 can-hover:hover:bg-zinc-200/70 dark:can-hover:hover:bg-zinc-700/70",
+          isActive && "font-medium text-zinc-700 dark:text-zinc-200",
+          className
+        )}
+      >
+        <span className="truncate">{label}</span>
+        {isActive && <SortIcon aria-hidden="true" className="h-3 w-3 shrink-0" />}
+      </button>
+    );
   };
 
   // Skeleton loading for desktop list view
@@ -1030,57 +1075,70 @@ export function FinderApp({
   );
 
   // Render desktop list view
-  const renderDesktopListView = () => (
-    <div className="flex flex-col">
-      {/* Column headers */}
-      <div className="flex items-center px-4 py-1 border-b border-zinc-200 dark:border-zinc-700 text-xs text-zinc-500 dark:text-zinc-400">
-        <div className="flex-1 min-w-0">Name</div>
-        <div className="w-32 text-left">Kind</div>
-        <div className="w-52 text-left">Date Modified</div>
+  const renderDesktopListView = () => {
+    const visibleFiles = listSort
+      ? sortFinderEntries(
+          files.map((file) => ({
+            ...file,
+            kind: getFileKind(file),
+            modifiedAt: getFileTimestamp(file),
+          })),
+          listSort
+        )
+      : files;
+
+    return (
+      <div className="flex flex-col">
+        {/* Column headers */}
+        <div className="flex items-center px-4 py-1 border-b border-zinc-200 dark:border-zinc-700 text-xs text-zinc-500 dark:text-zinc-400">
+          {renderSortHeader("name", "Name", "flex-1")}
+          {renderSortHeader("kind", "Kind", "w-32")}
+          {renderSortHeader("date", "Date Modified", "w-52")}
+        </div>
+        {/* File rows */}
+        <div className="flex-1">
+          {visibleFiles.map(file => (
+            <button
+              key={file.path}
+              onClick={(e) => { e.stopPropagation(); handleFileClick(file); }}
+              onDoubleClick={() => handleFileDoubleClick(file)}
+              className={cn(
+                "w-full flex items-center px-4 py-1 text-left text-sm text-zinc-900 dark:text-zinc-100",
+                selectedFile === file.path && "bg-blue-500 text-white"
+              )}
+            >
+              <div className="flex-1 min-w-0 flex items-center gap-2">
+                <FileIcon
+                  type={file.type}
+                  name={file.name}
+                  icon={file.icon}
+                  className={cn("w-4 h-4 flex-shrink-0", selectedFile === file.path && file.type !== "app" && "brightness-0 invert")}
+                />
+                <span className="truncate">{file.displayName || file.name}</span>
+              </div>
+              <div className={cn(
+                "w-32 text-left truncate",
+                selectedFile === file.path ? "text-white/80" : "text-zinc-500 dark:text-zinc-400"
+              )}>
+                {getFileKind(file)}
+              </div>
+              <div className={cn(
+                "w-52 text-left truncate",
+                selectedFile === file.path ? "text-white/80" : "text-zinc-500 dark:text-zinc-400"
+              )}>
+                {getFileDate(file)}
+              </div>
+            </button>
+          ))}
+          {files.length === 0 && !loading && (
+            <div className="text-center text-sm text-zinc-400 dark:text-zinc-500 py-8">
+              This folder is empty
+            </div>
+          )}
+        </div>
       </div>
-      {/* File rows */}
-      <div className="flex-1">
-        {files.map(file => (
-          <button
-            key={file.path}
-            onClick={(e) => { e.stopPropagation(); handleFileClick(file); }}
-            onDoubleClick={() => handleFileDoubleClick(file)}
-            className={cn(
-              "w-full flex items-center px-4 py-1 text-left text-sm text-zinc-900 dark:text-zinc-100",
-              selectedFile === file.path && "bg-blue-500 text-white"
-            )}
-          >
-            <div className="flex-1 min-w-0 flex items-center gap-2">
-              <FileIcon
-                type={file.type}
-                name={file.name}
-                icon={file.icon}
-                className={cn("w-4 h-4 flex-shrink-0", selectedFile === file.path && file.type !== "app" && "brightness-0 invert")}
-              />
-              <span className="truncate">{file.displayName || file.name}</span>
-            </div>
-            <div className={cn(
-              "w-32 text-left truncate",
-              selectedFile === file.path ? "text-white/80" : "text-zinc-500 dark:text-zinc-400"
-            )}>
-              {getFileKind(file)}
-            </div>
-            <div className={cn(
-              "w-52 text-left truncate",
-              selectedFile === file.path ? "text-white/80" : "text-zinc-500 dark:text-zinc-400"
-            )}>
-              {getFileDate(file)}
-            </div>
-          </button>
-        ))}
-        {files.length === 0 && !loading && (
-          <div className="text-center text-sm text-zinc-400 dark:text-zinc-500 py-8">
-            This folder is empty
-          </div>
-        )}
-      </div>
-    </div>
-  );
+    );
+  };
 
   const renderColumnsView = (
     items: FileItem[],

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -64,6 +64,7 @@ import {
   type FinderViewMode,
 } from "@/components/apps/finder/view-mode";
 import type { WeatherTemperatureUnit } from "@/lib/weather";
+import { parseFinderSort } from "@/lib/finder-sort";
 
 const SettingsApp = dynamic(() => import("@/components/apps/settings/settings-app").then(m => ({ default: m.SettingsApp })));
 const ITermApp = dynamic(() => import("@/components/apps/iterm/iterm-app").then(m => ({ default: m.ITermApp })));
@@ -1076,6 +1077,8 @@ function DesktopContent({
                     inShell={true}
                     viewMode={viewMode}
                     onViewModeChange={(mode) => updateWindowMetadata(windowState.id, { viewMode: mode })}
+                    listSort={parseFinderSort(windowState.metadata?.listSort)}
+                    onListSortChange={(sort) => updateWindowMetadata(windowState.id, { listSort: sort })}
                     showStatusBar={finderStatusBarVisible}
                     showPathBar={finderPathBarVisible}
                     initialPath={currentPath}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -580,6 +580,10 @@ machine.
 - Same-tab refresh restores the complete desktop.
 - Separate tabs have independent desktops and cannot overwrite one another.
 - Closing the tab ends its desktop session.
+- Finder's explicit List sort is stored per window in its metadata alongside
+  the folder and view mode. Refresh restores it, closing that window removes it,
+  and a new Finder window uses its folder's default sort. Sorting preserves the
+  selected file; it must not trigger the content area's deselection handler.
 - Durable app content and preferences remain available when a fresh desktop starts.
 - A one-time compatibility migration copies the legacy `localStorage`
   `desktop-window-state` value into the current tab's `sessionStorage`, then

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -442,7 +442,9 @@ Keep the Apple icon visually separated from the focused app, then group the app 
 
 Finder List view uses the same column-header renderer while loading and after
 rows arrive. Keep its geometry, sort caret, and label styling identical; apply
-the loading pulse only to placeholder rows, never the header.
+the loading pulse only to placeholder rows, never the header. List skeleton rows
+match the loaded rows' 28px height, with centered 12px text bars and 16px icons
+so placeholders align with the visible text rather than filling its line box.
 
 ```tsx
 <div className="flex-1 flex items-center justify-center">

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -440,6 +440,10 @@ Keep the Apple icon visually separated from the focused app, then group the app 
 
 ### Loading State
 
+Finder List view uses the same column-header renderer while loading and after
+rows arrive. Keep its geometry, sort caret, and label styling identical; apply
+the loading pulse only to placeholder rows, never the header.
+
 ```tsx
 <div className="flex-1 flex items-center justify-center">
   <Spinner className="text-muted-foreground" />

--- a/lib/finder-sort.ts
+++ b/lib/finder-sort.ts
@@ -6,6 +6,18 @@ export interface FinderSort {
   direction: FinderSortDirection;
 }
 
+export function parseFinderSort(value: unknown): FinderSort | null {
+  if (!value || typeof value !== "object") return null;
+  const { key, direction } = value as Partial<FinderSort>;
+  if (
+    (key !== "name" && key !== "kind" && key !== "date") ||
+    (direction !== "ascending" && direction !== "descending")
+  ) {
+    return null;
+  }
+  return { key, direction };
+}
+
 export interface FinderSortableEntry {
   name: string;
   displayName?: string;

--- a/lib/finder-sort.ts
+++ b/lib/finder-sort.ts
@@ -18,6 +18,12 @@ const textCollator = new Intl.Collator("en", {
   sensitivity: "base",
 });
 
+export function getDefaultFinderSort(path: string): FinderSort {
+  return path === "recents"
+    ? { key: "date", direction: "descending" }
+    : { key: "name", direction: "ascending" };
+}
+
 export function getNextFinderSort(
   current: FinderSort | null,
   key: FinderSortKey

--- a/lib/finder-sort.ts
+++ b/lib/finder-sort.ts
@@ -1,0 +1,70 @@
+export type FinderSortKey = "name" | "kind" | "date";
+export type FinderSortDirection = "ascending" | "descending";
+
+export interface FinderSort {
+  key: FinderSortKey;
+  direction: FinderSortDirection;
+}
+
+export interface FinderSortableEntry {
+  name: string;
+  displayName?: string;
+  kind: string;
+  modifiedAt: number;
+}
+
+const textCollator = new Intl.Collator("en", {
+  numeric: true,
+  sensitivity: "base",
+});
+
+export function getNextFinderSort(
+  current: FinderSort | null,
+  key: FinderSortKey
+): FinderSort {
+  if (current?.key === key) {
+    return {
+      key,
+      direction:
+        current.direction === "ascending" ? "descending" : "ascending",
+    };
+  }
+
+  return {
+    key,
+    direction: key === "date" ? "descending" : "ascending",
+  };
+}
+
+export function sortFinderEntries<T extends FinderSortableEntry>(
+  entries: readonly T[],
+  sort: FinderSort
+): T[] {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((left, right) => {
+      let comparison = 0;
+
+      if (sort.key === "name") {
+        comparison = textCollator.compare(
+          left.entry.displayName ?? left.entry.name,
+          right.entry.displayName ?? right.entry.name
+        );
+      } else if (sort.key === "kind") {
+        comparison = textCollator.compare(left.entry.kind, right.entry.kind);
+      } else {
+        comparison = left.entry.modifiedAt - right.entry.modifiedAt;
+      }
+
+      if (comparison !== 0) {
+        return sort.direction === "ascending" ? comparison : -comparison;
+      }
+
+      const nameComparison = textCollator.compare(
+        left.entry.displayName ?? left.entry.name,
+        right.entry.displayName ?? right.entry.name
+      );
+      return nameComparison || left.index - right.index;
+    })
+    .map(({ entry }) => entry);
+}

--- a/tests/finder-sort.test.ts
+++ b/tests/finder-sort.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getNextFinderSort,
+  sortFinderEntries,
+  type FinderSortableEntry,
+} from "../lib/finder-sort";
+
+const entries: FinderSortableEntry[] = [
+  { name: "zeta.ts", kind: "TypeScript", modifiedAt: 20 },
+  { name: "Folder 10", kind: "Folder", modifiedAt: 10 },
+  { name: "folder 2", kind: "Folder", modifiedAt: 30 },
+];
+
+test("Finder sort uses native-feeling initial directions and reverses", () => {
+  assert.deepEqual(getNextFinderSort(null, "name"), {
+    key: "name",
+    direction: "ascending",
+  });
+  assert.deepEqual(getNextFinderSort(null, "date"), {
+    key: "date",
+    direction: "descending",
+  });
+  assert.deepEqual(
+    getNextFinderSort({ key: "name", direction: "ascending" }, "name"),
+    { key: "name", direction: "descending" }
+  );
+});
+
+test("Finder name sorting is case-insensitive and numeric", () => {
+  assert.deepEqual(
+    sortFinderEntries(entries, { key: "name", direction: "ascending" }).map(
+      (entry) => entry.name
+    ),
+    ["folder 2", "Folder 10", "zeta.ts"]
+  );
+});
+
+test("Finder kind sorting uses names as deterministic ties", () => {
+  assert.deepEqual(
+    sortFinderEntries(entries, { key: "kind", direction: "ascending" }).map(
+      (entry) => entry.name
+    ),
+    ["folder 2", "Folder 10", "zeta.ts"]
+  );
+});
+
+test("Finder date sorting supports newest and oldest first", () => {
+  assert.deepEqual(
+    sortFinderEntries(entries, { key: "date", direction: "descending" }).map(
+      (entry) => entry.name
+    ),
+    ["folder 2", "zeta.ts", "Folder 10"]
+  );
+  assert.deepEqual(
+    sortFinderEntries(entries, { key: "date", direction: "ascending" }).map(
+      (entry) => entry.name
+    ),
+    ["Folder 10", "zeta.ts", "folder 2"]
+  );
+});

--- a/tests/finder-sort.test.ts
+++ b/tests/finder-sort.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   getDefaultFinderSort,
   getNextFinderSort,
+  parseFinderSort,
   sortFinderEntries,
   type FinderSortableEntry,
 } from "../lib/finder-sort";
@@ -13,6 +14,21 @@ const entries: FinderSortableEntry[] = [
   { name: "Folder 10", kind: "Folder", modifiedAt: 10 },
   { name: "folder 2", kind: "Folder", modifiedAt: 30 },
 ];
+
+test("Finder restores valid sort metadata and rejects invalid saved values", () => {
+  for (const key of ["name", "kind", "date"]) {
+    for (const direction of ["ascending", "descending"]) {
+      assert.deepEqual(parseFinderSort({ key, direction }), { key, direction });
+    }
+  }
+  for (const value of [null, undefined, "name", [], {},
+    { key: "size", direction: "ascending" },
+    { key: "name", direction: "up" },
+    { key: "name" },
+  ]) {
+    assert.equal(parseFinderSort(value), null);
+  }
+});
 
 test("Finder defaults match the indicated column and reverse on first click", () => {
   const recentsSort = getDefaultFinderSort("recents");

--- a/tests/finder-sort.test.ts
+++ b/tests/finder-sort.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  getDefaultFinderSort,
   getNextFinderSort,
   sortFinderEntries,
   type FinderSortableEntry,
@@ -12,6 +13,30 @@ const entries: FinderSortableEntry[] = [
   { name: "Folder 10", kind: "Folder", modifiedAt: 10 },
   { name: "folder 2", kind: "Folder", modifiedAt: 30 },
 ];
+
+test("Finder defaults match the indicated column and reverse on first click", () => {
+  const recentsSort = getDefaultFinderSort("recents");
+  assert.deepEqual(recentsSort, { key: "date", direction: "descending" });
+  assert.deepEqual(
+    sortFinderEntries(entries, recentsSort).map((entry) => entry.name),
+    ["folder 2", "zeta.ts", "Folder 10"]
+  );
+  assert.deepEqual(getNextFinderSort(recentsSort, "date"), {
+    key: "date", direction: "ascending",
+  });
+
+  for (const path of ["applications", "/Users/alana/Documents", "trash"]) {
+    const folderSort = getDefaultFinderSort(path);
+    assert.deepEqual(folderSort, { key: "name", direction: "ascending" });
+    assert.deepEqual(
+      sortFinderEntries(entries, folderSort).map((entry) => entry.name),
+      ["folder 2", "Folder 10", "zeta.ts"]
+    );
+    assert.deepEqual(getNextFinderSort(folderSort, "name"), {
+      key: "name", direction: "descending",
+    });
+  }
+});
 
 test("Finder sort uses native-feeling initial directions and reverses", () => {
   assert.deepEqual(getNextFinderSort(null, "name"), {

--- a/tests/window-state-storage.test.ts
+++ b/tests/window-state-storage.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { parseFinderSort } from "../lib/finder-sort";
 
 import {
   WINDOW_STATE_STORAGE_KEY,
@@ -29,6 +30,20 @@ class MemoryStorage {
 
 const deserialize = (value: string): string | null =>
   value.startsWith("valid:") ? value : null;
+
+test("restores independent Finder sorts with each window's metadata", () => {
+  const tabStorage = new MemoryStorage();
+  const durableStorage = new MemoryStorage();
+  const windows = {
+    first: { metadata: { currentPath: "recents", listSort: { key: "name", direction: "descending" } } },
+    second: { metadata: { currentPath: "applications", listSort: { key: "date", direction: "ascending" } } },
+  };
+  saveWindowStatePayload(tabStorage, JSON.stringify(windows));
+  const restored = loadWindowState(tabStorage, durableStorage, JSON.parse) as typeof windows;
+  assert.deepEqual(parseFinderSort(restored.first.metadata.listSort), windows.first.metadata.listSort);
+  assert.deepEqual(parseFinderSort(restored.second.metadata.listSort), windows.second.metadata.listSort);
+  assert.equal(loadWindowState(new MemoryStorage(), durableStorage, JSON.parse), null);
+});
 
 test("prefers tab-scoped state and removes a stale durable copy", () => {
   const tabStorage = new MemoryStorage();


### PR DESCRIPTION
## Today's delight

Finder's List view column headers now behave like macOS Finder: click Name, Kind, or Date Modified to sort the visible folder, then click the same header again to reverse direction. The active column shows a compact direction indicator at its right edge, including before any header is clicked, and exposes its state accessibly. Headers do not gain a hover background.

## Baseline and delta

- Before: Finder displayed Name, Kind, and Date Modified as inert text; clicking a header did not reorder the rows.
- Now: each header is a functional sort control with native-feeling defaults—text ascending and dates newest-first—and a repeat click reverses the order.
- Default order: Recents starts with Date Modified descending; other folders start with Name ascending. The initial caret and actual row order use the same sort state. Clicking the default header reverses it immediately.
- Review fixes: sorting retains the selected row, and each Finder window restores its explicit sort on refresh through existing tab-scoped window metadata. Invalid saved sorts fall back safely; new windows keep their defaults.
- Preserved: row selection, app double-open, sidebar navigation, search, path/status bars, and the other Finder view modes continue to behave as before.

## Built result — desktop

<!-- Desktop screenshot will be attached here. -->

At 1280×720, the Applications folder is sorted by Name ascending, the direction indicator is visible, Music remains selected, and the existing Finder chrome is unchanged.

## Built result — mobile

Mobile screenshot not captured. Finder is intentionally unsupported on mobile and should retain the registered Notes fallback, but the Mac was locked and the available browser viewport continued reporting a fine pointer with hover rather than genuine touch/coarse-pointer emulation. The owner explicitly asked to publish this draft despite that outstanding verification gap.

## macOS inspiration

[Apple's current Finder guide](https://support.apple.com/en-au/guide/mac-help/mchlp1745/mac) documents clicking a List-view column header to sort by that column and clicking it again to reverse the order. This implementation maps that interaction to Finder's existing Name, Kind, and Date Modified columns without adding shortcuts or changing the surrounding workflows.

## Why this one

Finder was a neglected registered app: its last primary daily delight was 2026-08-03 and its last visible touch was 2026-08-24. This was the highest-scoring bounded candidate after checking recent default-branch merges, non-delight work, and open PR overlap; the existing menu-bar PR remains untouched.

## Verification

- `npm run check` — passed with six pre-existing lint warnings and zero errors, all 154 tests, typecheck, and the 41-route production build
- Focused Finder sorting tests — default sort/row order alignment and first-click reversal, direction toggles, numeric/case-insensitive names, deterministic Kind ties, and date order
- Desktop: 1280×720; Name ascending/descending, Date newest-first, active state, row selection, app double-open, and zero console errors
- Mobile: not verified under genuine touch/coarse-pointer emulation; explicitly waived for draft publication by the owner

## Scope

Six intended files after review fixes; no dependency, backend, schema, personal-content, or keyboard-command changes. The branch is based on current `origin/main`; the only open PR targets the menu bar and does not overlap.


