### PR TITLE
Make Messages search jump to exact matches

### DIFF
--- a/components/apps/calendar/calendar-app.tsx
+++ b/components/apps/calendar/calendar-app.tsx
@@ -11,6 +11,11 @@ import { EventForm } from "./event-form";
 import { ViewType, CalendarEvent, Calendar } from "./types";
 import { getUpcomingEventDefaults, navigateDate } from "./utils";
 import { loadCalendars } from "./data";
+import { EventSearch } from "./event-search";
+import {
+  getCalendarEventDate,
+  getCalendarEventSearchScrollTop,
+} from "./search-utils";
 
 // Valid view types for type guard
 const VALID_VIEW_TYPES: ViewType[] = ["day", "week", "month", "year"];
@@ -158,6 +163,8 @@ export function CalendarApp({
 }: CalendarAppProps) {
   const windowFocus = useWindowFocus();
   const containerRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const nextScrollRequestId = useRef(0);
   const dialogContainer =
     windowFocus?.dialogContainerRef?.current ?? containerRef.current;
 
@@ -168,6 +175,10 @@ export function CalendarApp({
   const [calendars, setCalendars] = useState<Calendar[]>([]);
   const [isLoaded, setIsLoaded] = useState(false);
   const [timeGridScrollTop, setTimeGridScrollTop] = useState(0);
+  const [timeGridScrollRequest, setTimeGridScrollRequest] = useState<{
+    id: number;
+    top: number;
+  } | null>(null);
 
   // Event form state
   const [eventFormOpen, setEventFormOpen] = useState(false);
@@ -295,6 +306,28 @@ export function CalendarApp({
     setEventFormOpen(true);
   }, []);
 
+  const handleSearchResultSelect = useCallback((event: CalendarEvent) => {
+    const eventScrollTop = getCalendarEventSearchScrollTop(
+      event,
+      DEFAULT_HOUR_HEIGHT,
+    );
+    if (eventScrollTop !== null) {
+      nextScrollRequestId.current += 1;
+      setTimeGridScrollTop(eventScrollTop);
+      setTimeGridScrollRequest({
+        id: nextScrollRequestId.current,
+        top: eventScrollTop,
+      });
+      saveScrollPosition(eventScrollTop);
+    } else {
+      setTimeGridScrollRequest(null);
+    }
+    setCurrentDate(getCalendarEventDate(event));
+    setView(isMobile ? "week" : "day");
+    setSelectedEventId(event.id);
+    handleViewEvent(event);
+  }, [handleViewEvent, isMobile]);
+
   // Event deletion (only user events can be deleted)
   const handleDeleteEvent = useCallback((eventId: string) => {
     // Only delete if it's a user event (exists in our events state)
@@ -355,6 +388,12 @@ export function CalendarApp({
         return;
       }
 
+      if (e.key === "/") {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+        return;
+      }
+
       switch (e.key.toLowerCase()) {
         case "d":
           setView("day");
@@ -407,7 +446,29 @@ export function CalendarApp({
           onNewEvent={handleNewEvent}
           inShell={inShell}
           isMobile={false}
+          search={
+            <EventSearch
+              events={events}
+              calendars={calendars}
+              currentDate={currentDate}
+              onSelect={handleSearchResultSelect}
+              inputRef={searchInputRef}
+            />
+          }
         />
+      )}
+
+      {isMobile && (
+        <div className="relative z-20 border-b border-border bg-background px-3 py-2">
+          <EventSearch
+            events={events}
+            calendars={calendars}
+            currentDate={currentDate}
+            onSelect={handleSearchResultSelect}
+            isMobile
+            inputRef={searchInputRef}
+          />
+        </div>
       )}
 
       {/* Calendar view */}
@@ -419,6 +480,7 @@ export function CalendarApp({
             calendars={calendars}
             onCreateEvent={handleCreateEvent}
             initialScrollTop={timeGridScrollTop}
+            scrollRequest={timeGridScrollRequest}
             onScrollChange={handleTimeGridScroll}
             selectedEventId={selectedEventId}
             onSelectEvent={handleSelectEvent}
@@ -433,6 +495,7 @@ export function CalendarApp({
             calendars={calendars}
             onCreateEvent={isMobile ? undefined : handleCreateEvent}
             initialScrollTop={timeGridScrollTop}
+            scrollRequest={timeGridScrollRequest}
             onScrollChange={handleTimeGridScroll}
             selectedEventId={isMobile ? null : selectedEventId}
             onSelectEvent={isMobile ? undefined : handleSelectEvent}

--- a/components/apps/calendar/day-view.tsx
+++ b/components/apps/calendar/day-view.tsx
@@ -11,6 +11,7 @@ interface DayViewProps {
   calendars: Calendar[];
   onCreateEvent: (date: Date, startTime: string, endTime: string) => void;
   initialScrollTop?: number;
+  scrollRequest?: { id: number; top: number } | null;
   onScrollChange?: (scrollTop: number) => void;
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
@@ -24,6 +25,7 @@ export function DayView({
   calendars,
   onCreateEvent,
   initialScrollTop,
+  scrollRequest,
   onScrollChange,
   selectedEventId,
   onSelectEvent,
@@ -63,6 +65,7 @@ export function DayView({
         onCreateEvent={onCreateEvent}
         showDayHeaders={false}
         initialScrollTop={initialScrollTop}
+        scrollRequest={scrollRequest}
         onScrollChange={onScrollChange}
         selectedEventId={selectedEventId}
         onSelectEvent={onSelectEvent}

--- a/components/apps/calendar/event-search.tsx
+++ b/components/apps/calendar/event-search.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { format, parseISO } from "date-fns";
+import { Search, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useWindowFocus } from "@/lib/window-focus-context";
+import { Calendar, CalendarEvent } from "./types";
+import { formatEventTime } from "./utils";
+import {
+  getNextCalendarSearchResultIndex,
+  searchCalendarEvents,
+} from "./search-utils";
+
+interface EventSearchProps {
+  events: CalendarEvent[];
+  calendars: Calendar[];
+  currentDate: Date;
+  onSelect: (event: CalendarEvent) => void;
+  isMobile?: boolean;
+  inputRef?: RefObject<HTMLInputElement>;
+}
+
+export function EventSearch({
+  events,
+  calendars,
+  currentDate,
+  onSelect,
+  isMobile = false,
+  inputRef,
+}: EventSearchProps) {
+  const windowFocus = useWindowFocus();
+  const internalInputRef = useRef<HTMLInputElement>(null);
+  const searchInputRef = inputRef ?? internalInputRef;
+  const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const results = useMemo(
+    () => searchCalendarEvents(events, calendars, query, currentDate),
+    [calendars, currentDate, events, query],
+  );
+  const calendarById = useMemo(
+    () => new Map(calendars.map((calendar) => [calendar.id, calendar])),
+    [calendars],
+  );
+  const isSearching = query.trim().length > 0;
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (windowFocus && !windowFocus.isFocused) return;
+
+      if (document.activeElement === searchInputRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        searchInputRef.current?.blur();
+        return;
+      }
+
+      if (query) {
+        event.preventDefault();
+        event.stopPropagation();
+        setQuery("");
+        setHighlightedIndex(0);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape, true);
+    return () => document.removeEventListener("keydown", handleEscape, true);
+  }, [query, searchInputRef, windowFocus]);
+
+  useEffect(() => {
+    setHighlightedIndex((index) => Math.min(index, Math.max(0, results.length - 1)));
+  }, [results.length]);
+
+  useEffect(() => {
+    if (!isSearching || results.length === 0) return;
+    resultsRef.current
+      ?.querySelector(`[data-calendar-search-result-index="${highlightedIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex, isSearching, results.length]);
+
+  const selectResult = (event: CalendarEvent) => {
+    setQuery("");
+    setHighlightedIndex(0);
+    onSelect(event);
+  };
+
+  return (
+    <div className={cn("relative", isMobile ? "w-full" : "w-52")}>
+      <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
+      <input
+        ref={searchInputRef}
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setHighlightedIndex(0);
+        }}
+        onKeyDown={(event) => {
+          if (
+            results.length > 0 &&
+            (event.key === "ArrowDown" || event.key === "ArrowUp")
+          ) {
+            event.preventDefault();
+            const direction: 1 | -1 = event.key === "ArrowDown" ? 1 : -1;
+            setHighlightedIndex((index) =>
+              getNextCalendarSearchResultIndex(index, results.length, direction),
+            );
+            return;
+          }
+          if (event.key === "Enter" && results[highlightedIndex]) {
+            event.preventDefault();
+            selectResult(results[highlightedIndex]);
+          }
+        }}
+        placeholder="Search"
+        aria-label="Search calendar events"
+        className="h-7 w-full rounded-lg border border-muted-foreground/15 bg-background/70 py-0.5 pl-7 pr-7 text-sm outline-none placeholder:text-muted-foreground focus:border-[#0A7CFF]/60"
+      />
+      {query && (
+        <button
+          type="button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => {
+            setQuery("");
+            setHighlightedIndex(0);
+            searchInputRef.current?.focus();
+          }}
+          aria-label="Clear calendar search"
+          className="absolute right-1.5 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-muted-foreground can-hover:hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      )}
+
+      {isSearching && (
+        <div ref={resultsRef} className="absolute left-0 right-0 top-[calc(100%+0.35rem)] z-30 max-h-72 overflow-y-auto rounded-xl border border-muted-foreground/20 bg-background/95 p-1 shadow-xl backdrop-blur-xl">
+          {results.length > 0 ? results.map((event, index) => {
+            const calendar = calendarById.get(event.calendarId);
+            const isHighlighted = index === highlightedIndex;
+            return (
+              <button
+                key={event.id}
+                type="button"
+                onClick={() => selectResult(event)}
+                data-calendar-search-result-index={index}
+                aria-current={isHighlighted ? "true" : undefined}
+                className={cn(
+                  "flex min-h-12 w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left active:bg-muted",
+                  isHighlighted && !isMobile
+                    ? "bg-[#0A7CFF] text-white"
+                    : "can-hover:hover:bg-muted",
+                )}
+              >
+                <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: calendar?.color ?? "#0A7CFF" }} aria-hidden />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">{event.title}</span>
+                  <span className={cn("block truncate text-xs", isHighlighted && !isMobile ? "text-white/80" : "text-muted-foreground")}>
+                    {format(parseISO(event.startDate), "EEE, MMM d")}
+                    {event.startTime ? ` at ${formatEventTime(event.startTime)}` : " · All day"}
+                    {event.location ? ` · ${event.location}` : ""}
+                  </span>
+                </span>
+              </button>
+            );
+          }) : (
+            <p className="px-3 py-4 text-center text-sm text-muted-foreground">No events found</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/apps/calendar/nav.tsx
+++ b/components/apps/calendar/nav.tsx
@@ -16,6 +16,7 @@ interface NavProps {
   onNewEvent: () => void;
   inShell?: boolean;
   isMobile?: boolean;
+  search?: React.ReactNode;
 }
 
 const VIEW_OPTIONS: { value: ViewType; label: string }[] = [
@@ -33,6 +34,7 @@ export function Nav({
   onNewEvent,
   inShell = false,
   isMobile = false,
+  search,
 }: NavProps) {
   const nav = useWindowNavBehavior({ isDesktop: inShell, isMobile });
 
@@ -70,7 +72,7 @@ export function Nav({
   return (
     <div
       className={cn(
-        "px-4 py-2 flex items-center gap-2 sticky top-0 z-[1] select-none bg-muted"
+        "relative px-4 py-2 flex items-center gap-2 sticky top-0 z-[1] select-none bg-muted"
       )}
       onMouseDown={nav.onDragStart}
     >
@@ -118,8 +120,13 @@ export function Nav({
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Right section - navigation (hidden on mobile, shown in view header instead) */}
-      <div className="flex items-center gap-0.5 desktop:gap-1 shrink-0" onMouseDown={(e) => e.stopPropagation()}>
+      {/* Search stays at the far right of the top toolbar. */}
+      <div className="shrink-0" onMouseDown={(e) => e.stopPropagation()}>
+        {search}
+      </div>
+
+      {/* Date navigation sits directly below Search in the view header. */}
+      <div className="absolute right-4 top-[calc(100%+0.625rem)] z-[2] flex items-center gap-0.5 desktop:gap-1" onMouseDown={(e) => e.stopPropagation()}>
         <Button
           variant="ghost"
           size="icon"

--- a/components/apps/calendar/search-utils.ts
+++ b/components/apps/calendar/search-utils.ts
@@ -1,0 +1,79 @@
+import { addDays, format, parseISO } from "date-fns";
+import { Calendar, CalendarEvent } from "./types";
+import { getEventsForDay } from "./utils";
+
+export function getNextCalendarSearchResultIndex(
+  currentIndex: number,
+  resultCount: number,
+  direction: 1 | -1,
+): number {
+  if (resultCount <= 0) return 0;
+  return (currentIndex + direction + resultCount) % resultCount;
+}
+
+export function getCalendarEventSearchScrollTop(
+  event: CalendarEvent,
+  hourHeight = 60,
+  viewportCenterOffset = 200,
+): number | null {
+  if (event.isAllDay || !event.startTime) return null;
+
+  const [hour, minute] = event.startTime.split(":").map(Number);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+
+  const eventTop = (hour * 60 + minute) * (hourHeight / 60);
+  return Math.max(0, eventTop - viewportCenterOffset);
+}
+
+export function searchCalendarEvents(
+  events: CalendarEvent[],
+  calendars: Calendar[],
+  query: string,
+  referenceDate: Date,
+  dayRadius = 183,
+  limit = 40,
+): CalendarEvent[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return [];
+
+  const calendarNames = new Map(
+    calendars.map((calendar) => [calendar.id, calendar.name.toLocaleLowerCase()]),
+  );
+  const results = new Map<string, CalendarEvent>();
+
+  const matchesQuery = (event: CalendarEvent) =>
+    [event.title, event.location, calendarNames.get(event.calendarId)]
+      .filter(Boolean)
+      .join(" ")
+      .toLocaleLowerCase()
+      .includes(normalizedQuery);
+
+  // Stored events are finite, so search all of them regardless of the date
+  // currently shown in Calendar. The radius below only bounds generated data.
+  for (const event of events) {
+    if (matchesQuery(event)) results.set(event.id, event);
+  }
+
+  for (let offset = -dayRadius; offset <= dayRadius; offset += 1) {
+    const day = addDays(referenceDate, offset);
+    for (const event of getEventsForDay(events, day)) {
+      if (matchesQuery(event)) results.set(event.id, event);
+    }
+  }
+
+  const referenceDay = format(referenceDate, "yyyy-MM-dd");
+  return [...results.values()]
+    .sort((first, second) => {
+      const firstIsFuture = first.startDate >= referenceDay;
+      const secondIsFuture = second.startDate >= referenceDay;
+      if (firstIsFuture !== secondIsFuture) return firstIsFuture ? -1 : 1;
+      return firstIsFuture
+        ? first.startDate.localeCompare(second.startDate)
+        : second.startDate.localeCompare(first.startDate);
+    })
+    .slice(0, limit);
+}
+
+export function getCalendarEventDate(event: CalendarEvent): Date {
+  return parseISO(event.startDate);
+}

--- a/components/apps/calendar/time-grid.tsx
+++ b/components/apps/calendar/time-grid.tsx
@@ -124,6 +124,7 @@ interface TimeGridProps {
   hourHeight?: number;
   showDayHeaders?: boolean;
   initialScrollTop?: number;
+  scrollRequest?: { id: number; top: number } | null;
   onScrollChange?: (scrollTop: number) => void;
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
@@ -167,6 +168,7 @@ export function TimeGrid({
   hourHeight = 60,
   showDayHeaders = false,
   initialScrollTop,
+  scrollRequest,
   onScrollChange,
   selectedEventId,
   onSelectEvent,
@@ -178,6 +180,7 @@ export function TimeGrid({
   const now = useCurrentTime();
   const gridRef = useRef<HTMLDivElement>(null);
   const hasRestoredScroll = useRef(false);
+  const handledScrollRequestId = useRef<number | null>(null);
   const [dragState, setDragState] = useState<{
     columnIndex: number;
     startY: number;
@@ -191,6 +194,19 @@ export function TimeGrid({
       hasRestoredScroll.current = true;
     }
   }, [initialScrollTop]);
+
+  useEffect(() => {
+    if (
+      !gridRef.current ||
+      !scrollRequest ||
+      handledScrollRequestId.current === scrollRequest.id
+    ) {
+      return;
+    }
+
+    gridRef.current.scrollTop = scrollRequest.top;
+    handledScrollRequestId.current = scrollRequest.id;
+  }, [scrollRequest]);
 
   // Handle scroll events
   const handleScroll = useCallback(() => {

--- a/components/apps/calendar/week-view.tsx
+++ b/components/apps/calendar/week-view.tsx
@@ -13,6 +13,7 @@ interface WeekViewProps {
   calendars: Calendar[];
   onCreateEvent?: (date: Date, startTime: string, endTime: string) => void;
   initialScrollTop?: number;
+  scrollRequest?: { id: number; top: number } | null;
   onScrollChange?: (scrollTop: number) => void;
   selectedEventId?: string | null;
   onSelectEvent?: (eventId: string | null) => void;
@@ -30,6 +31,7 @@ export function WeekView({
   calendars,
   onCreateEvent,
   initialScrollTop,
+  scrollRequest,
   onScrollChange,
   selectedEventId,
   onSelectEvent,
@@ -145,6 +147,7 @@ export function WeekView({
         onCreateEvent={onCreateEvent}
         showDayHeaders={false}
         initialScrollTop={initialScrollTop}
+        scrollRequest={scrollRequest}
         onScrollChange={onScrollChange}
         selectedEventId={selectedEventId}
         onSelectEvent={onSelectEvent}

--- a/components/apps/finder/finder-app.tsx
+++ b/components/apps/finder/finder-app.tsx
@@ -758,12 +758,13 @@ export function FinderApp({
 
       if (e.key === "Escape" && searchActive) {
         e.preventDefault();
-        if (searchQuery) {
+        if (document.activeElement === searchInputRef.current) {
+          searchInputRef.current?.blur();
+        } else if (searchQuery) {
           setSearchQuery("");
         } else {
           setSearchActive(false);
         }
-        (document.activeElement as HTMLElement)?.blur();
         return;
       }
 

--- a/components/apps/finder/nav.tsx
+++ b/components/apps/finder/nav.tsx
@@ -185,6 +185,7 @@ export function FinderNav({
                 ref={searchInputRef}
                 type="text"
                 placeholder="Search"
+                aria-label="Search files and folders"
                 value={searchQuery}
                 onChange={(event) => onSearchQueryChange(event.target.value)}
                 onBlur={onSearchBlur}
@@ -192,9 +193,11 @@ export function FinderNav({
               />
               {searchQuery && (
                 <button
+                  type="button"
                   onClick={onSearchClear}
                   onMouseDown={(event) => event.preventDefault()}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  aria-label="Clear search"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground can-hover:hover:text-foreground"
                 >
                   <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                     <path d="M18 6L6 18M6 6l12 12" />
@@ -204,8 +207,10 @@ export function FinderNav({
             </div>
           ) : (
             <button
+              type="button"
               onClick={onSearchActivate}
-              className="p-1 rounded text-muted-foreground hover:bg-zinc-200 dark:hover:bg-zinc-700"
+              aria-label="Search"
+              className="p-1 rounded text-muted-foreground can-hover:hover:bg-zinc-200 dark:can-hover:hover:bg-zinc-700"
               title="Search (/)"
             >
               <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/components/apps/messages/app.tsx
+++ b/components/apps/messages/app.tsx
@@ -93,6 +93,11 @@ export default function App({
     recipient: string;
   } | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
+  const [searchTarget, setSearchTarget] = useState<{
+    messageId: string;
+    requestId: number;
+  } | null>(null);
+  const searchRequestIdRef = useRef(0);
   const [isScrolled, setIsScrolled] = useState(false);
   const lastHandledExternalRequestIdRef = useRef<number | null>(null);
 
@@ -1045,6 +1050,20 @@ export default function App({
     return total + (conv.unreadCount || 0);
   }, 0);
 
+  const handleSearchChange = useCallback((term: string) => {
+    setSearchTerm(term);
+    if (!term) setSearchTarget(null);
+  }, []);
+
+  const handleSelectMessageResult = useCallback(
+    (conversationId: string, messageId: string) => {
+      searchRequestIdRef.current += 1;
+      setSearchTarget({ messageId, requestId: searchRequestIdRef.current });
+      selectConversation(conversationId);
+    },
+    [selectConversation],
+  );
+
   useEffect(() => {
     if (!onUnreadBadgeCountChange) return;
     onUnreadBadgeCountChange(totalUnreadCount);
@@ -1078,13 +1097,15 @@ export default function App({
               conversations={conversations}
               activeConversation={activeConversation}
               onSelectConversation={(id) => {
+                setSearchTarget(null);
                 selectConversation(id);
               }}
+              onSelectMessageResult={handleSelectMessageResult}
               onDeleteConversation={handleDeleteConversation}
               onUpdateConversation={handleUpdateConversation}
               isMobileView={isMobileView}
               searchTerm={searchTerm}
-              onSearchChange={setSearchTerm}
+              onSearchChange={handleSearchChange}
               typingStatus={typingStatus}
               onScroll={setIsScrolled}
               onSoundToggle={handleSoundToggle}
@@ -1124,8 +1145,12 @@ export default function App({
                 setIsNewConversation(false);
                 selectConversation(null);
               }}
-              onSendMessage={handleSendMessage}
+              onSendMessage={(message, conversationId) => {
+                setSearchTarget(null);
+                handleSendMessage(message, conversationId);
+              }}
               justSentMessageId={justSentMessageId}
+              searchTarget={searchTarget}
               onReaction={handleReaction}
               typingStatus={typingStatus}
               conversationId={activeConversation || ""}

--- a/components/apps/messages/chat-area.tsx
+++ b/components/apps/messages/chat-area.tsx
@@ -33,6 +33,7 @@ interface ChatAreaProps {
   focusModeActive?: boolean;
   isWindowFocused?: boolean;
   justSentMessageId?: string | null;
+  searchTarget?: { messageId: string; requestId: number } | null;
 }
 
 type NavigatorWithVirtualKeyboard = Navigator & {
@@ -63,6 +64,7 @@ export function ChatArea({
   focusModeActive = false,
   isWindowFocused = true,
   justSentMessageId,
+  searchTarget,
 }: ChatAreaProps) {
   const [showCompactNewChat, setShowCompactNewChat] = useState(false);
 
@@ -195,6 +197,7 @@ export function ChatArea({
                 focusModeActive={focusModeActive}
                 isWindowFocused={isWindowFocused}
                 justSentMessageId={justSentMessageId}
+                searchTarget={searchTarget}
               />
               <div className="w-3 bg-background" />
             </div>

--- a/components/apps/messages/message-list.tsx
+++ b/components/apps/messages/message-list.tsx
@@ -22,6 +22,7 @@ interface MessageListProps {
   focusModeActive?: boolean;
   isWindowFocused?: boolean;
   justSentMessageId?: string | null;
+  searchTarget?: { messageId: string; requestId: number } | null;
 }
 
 export function MessageList({
@@ -36,6 +37,7 @@ export function MessageList({
   focusModeActive = false,
   isWindowFocused = true,
   justSentMessageId,
+  searchTarget,
 }: MessageListProps) {
   const [activeMessageId, setActiveMessageId] = useState<string | null>(null);
   const [isAnyReactionMenuOpen, setIsAnyReactionMenuOpen] = useState(false);
@@ -43,6 +45,9 @@ export function MessageList({
   const prevMessageCountRef = useRef(0);
   const messageListRef = useRef<HTMLDivElement>(null);
   const [wasAtBottom, setWasAtBottom] = useState(true);
+  const [highlightedMessageId, setHighlightedMessageId] = useState<
+    string | null
+  >(null);
 
   const lastUserMessageIndex = messages.findLastIndex(
     (msg) => msg.sender === "me"
@@ -125,6 +130,7 @@ export function MessageList({
     };
 
     const resizeObserver = new ResizeObserver(() => {
+      if (searchTarget) return;
       if (isFirstScroll || shouldAutoScrollRef.current) {
         scrollToBottom();
       }
@@ -137,7 +143,39 @@ export function MessageList({
     }
 
     return () => resizeObserver.disconnect();
-  }, [conversationId]);
+  }, [conversationId, searchTarget]);
+
+  useEffect(() => {
+    if (!searchTarget) {
+      setHighlightedMessageId(null);
+      return;
+    }
+
+    const targetMessage = Array.from(
+      messageListRef.current?.querySelectorAll<HTMLElement>(
+        "[data-message-id]"
+      ) ?? []
+    ).find((element) => element.dataset.messageId === searchTarget.messageId);
+    if (!targetMessage) return;
+
+    setHighlightedMessageId(searchTarget.messageId);
+    shouldAutoScrollRef.current = false;
+    setWasAtBottom(false);
+
+    const animationFrame = requestAnimationFrame(() => {
+      targetMessage.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+    const highlightTimer = window.setTimeout(() => {
+      setHighlightedMessageId((current) =>
+        current === searchTarget.messageId ? null : current
+      );
+    }, 4000);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      clearTimeout(highlightTimer);
+    };
+  }, [conversationId, searchTarget]);
 
   // Reset tracking when conversation changes (must be defined before the message effect)
   useEffect(() => {
@@ -181,7 +219,11 @@ export function MessageList({
           <div
             key={message.id}
             data-message-id={message.id}
-            className="relative"
+            className={cn(
+              "relative rounded-2xl transition-[background-color,box-shadow] duration-300",
+              message.id === highlightedMessageId &&
+                "bg-[#0A7CFF]/10 ring-2 ring-inset ring-[#0A7CFF]/35"
+            )}
           >
             {/* Overlay for non-active messages */}
             {isAnyReactionMenuOpen && message.id !== activeMessageId && (

--- a/components/apps/messages/search-bar.tsx
+++ b/components/apps/messages/search-bar.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { Icons } from "./icons";
 import { useWindowFocus } from "@/lib/window-focus-context";
 
 interface SearchBarProps {
+  inputRef: RefObject<HTMLInputElement>;
   value: string;
   onChange: (value: string) => void;
 }
 
-export function SearchBar({ value, onChange }: SearchBarProps) {
+export function SearchBar({ inputRef, value, onChange }: SearchBarProps) {
   const justBlurred = useRef(false);
   const windowFocus = useWindowFocus();
 
@@ -24,11 +25,8 @@ export function SearchBar({ value, onChange }: SearchBarProps) {
       }
 
       if (e.key === "Escape") {
-        const searchInput = document.querySelector(
-          'input[placeholder="Search"]'
-        );
         if (
-          document.activeElement !== searchInput &&
+          document.activeElement !== inputRef.current &&
           value &&
           !justBlurred.current
         ) {
@@ -40,13 +38,14 @@ export function SearchBar({ value, onChange }: SearchBarProps) {
 
     window.addEventListener("keydown", handleGlobalEscape);
     return () => window.removeEventListener("keydown", handleGlobalEscape);
-  }, [value, onChange, windowFocus]);
+  }, [inputRef, value, onChange, windowFocus]);
 
   return (
     <div className="p-2">
       <div className="relative">
         <Icons.search className="absolute left-2 top-1/2 transform -translate-y-1/2 text-muted-foreground" />
         <input
+          ref={inputRef}
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
@@ -63,12 +62,18 @@ export function SearchBar({ value, onChange }: SearchBarProps) {
             }
           }}
           placeholder="Search"
+          aria-label="Search messages"
           className="w-full pl-8 pr-8 py-0.5 rounded-lg text-base desktop:text-sm placeholder:text-sm placeholder:text-muted-foreground focus:outline-none bg-[#E8E8E7] dark:bg-[#353533]"
         />
         {value && (
           <button
-            onClick={() => onChange("")}
-            className="absolute right-2 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            type="button"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => {
+              onChange("");
+              inputRef.current?.focus();
+            }}
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 text-muted-foreground can-hover:hover:text-foreground"
             aria-label="Clear search"
           >
             <Icons.close className="h-4 w-4" />

--- a/components/apps/messages/sidebar.tsx
+++ b/components/apps/messages/sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Conversation } from "@/types/messages";
 import { SearchBar } from "./search-bar";
 import { format, isToday, isYesterday, isThisWeek, parseISO } from "date-fns";
@@ -10,12 +10,21 @@ import { cn } from "@/lib/utils";
 import { useWindowFocus } from "@/lib/window-focus-context";
 import Image from "next/image";
 import { toggleConversationReadState } from "@/lib/messages/read-state";
+import {
+  getConversationNameMatches,
+  getConversationSearchName,
+  getMessageSearchPreviewText,
+  getMessageSearchResults,
+  getNextMessageSearchResultIndex,
+  type MessageSearchResult,
+} from "@/lib/messages/search";
 
 interface SidebarProps {
   children: React.ReactNode;
   conversations: Conversation[];
   activeConversation: string | null;
   onSelectConversation: (id: string) => void;
+  onSelectMessageResult: (conversationId: string, messageId: string) => void;
   onDeleteConversation: (id: string) => void;
   onUpdateConversation: (
     conversations: Conversation[],
@@ -29,11 +38,178 @@ interface SidebarProps {
   onSoundToggle: () => void;
 }
 
+function SearchResultAvatar({ conversation }: { conversation: Conversation }) {
+  const recipient = conversation.recipients[0];
+  const names = recipient.name.split(" ");
+  const initials =
+    names.length >= 2
+      ? `${names[0][0]}${names[names.length - 1][0]}`.toUpperCase()
+      : recipient.name[0].toUpperCase();
+
+  return (
+    <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded-full">
+      {recipient.avatar ? (
+        <Image
+          src={recipient.avatar}
+          alt={`${recipient.name} avatar`}
+          fill
+          sizes="40px"
+          className="object-cover"
+          unoptimized
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center bg-gradient-to-b from-[#9BA1AA] to-[#7D828A] text-sm font-medium text-white">
+          {initials}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HighlightedMatch({
+  content,
+  query,
+  isHighlighted,
+}: {
+  content: string;
+  query: string;
+  isHighlighted: boolean;
+}) {
+  const index = content
+    .toLocaleLowerCase()
+    .indexOf(query.trim().toLocaleLowerCase());
+  if (index < 0) return content;
+
+  return (
+    <>
+      {content.slice(0, index)}
+      <strong className={cn("font-semibold", isHighlighted ? "text-white" : "text-foreground")}>
+        {content.slice(index, index + query.trim().length)}
+      </strong>
+      {content.slice(index + query.trim().length)}
+    </>
+  );
+}
+
+function MessageSearchResults({
+  conversationMatches,
+  messageMatches,
+  query,
+  formatTime,
+  highlightedIndex,
+  isMobileView,
+  onSelectResult,
+}: {
+  conversationMatches: Conversation[];
+  messageMatches: MessageSearchResult[];
+  query: string;
+  formatTime: (timestamp: string | undefined) => string;
+  highlightedIndex: number;
+  isMobileView: boolean;
+  onSelectResult: (index: number) => void;
+}) {
+  if (conversationMatches.length === 0 && messageMatches.length === 0) {
+    return (
+      <p className="mt-4 px-2 py-2 text-sm text-muted-foreground">
+        No results found
+      </p>
+    );
+  }
+
+  return (
+    <div className="pb-4">
+      {conversationMatches.length > 0 && (
+        <section aria-labelledby="messages-conversation-results">
+          <h2
+            id="messages-conversation-results"
+            className="px-2 pb-1 pt-3 text-xs font-semibold text-muted-foreground"
+          >
+            Conversations
+          </h2>
+          {conversationMatches.map((conversation, index) => {
+            const isHighlighted = index === highlightedIndex;
+            return (
+              <button
+                key={conversation.id}
+                type="button"
+                onClick={() => onSelectResult(index)}
+                data-message-search-result-index={index}
+                aria-current={isHighlighted ? "true" : undefined}
+                className={cn(
+                  "flex h-[62px] w-full items-center gap-3 rounded-lg px-2 text-left",
+                  isHighlighted && !isMobileView
+                    ? "bg-[#0A7CFF] text-white"
+                    : "can-hover:hover:bg-muted-foreground/10",
+                )}
+              >
+                <SearchResultAvatar conversation={conversation} />
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {getConversationSearchName(conversation)}
+                </span>
+              </button>
+            );
+          })}
+        </section>
+      )}
+
+      {messageMatches.length > 0 && (
+        <section aria-labelledby="messages-message-results">
+          <h2
+            id="messages-message-results"
+            className="px-2 pb-1 pt-3 text-xs font-semibold text-muted-foreground"
+          >
+            Messages
+          </h2>
+          {messageMatches.map(({ conversation, message }, index) => {
+            const resultIndex = conversationMatches.length + index;
+            const isHighlighted = resultIndex === highlightedIndex;
+            const preview = getMessageSearchPreviewText(message.content, query);
+            return (
+              <button
+                key={`${conversation.id}-${message.id}`}
+                type="button"
+                onClick={() => onSelectResult(resultIndex)}
+                data-message-search-result-index={resultIndex}
+                aria-current={isHighlighted ? "true" : undefined}
+                aria-label={`Open matching message in ${getConversationSearchName(
+                  conversation
+                )}`}
+                className={cn(
+                  "flex min-h-[70px] w-full items-center gap-3 rounded-lg px-2 py-2 text-left",
+                  isHighlighted && !isMobileView
+                    ? "bg-[#0A7CFF] text-white"
+                    : "can-hover:hover:bg-muted-foreground/10",
+                )}
+              >
+                <SearchResultAvatar conversation={conversation} />
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-baseline justify-between gap-2">
+                    <span className="truncate text-sm font-medium">
+                      {getConversationSearchName(conversation)}
+                    </span>
+                    <span className={cn("shrink-0 text-xs", isHighlighted && !isMobileView ? "text-white/80" : "text-muted-foreground")}>
+                      {formatTime(message.timestamp)}
+                    </span>
+                  </span>
+                  <span className={cn("mt-0.5 block line-clamp-2 text-xs", isHighlighted && !isMobileView ? "text-white/80" : "text-muted-foreground")}>
+                    <HighlightedMatch content={preview} query={query} isHighlighted={isHighlighted && !isMobileView} />
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </section>
+      )}
+    </div>
+  );
+}
+
 export function Sidebar({
   children,
   conversations,
   activeConversation,
   onSelectConversation,
+  onSelectMessageResult,
   onDeleteConversation,
   onUpdateConversation,
   isMobileView,
@@ -46,8 +222,11 @@ export function Sidebar({
   const { theme, systemTheme } = useTheme();
   const effectiveTheme = theme === "system" ? systemTheme : theme;
   const windowFocus = useWindowFocus();
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const [openSwipedConvo, setOpenSwipedConvo] = useState<string | null>(null);
+  const [highlightedSearchIndex, setHighlightedSearchIndex] = useState(0);
   const formatTime = (timestamp: string | undefined) => {
     if (!timestamp) return "";
 
@@ -97,23 +276,65 @@ export function Sidebar({
     return timeB - timeA; // Most recent first
   }), [conversations]);
 
-  const filteredConversations = useMemo(() => sortedConversations.filter((conversation) => {
-    if (!searchTerm) return true;
+  const conversationMatches = useMemo(
+    () => getConversationNameMatches(sortedConversations, searchTerm),
+    [sortedConversations, searchTerm],
+  );
+  const messageMatches = useMemo(
+    () => getMessageSearchResults(sortedConversations, searchTerm),
+    [sortedConversations, searchTerm],
+  );
+  const searchResults = useMemo(
+    () => [
+      ...conversationMatches.map((conversation) => ({
+        kind: "conversation" as const,
+        conversation,
+      })),
+      ...messageMatches.map(({ conversation, message }) => ({
+        kind: "message" as const,
+        conversation,
+        message,
+      })),
+    ],
+    [conversationMatches, messageMatches],
+  );
+  const filteredConversations = useMemo(() => {
+    if (!searchTerm) return sortedConversations;
+    const matchingIds = new Set([
+      ...conversationMatches.map(({ id }) => id),
+      ...messageMatches.map(({ conversation }) => conversation.id),
+    ]);
+    return sortedConversations.filter(({ id }) => matchingIds.has(id));
+  }, [conversationMatches, messageMatches, searchTerm, sortedConversations]);
 
-    // Search in non-system messages content only
-    const hasMatchInMessages = conversation.messages
-      .filter((message) => message.sender !== "system")
-      .some((message) =>
-        message.content.toLowerCase().includes(searchTerm.toLowerCase())
-      );
+  const handleSearchChange = useCallback((term: string) => {
+    setHighlightedSearchIndex(0);
+    onSearchChange(term);
+  }, [onSearchChange]);
 
-    // Search in recipient names
-    const hasMatchInNames = conversation.recipients.some((recipient) =>
-      recipient.name.toLowerCase().includes(searchTerm.toLowerCase())
-    );
+  const selectSearchResult = useCallback((index: number) => {
+    const result = searchResults[index];
+    if (!result) return;
 
-    return hasMatchInMessages || hasMatchInNames;
-  }), [sortedConversations, searchTerm]);
+    setHighlightedSearchIndex(index);
+    if (result.kind === "conversation") {
+      onSelectConversation(result.conversation.id);
+    } else {
+      onSelectMessageResult(result.conversation.id, result.message.id);
+    }
+  }, [onSelectConversation, onSelectMessageResult, searchResults]);
+
+  useEffect(() => {
+    if (!searchTerm || searchResults.length === 0) return;
+    setHighlightedSearchIndex((index) => Math.min(index, searchResults.length - 1));
+  }, [searchResults.length, searchTerm]);
+
+  useEffect(() => {
+    if (!searchTerm) return;
+    sidebarRef.current
+      ?.querySelector(`[data-message-search-result-index="${highlightedSearchIndex}"]`)
+      ?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [highlightedSearchIndex, searchTerm]);
 
   // Keyboard navigation
   useEffect(() => {
@@ -185,12 +406,26 @@ export function Sidebar({
         !document.activeElement?.closest(".ProseMirror")
       ) {
         e.preventDefault();
-        const searchInput = document.querySelector(
-          'input[type="text"][placeholder="Search"]'
-        ) as HTMLInputElement;
-        if (searchInput) {
-          searchInput.focus();
-        }
+        searchInputRef.current?.focus();
+        return;
+      }
+
+      if (
+        searchTerm &&
+        searchResults.length > 0 &&
+        ["ArrowDown", "ArrowUp", "j", "k"].includes(e.key)
+      ) {
+        e.preventDefault();
+        const direction: 1 | -1 = ["ArrowDown", "j"].includes(e.key) ? 1 : -1;
+        setHighlightedSearchIndex((index) =>
+          getNextMessageSearchResultIndex(index, searchResults.length, direction),
+        );
+        return;
+      }
+
+      if (searchTerm && e.key === "Enter" && searchResults.length > 0) {
+        e.preventDefault();
+        selectSearchResult(highlightedSearchIndex);
         return;
       }
 
@@ -297,10 +532,15 @@ export function Sidebar({
     onDeleteConversation,
     windowFocus,
     onSoundToggle,
+    searchTerm,
+    searchResults.length,
+    highlightedSearchIndex,
+    selectSearchResult,
   ]);
 
   return (
     <div
+      ref={sidebarRef}
       className={cn(
         "flex flex-col h-full",
         isMobileView ? "bg-background" : "bg-muted"
@@ -322,22 +562,30 @@ export function Sidebar({
           withVerticalMargins={false}
         >
           <div className={`${isMobileView ? "w-full" : "w-[320px]"} px-2`}>
-            <SearchBar value={searchTerm} onChange={onSearchChange} />
+            <SearchBar
+              inputRef={searchInputRef}
+              value={searchTerm}
+              onChange={handleSearchChange}
+            />
             <div className="w-full">
-              {filteredConversations.length === 0 && searchTerm ? (
-                <div className="py-2">
-                  <p className="text-sm text-muted-foreground px-2 mt-4">
-                    No results found
-                  </p>
-                </div>
+              {searchTerm ? (
+                <MessageSearchResults
+                  conversationMatches={conversationMatches}
+                  messageMatches={messageMatches}
+                  query={searchTerm}
+                  formatTime={formatTime}
+                  highlightedIndex={highlightedSearchIndex}
+                  isMobileView={isMobileView}
+                  onSelectResult={selectSearchResult}
+                />
               ) : (
                 <>
                   {/* Pinned Conversations Grid */}
-                  {filteredConversations.some((conv) => conv.pinned) && (
+                  {sortedConversations.some((conv) => conv.pinned) && (
                     <div className="p-2">
                       <div
                         className={`flex flex-wrap gap-1 ${
-                          filteredConversations.filter((c) => c.pinned)
+                          sortedConversations.filter((c) => c.pinned)
                             .length <= 2
                             ? "justify-center"
                             : ""
@@ -346,7 +594,7 @@ export function Sidebar({
                           display: "grid",
                           gap: "1rem",
                           gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
-                          ...(filteredConversations.filter((c) => c.pinned)
+                          ...(sortedConversations.filter((c) => c.pinned)
                             .length <= 2 && {
                             display: "flex",
                             maxWidth: "fit-content",
@@ -354,7 +602,7 @@ export function Sidebar({
                           }),
                         }}
                       >
-                        {filteredConversations
+                        {sortedConversations
                           .filter((conv) => conv.pinned)
                           .map((conversation) => (
                             <div
@@ -595,7 +843,7 @@ export function Sidebar({
                   )}
 
                   {/* Regular Conversation List */}
-                  {filteredConversations
+                  {sortedConversations
                     .filter((conv) => !conv.pinned)
                     .map((conversation, index, array) => {
                       const isActive = conversation.id === activeConversation;

--- a/components/apps/notes/note-item.tsx
+++ b/components/apps/notes/note-item.tsx
@@ -12,10 +12,39 @@ import {
 import { Note } from "@/lib/notes/types";
 import { getDisplayCreatedAt } from "@/lib/notes/display-created-at";
 import { Dispatch, SetStateAction } from "react";
-import { getNotePreviewText } from "@/lib/notes/note-utils";
+import {
+  getNotePreviewText,
+  getNoteSearchPreviewText,
+} from "@/lib/notes/note-utils";
 import { Pencil, Pin, PinOff, Trash2 } from "lucide-react";
 
 const SIDEBAR_DATE_PLACEHOLDER = "00/00/0000";
+
+function HighlightedSearchPreview({
+  content,
+  query,
+}: {
+  content: string;
+  query: string;
+}) {
+  const preview = getNoteSearchPreviewText(content, query);
+  const trimmedQuery = query.trim();
+  const matchIndex = preview
+    .toLocaleLowerCase()
+    .indexOf(trimmedQuery.toLocaleLowerCase());
+
+  if (!trimmedQuery || matchIndex < 0) return preview;
+
+  return (
+    <>
+      {preview.slice(0, matchIndex)}
+      <strong className="font-semibold text-foreground">
+        {preview.slice(matchIndex, matchIndex + trimmedQuery.length)}
+      </strong>
+      {preview.slice(matchIndex + trimmedQuery.length)}
+    </>
+  );
+}
 
 interface NoteItemProps {
   item: Note;
@@ -32,6 +61,7 @@ interface NoteItemProps {
   setOpenSwipeItemSlug: Dispatch<SetStateAction<string | null>>;
   showDivider?: boolean;
   useCallbackNavigation?: boolean;
+  searchQuery?: string;
 }
 
 export const NoteItem = React.memo(function NoteItem({
@@ -49,6 +79,7 @@ export const NoteItem = React.memo(function NoteItem({
   setOpenSwipeItemSlug,
   showDivider = false,
   useCallbackNavigation = false,
+  searchQuery = "",
 }: NoteItemProps) {
   const isMobile = useMobileDetect();
   const [isSwiping, setIsSwiping] = useState(false);
@@ -123,7 +154,14 @@ export const NoteItem = React.memo(function NoteItem({
           </span>
         </span>
         <span className="block w-0 min-w-0 flex-1 truncate">
-          {getNotePreviewText(item.content)}
+          {isSearching ? (
+            <HighlightedSearchPreview
+              content={item.content}
+              query={searchQuery}
+            />
+          ) : (
+            getNotePreviewText(item.content)
+          )}
         </span>
       </p>
     </>

--- a/components/apps/notes/notes-app.tsx
+++ b/components/apps/notes/notes-app.tsx
@@ -29,6 +29,7 @@ export function NotesApp({
   const containerRef = useRef<HTMLDivElement>(null);
   const [viewMode, setViewMode] = useState<NotesViewMode>("list");
   const [viewModeLoaded, setViewModeLoaded] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const windowFocus = useWindowFocus();
   const {
     loading,
@@ -98,6 +99,8 @@ export function NotesApp({
           showSidebar={showSidebar}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
+          searchQuery={searchQuery}
+          onSearchQueryChange={setSearchQuery}
         />
       </SessionNotesProvider>
     );
@@ -124,6 +127,8 @@ export function NotesApp({
         windowFocus={windowFocus}
         viewMode={viewMode}
         onViewModeChange={setViewMode}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
       />
     </SessionNotesProvider>
   );

--- a/components/apps/notes/presenters/notes-desktop-presenter.tsx
+++ b/components/apps/notes/presenters/notes-desktop-presenter.tsx
@@ -22,6 +22,8 @@ interface NotesDesktopPresenterProps {
   windowFocus: WindowFocusValue;
   viewMode: NotesViewMode;
   onViewModeChange: (viewMode: NotesViewMode) => void;
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
 }
 
 export function NotesDesktopPresenter({
@@ -36,6 +38,8 @@ export function NotesDesktopPresenter({
   windowFocus,
   viewMode,
   onViewModeChange,
+  searchQuery,
+  onSearchQueryChange,
 }: NotesDesktopPresenterProps) {
   const [isGalleryDetailOpen, setIsGalleryDetailOpen] = useState(
     () => viewMode === "gallery" && Boolean(initialSlug),
@@ -91,6 +95,8 @@ export function NotesDesktopPresenter({
         onViewModeChange={onViewModeChange}
         galleryDetailNote={isGalleryDetailOpen ? selectedNote : null}
         onGalleryBack={handleBackToGallery}
+        controlledSearchQuery={searchQuery}
+        onSearchQueryChange={onSearchQueryChange}
       />
       {viewMode === "list" && (
         <div className="flex-grow h-full overflow-hidden relative">

--- a/components/apps/notes/presenters/notes-mobile-presenter.tsx
+++ b/components/apps/notes/presenters/notes-mobile-presenter.tsx
@@ -18,6 +18,8 @@ interface NotesMobilePresenterProps {
   showSidebar: boolean;
   viewMode: NotesViewMode;
   onViewModeChange: (viewMode: NotesViewMode) => void;
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
 }
 
 export function NotesMobilePresenter({
@@ -32,6 +34,8 @@ export function NotesMobilePresenter({
   showSidebar,
   viewMode,
   onViewModeChange,
+  searchQuery,
+  onSearchQueryChange,
 }: NotesMobilePresenterProps) {
   return (
     <div
@@ -54,6 +58,8 @@ export function NotesMobilePresenter({
             onNoteCreated={handleNoteCreated}
             viewMode={viewMode}
             onViewModeChange={onViewModeChange}
+            controlledSearchQuery={searchQuery}
+            onSearchQueryChange={onSearchQueryChange}
           />
         )
       ) : (

--- a/components/apps/notes/search.tsx
+++ b/components/apps/notes/search.tsx
@@ -1,12 +1,8 @@
 import { RefObject, Dispatch, SetStateAction, useEffect } from "react";
-import { Note } from "@/lib/notes/types";
 import { Icons } from "./icons";
 import { useWindowFocus } from "@/lib/window-focus-context";
 
 interface SearchBarProps {
-  notes: Note[];
-  onSearchResults: (results: Note[] | null) => void;
-  sessionId: string;
   inputRef: RefObject<HTMLInputElement>;
   searchQuery: string;
   setSearchQuery: (query: string) => void;
@@ -15,9 +11,6 @@ interface SearchBarProps {
 }
 
 export function SearchBar({
-  notes,
-  onSearchResults,
-  sessionId,
   inputRef,
   searchQuery,
   setSearchQuery,
@@ -54,15 +47,6 @@ export function SearchBar({
       clearSearch();
       return;
     }
-
-    const filteredNotes = notes.filter(
-      (note) =>
-        (note.public || note.session_id === sessionId) &&
-        (note.title.toLowerCase().includes(query.trim().toLowerCase()) ||
-          note.content.toLowerCase().includes(query.trim().toLowerCase()))
-    );
-
-    onSearchResults(filteredNotes);
     setHighlightedIndex(0);
   };
 
@@ -85,8 +69,13 @@ export function SearchBar({
         />
         {searchQuery && (
           <button
-            onClick={clearSearch}
-            className="absolute right-2 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            type="button"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => {
+              clearSearch();
+              inputRef.current?.focus();
+            }}
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 text-muted-foreground can-hover:hover:text-foreground"
             aria-label="Clear search"
           >
             <Icons.close className="h-4 w-4 text-muted-foreground" />

--- a/components/apps/notes/sidebar-content.tsx
+++ b/components/apps/notes/sidebar-content.tsx
@@ -50,6 +50,7 @@ interface SidebarContentProps {
   useCallbackNavigation?: boolean;
   isMobile?: boolean;
   viewMode: NotesViewMode;
+  searchQuery: string;
 }
 
 interface GalleryCardProps {
@@ -611,6 +612,7 @@ export function SidebarContent({
   useCallbackNavigation = false,
   isMobile = false,
   viewMode,
+  searchQuery,
 }: SidebarContentProps) {
   const router = useRouter();
 
@@ -769,6 +771,7 @@ export function SidebarContent({
               setOpenSwipeItemSlug={setOpenSwipeItemSlug}
               showDivider={index < localSearchResults.length - 1}
               useCallbackNavigation={useCallbackNavigation}
+              searchQuery={searchQuery}
             />
           ))}
         </ul>

--- a/components/apps/notes/sidebar.tsx
+++ b/components/apps/notes/sidebar.tsx
@@ -39,6 +39,7 @@ import {
   saveNotesSortPreferences,
 } from "@/lib/notes/display-preferences";
 import NoteDocument from "./note";
+import { searchNotes } from "@/lib/notes/search";
 
 const labels = {
   pinned: "Pinned",
@@ -64,6 +65,8 @@ export default function Sidebar({
   onViewModeChange,
   galleryDetailNote,
   onGalleryBack,
+  controlledSearchQuery,
+  onSearchQueryChange,
 }: {
   notes: Note[];
   onNoteSelect: (note: Note) => void;
@@ -75,6 +78,8 @@ export default function Sidebar({
   onViewModeChange: (viewMode: NotesViewMode) => void;
   galleryDetailNote?: Note | null;
   onGalleryBack?: () => void;
+  controlledSearchQuery?: string;
+  onSearchQueryChange?: (query: string) => void;
 }) {
   const router = useRouter();
   const supabase = createClient();
@@ -84,9 +89,6 @@ export default function Sidebar({
   const [pinnedNotes, setPinnedNotes] = useState<Set<string>>(new Set());
   const pathname = usePathname();
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const [localSearchResults, setLocalSearchResults] = useState<Note[] | null>(
-    null
-  );
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [groupedNotes, setGroupedNotes] = useState<GroupedNotes>({});
   const [selectedNote, setSelectedNote] = useState<Note | null>(null);
@@ -94,7 +96,9 @@ export default function Sidebar({
     null
   );
   const [highlightedNote, setHighlightedNote] = useState<Note | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [internalSearchQuery, setInternalSearchQuery] = useState("");
+  const searchQuery = controlledSearchQuery ?? internalSearchQuery;
+  const setSearchQuery = onSearchQueryChange ?? setInternalSearchQuery;
   const [groupMode, setGroupMode] = useState<NotesGroupMode>("edited");
   const [sortField, setSortField] = useState<NotesSortField>("default");
   const [sortDirection, setSortDirection] =
@@ -263,12 +267,28 @@ export default function Sidebar({
   ]);
 
   const orderedSearchResults = useMemo(
-    () =>
-      localSearchResults === null
-        ? null
-        : sortNotes(localSearchResults, sortField, sortDirection),
-    [localSearchResults, sortDirection, sortField],
+    () => {
+      if (!searchQuery.trim()) return null;
+      return sortNotes(
+        searchNotes(notes, searchQuery, sessionId),
+        sortField,
+        sortDirection,
+      );
+    },
+    [notes, searchQuery, sessionId, sortDirection, sortField],
   );
+
+  useEffect(() => {
+    if (!orderedSearchResults || !selectedNoteSlug) return;
+
+    const selectedResultIndex = orderedSearchResults.findIndex(
+      (note) => note.slug === selectedNoteSlug,
+    );
+
+    if (selectedResultIndex >= 0) {
+      setHighlightedIndex(selectedResultIndex);
+    }
+  }, [orderedSearchResults, selectedNoteSlug]);
 
   useEffect(() => {
     if (orderedSearchResults && orderedSearchResults.length > 0) {
@@ -279,13 +299,12 @@ export default function Sidebar({
   }, [orderedSearchResults, highlightedIndex, selectedNote]);
 
   const clearSearch = useCallback(() => {
-    setLocalSearchResults(null);
     setSearchQuery("");
     setHighlightedIndex(0);
     if (searchInputRef.current) {
       searchInputRef.current.value = "";
     }
-  }, [setLocalSearchResults, setHighlightedIndex]);
+  }, [setHighlightedIndex, setSearchQuery]);
 
   const flattenedNotes = useCallback(() => {
     return activeCategoryOrder.flatMap((category) =>
@@ -458,9 +477,8 @@ export default function Sidebar({
         const selectedElement = document.querySelector(`[data-note-slug="${selectedNote.slug}"]`);
         selectedElement?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
       }, 0);
-      clearSearch();
     }
-  }, [orderedSearchResults, highlightedIndex, router, clearSearch, useCallbackNavigation, selectNoteInApp]);
+  }, [orderedSearchResults, highlightedIndex, router, useCallbackNavigation, selectNoteInApp]);
 
   // Register file menu actions for desktop menubar
   useEffect(() => {
@@ -531,7 +549,20 @@ export default function Sidebar({
         target.isContentEditable;
 
       if (isTyping) {
-        if (event.key === "Escape") {
+        if (
+          target === searchInputRef.current &&
+          orderedSearchResults &&
+          orderedSearchResults.length > 0 &&
+          (event.key === "ArrowDown" || event.key === "ArrowUp")
+        ) {
+          event.preventDefault();
+          const direction = event.key === "ArrowDown" ? 1 : -1;
+          setHighlightedIndex(
+            (prevIndex) =>
+              (prevIndex + direction + orderedSearchResults.length) %
+              orderedSearchResults.length,
+          );
+        } else if (event.key === "Escape") {
           shortcuts["Escape"]();
         } else if (
           event.key === "Enter" &&
@@ -591,10 +622,8 @@ export default function Sidebar({
       if (!isMobile && !useCallbackNavigation) {
         router.push(`/notes/${note.slug}`);
       }
-      clearSearch();
     },
     [
-      clearSearch,
       selectNoteInApp,
       isMobile,
       router,
@@ -675,9 +704,6 @@ export default function Sidebar({
                   )}
                 >
                   <SearchBar
-                    notes={notes}
-                    onSearchResults={setLocalSearchResults}
-                    sessionId={sessionId}
                     inputRef={searchInputRef}
                     searchQuery={searchQuery}
                     setSearchQuery={setSearchQuery}
@@ -704,6 +730,7 @@ export default function Sidebar({
                   useCallbackNavigation={useCallbackNavigation}
                   isMobile={isMobile}
                   viewMode={viewMode}
+                  searchQuery={searchQuery}
                 />
               </div>
             </div>

--- a/components/apps/settings/content.tsx
+++ b/components/apps/settings/content.tsx
@@ -147,7 +147,10 @@ export function Content({
 
   return (
     <div className="flex-1 overflow-y-auto bg-background">
-      <div className="flex flex-col items-center py-8 px-4 border-b border-border/50">
+      <div
+        data-setting-search-id={selectedCategory}
+        className="flex flex-col items-center py-8 px-4 border-b border-border/50"
+      >
         <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-muted mb-3">
           {info.icon}
         </div>

--- a/components/apps/settings/panels/about.tsx
+++ b/components/apps/settings/panels/about.tsx
@@ -15,7 +15,7 @@ export function AboutPanel({ onCategorySelect }: AboutPanelProps) {
   const thumbnailPath = getThumbnailPath(osVersionId);
 
   return (
-    <div className="max-w-lg mx-auto py-6 px-4">
+    <div data-setting-search-id="about" className="max-w-lg mx-auto py-6 px-4">
       {/* MacBook Image */}
       <div className="flex flex-col items-center mb-8">
         <div className="relative w-32 h-24 mb-4">

--- a/components/apps/settings/panels/appearance.tsx
+++ b/components/apps/settings/panels/appearance.tsx
@@ -193,7 +193,7 @@ export function AppearancePanel({ scrollToOSVersion, onScrollComplete }: Appeara
 
   return (
     <div className="space-y-4">
-      <div className="rounded-xl bg-muted/50 p-4">
+      <div data-setting-search-id="appearance" className="rounded-xl bg-muted/50 p-4">
         <div className="flex items-center justify-between">
           <span className="text-xs">Appearance</span>
           <div className="flex gap-2">
@@ -220,7 +220,7 @@ export function AppearancePanel({ scrollToOSVersion, onScrollComplete }: Appeara
       </div>
 
       {/* macOS Version section */}
-      <div ref={osVersionRef} className="rounded-xl bg-muted/50 p-4">
+      <div ref={osVersionRef} data-setting-search-id="macos-version" className="rounded-xl bg-muted/50 p-4">
         <h3 className="text-xs font-medium mb-3">macOS Version</h3>
         <div className="grid grid-cols-4 gap-3">
           {OS_VERSIONS.map((os) => (

--- a/components/apps/settings/panels/bluetooth.tsx
+++ b/components/apps/settings/panels/bluetooth.tsx
@@ -100,7 +100,7 @@ export function BluetoothPanel() {
   return (
     <div className="max-w-2xl">
       {/* Header section with toggle */}
-      <div className="flex items-start gap-4 pb-4 border-b border-border/50">
+      <div data-setting-search-id="bluetooth" className="flex items-start gap-4 pb-4 border-b border-border/50">
         <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-blue-500 shrink-0">
           <Bluetooth className="w-7 h-7 text-white" />
         </div>

--- a/components/apps/settings/panels/desktop-dock.tsx
+++ b/components/apps/settings/panels/desktop-dock.tsx
@@ -7,10 +7,10 @@ export function DesktopDockPanel() {
   const { showDockIndicators, setShowDockIndicators } = useSystemSettings();
 
   return (
-    <div className="mx-auto w-full max-w-2xl space-y-3 p-6">
+    <div data-setting-search-id="desktop-dock" className="mx-auto w-full max-w-2xl space-y-3 p-6">
       <h2 className="text-sm font-semibold">Dock</h2>
       <div className="rounded-xl bg-muted/60 text-sm">
-        <div className="flex min-h-11 items-center justify-between gap-4 px-4 py-2.5">
+        <div data-setting-search-id="dock-indicators" className="flex min-h-11 items-center justify-between gap-4 px-4 py-2.5">
           <span>Show indicators for open applications</span>
           <SettingsSwitch
             aria-label="Show indicators for open applications"

--- a/components/apps/settings/panels/focus.tsx
+++ b/components/apps/settings/panels/focus.tsx
@@ -59,6 +59,7 @@ export function FocusPanel() {
     <div className="mx-auto w-full max-w-2xl space-y-4 p-6">
 
       <div
+        data-setting-search-id="focus-modes"
         role="group"
         aria-label="Focus modes"
         className="overflow-hidden rounded-xl bg-muted/60"

--- a/components/apps/settings/panels/menu-bar.tsx
+++ b/components/apps/settings/panels/menu-bar.tsx
@@ -161,7 +161,7 @@ export function MenuBarPanel() {
   return (
     <div className="mx-auto w-full max-w-2xl space-y-7 p-6">
       <div className="rounded-xl bg-muted/60 text-sm">
-        <div className="flex items-center justify-between gap-4 px-4 py-3">
+        <div data-setting-search-id="menu-bar-background" className="flex items-center justify-between gap-4 px-4 py-3">
           <div className="flex items-center gap-3">
             <PanelTop className="h-5 w-5 text-muted-foreground" />
             <div>
@@ -187,7 +187,7 @@ export function MenuBarPanel() {
           System controls can be configured to appear in the menu bar.
         </div>
         <div className="rounded-xl bg-muted/60">
-          <div className="flex items-center justify-between gap-4 px-4 py-3">
+          <div data-setting-search-id="clock" className="flex items-center justify-between gap-4 px-4 py-3">
             <div className="flex min-w-0 items-center gap-3">
               <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-400 text-white shadow-sm">
                 <Clock3 className="h-5 w-5" />

--- a/components/apps/settings/panels/personal-info.tsx
+++ b/components/apps/settings/panels/personal-info.tsx
@@ -79,7 +79,7 @@ function DeviceIcon({ type }: { type: Device["type"] }) {
 
 export function PersonalInfoPanel() {
   return (
-    <div className="max-w-2xl mx-auto py-4 px-4 space-y-6">
+    <div data-setting-search-id="personal-info" className="max-w-2xl mx-auto py-4 px-4 space-y-6">
       {/* Personal Information Card */}
       <div className="rounded-xl bg-muted/50 overflow-hidden">
         <div className="divide-y divide-border/50">

--- a/components/apps/settings/panels/storage.tsx
+++ b/components/apps/settings/panels/storage.tsx
@@ -22,7 +22,7 @@ export function StoragePanel() {
   const usedPercent = (usedSize / totalSize) * 100;
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-6">
+    <div data-setting-search-id="storage" className="mx-auto max-w-2xl px-6 py-6">
       {/* Macintosh HD Header */}
       <div className="mb-4">
         <div className="flex items-center justify-between mb-2">

--- a/components/apps/settings/panels/wallpaper.tsx
+++ b/components/apps/settings/panels/wallpaper.tsx
@@ -41,6 +41,7 @@ export function WallpaperPanel() {
   return (
     <div
       ref={panelRef}
+      data-setting-search-id="wallpaper"
       className="mx-auto w-full max-w-5xl space-y-8 p-6 pb-10"
       data-testid="settings-wallpaper-panel"
     >

--- a/components/apps/settings/panels/wifi.tsx
+++ b/components/apps/settings/panels/wifi.tsx
@@ -32,7 +32,7 @@ export function WifiPanel() {
   return (
     <div className="max-w-2xl">
       {/* Header section with toggle */}
-      <div className="flex items-start gap-4 pb-4 border-b border-border/50">
+      <div data-setting-search-id="wifi" className="flex items-start gap-4 pb-4 border-b border-border/50">
         <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-blue-500 shrink-0">
           <Wifi className="w-7 h-7 text-white" />
         </div>

--- a/components/apps/settings/search-items.ts
+++ b/components/apps/settings/search-items.ts
@@ -1,0 +1,47 @@
+import type { SettingsCategory, SettingsPanel } from "./settings-app";
+
+export interface SettingsSearchItem {
+  id: string;
+  label: string;
+  category: SettingsCategory;
+  panel: SettingsPanel;
+  keywords: string[];
+}
+
+export const SETTINGS_SEARCH_ITEMS: SettingsSearchItem[] = [
+  { id: "wifi", label: "Wi-Fi", category: "wifi", panel: null, keywords: ["wireless", "network", "internet", "connect"] },
+  { id: "bluetooth", label: "Bluetooth", category: "bluetooth", panel: null, keywords: ["wireless", "devices", "airpods", "keyboard", "trackpad"] },
+  { id: "general", label: "General", category: "general", panel: null, keywords: ["settings", "preferences"] },
+  { id: "appearance", label: "Appearance", category: "appearance", panel: null, keywords: ["light", "dark", "auto", "theme", "mode"] },
+  { id: "macos-version", label: "macOS Version", category: "appearance", panel: null, keywords: ["software update", "operating system", "sierra", "sonoma"] },
+  { id: "wallpaper", label: "Wallpaper", category: "wallpaper", panel: null, keywords: ["background", "desktop", "photo", "theme"] },
+  { id: "desktop-dock", label: "Desktop & Dock", category: "desktop-dock", panel: null, keywords: ["applications", "desktop", "dock"] },
+  { id: "dock-indicators", label: "Show indicators for open applications", category: "desktop-dock", panel: null, keywords: ["dock", "running apps", "dots"] },
+  { id: "menu-bar-background", label: "Show menu bar background", category: "menu-bar", panel: null, keywords: ["contrast", "transparent", "menu bar"] },
+  { id: "clock", label: "Clock Options", category: "menu-bar", panel: null, keywords: ["time", "date", "weekday", "seconds", "digital", "analog"] },
+  { id: "focus-modes", label: "Focus Modes", category: "focus", panel: null, keywords: ["do not disturb", "sleep", "reduce interruptions", "notifications"] },
+  { id: "about", label: "About This Mac", category: "general", panel: "about", keywords: ["macbook", "chip", "memory", "serial"] },
+  { id: "storage", label: "Storage", category: "general", panel: "storage", keywords: ["disk", "space", "capacity"] },
+  { id: "personal-info", label: "Personal Information", category: "general", panel: "personal-info", keywords: ["apple account", "name", "birthday"] },
+];
+
+export function searchSettings(query: string): SettingsSearchItem[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return [];
+
+  return SETTINGS_SEARCH_ITEMS.filter((item) =>
+    [item.label, ...item.keywords]
+      .join(" ")
+      .toLocaleLowerCase()
+      .includes(normalizedQuery),
+  );
+}
+
+export function getNextSettingsSearchResultIndex(
+  currentIndex: number,
+  resultCount: number,
+  direction: 1 | -1,
+): number {
+  if (resultCount <= 0) return 0;
+  return (currentIndex + direction + resultCount) % resultCount;
+}

--- a/components/apps/settings/settings-app.tsx
+++ b/components/apps/settings/settings-app.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { Nav } from "./nav";
 import { Sidebar } from "./sidebar";
 import { Content } from "./content";
 import { loadSettingsState, saveSettingsState } from "@/lib/sidebar-persistence";
+import type { SettingsSearchItem } from "./search-items";
 
 export type SettingsCategory = "general" | "appearance" | "wallpaper" | "wifi" | "bluetooth" | "focus" | "desktop-dock" | "menu-bar";
 export type SettingsPanel = "about" | "personal-info" | "storage" | null;
@@ -22,6 +23,7 @@ interface SettingsAppProps {
 }
 
 export function SettingsApp({ inShell = false, initialPanel, initialCategory, navigationRequestId }: SettingsAppProps) {
+  const appRef = useRef<HTMLDivElement>(null);
   // Load persisted state (props take precedence if provided)
   const getInitialState = (): HistoryEntry => {
     if (initialCategory || initialPanel) {
@@ -40,6 +42,8 @@ export function SettingsApp({ inShell = false, initialPanel, initialCategory, na
   const [history, setHistory] = useState<HistoryEntry[]>(() => [getInitialState()]);
   const [historyIndex, setHistoryIndex] = useState(0);
   const [scrollToOSVersion, setScrollToOSVersion] = useState(false);
+  const [highlightedSettingId, setHighlightedSettingId] = useState<string | null>(null);
+  const [highlightRequestId, setHighlightRequestId] = useState(0);
 
   // Handle initialPanel/initialCategory changes (e.g., from menu bar)
   useEffect(() => {
@@ -73,6 +77,7 @@ export function SettingsApp({ inShell = false, initialPanel, initialCategory, na
   }, [history, historyIndex]);
 
   const handleCategorySelect = (category: SettingsCategory, options?: { scrollToOSVersion?: boolean }) => {
+    setHighlightedSettingId(null);
     navigate(category, null);
     if (options?.scrollToOSVersion) {
       setScrollToOSVersion(true);
@@ -84,20 +89,52 @@ export function SettingsApp({ inShell = false, initialPanel, initialCategory, na
   }, []);
 
   const handlePanelSelect = (panel: SettingsPanel) => {
+    setHighlightedSettingId(null);
     navigate(selectedCategory, panel);
   };
 
   const handleAccountClick = () => {
+    setHighlightedSettingId(null);
     navigate(selectedCategory, "personal-info");
   };
 
+  const handleSearchResultSelect = (item: SettingsSearchItem) => {
+    navigate(item.category, item.panel);
+    setHighlightedSettingId(item.id);
+    setHighlightRequestId((requestId) => requestId + 1);
+  };
+
+  useEffect(() => {
+    if (!highlightedSettingId) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      const target = appRef.current?.querySelector<HTMLElement>(
+        `[data-setting-search-id="${highlightedSettingId}"]`,
+      );
+      if (!target) return;
+
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+      target.animate(
+        [
+          { boxShadow: "0 0 0 2px rgb(10 124 255 / 0.8)" },
+          { boxShadow: "0 0 0 2px rgb(10 124 255 / 0)" },
+        ],
+        { duration: 1400, easing: "ease-out" },
+      );
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [highlightedSettingId, highlightRequestId, selectedCategory, selectedPanel]);
+
   const handleBack = () => {
+    setHighlightedSettingId(null);
     if (historyIndex > 0) {
       setHistoryIndex(historyIndex - 1);
     }
   };
 
   const handleForward = () => {
+    setHighlightedSettingId(null);
     if (historyIndex < history.length - 1) {
       setHistoryIndex(historyIndex + 1);
     }
@@ -122,13 +159,14 @@ export function SettingsApp({ inShell = false, initialPanel, initialCategory, na
   };
 
   return (
-    <div className="relative flex h-full flex-col overflow-hidden bg-background" data-app="settings">
+    <div ref={appRef} className="relative flex h-full flex-col overflow-hidden bg-background" data-app="settings">
       <div className="flex flex-1 overflow-hidden">
         <Sidebar
           selectedCategory={selectedCategory}
           selectedPanel={selectedPanel}
           onCategorySelect={handleCategorySelect}
           onAccountClick={handleAccountClick}
+          onSearchResultSelect={handleSearchResultSelect}
           isDesktop={inShell}
         />
         <div className="flex-1 flex flex-col overflow-hidden">

--- a/components/apps/settings/sidebar.tsx
+++ b/components/apps/settings/sidebar.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { Settings, Paintbrush, Search, X, Wifi, Bluetooth, Moon, PanelBottom, PanelTop, ImageIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettingsCategory, SettingsPanel } from "./settings-app";
 import { SidebarNav } from "./sidebar-nav";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  getNextSettingsSearchResultIndex,
+  searchSettings,
+  type SettingsSearchItem,
+} from "./search-items";
+import { useWindowFocus } from "@/lib/window-focus-context";
 
 interface SidebarProps {
   selectedCategory: SettingsCategory;
@@ -14,6 +20,7 @@ interface SidebarProps {
   onCategorySelect: (category: SettingsCategory) => void;
   onAccountClick: () => void;
   isDesktop?: boolean;
+  onSearchResultSelect: (item: SettingsSearchItem) => void;
 }
 
 const categories: { id: SettingsCategory; name: string; icon: React.ReactNode; iconBg: string; keywords: string[] }[] = [
@@ -83,11 +90,17 @@ export function Sidebar({
   onCategorySelect,
   onAccountClick,
   isDesktop = false,
+  onSearchResultSelect,
 }: SidebarProps) {
+  const windowFocus = useWindowFocus();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchResultsRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [highlightedSearchIndex, setHighlightedSearchIndex] = useState(0);
   const [isScrolled, setIsScrolled] = useState(false);
 
   const query = searchQuery.toLowerCase();
+  const searchResults = searchSettings(searchQuery);
 
   // Filter categories based on search (name or keywords)
   const filteredCategories = categories.filter((category) => {
@@ -99,6 +112,78 @@ export function Sidebar({
   const showAppleAccount =
     searchQuery === "" ||
     appleAccountKeywords.some((keyword) => keyword.includes(query));
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (windowFocus && !windowFocus.isFocused) return;
+
+      const target = event.target as HTMLElement | null;
+      const isTypingTarget =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable;
+      const isSearchFocused = document.activeElement === searchInputRef.current;
+
+      if (event.key === "Escape" && (isSearchFocused || searchQuery)) {
+        event.preventDefault();
+        if (isSearchFocused) {
+          searchInputRef.current?.blur();
+        } else {
+          setSearchQuery("");
+          setHighlightedSearchIndex(0);
+        }
+        return;
+      }
+
+      if (
+        event.key === "/" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !isTypingTarget
+      ) {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+        return;
+      }
+
+      if (!searchQuery || searchResults.length === 0) return;
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const direction: 1 | -1 = event.key === "ArrowDown" ? 1 : -1;
+        setHighlightedSearchIndex((index) =>
+          getNextSettingsSearchResultIndex(index, searchResults.length, direction),
+        );
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const item = searchResults[highlightedSearchIndex];
+        if (!item) return;
+        event.preventDefault();
+        onSearchResultSelect(item);
+        setSearchQuery("");
+        setHighlightedSearchIndex(0);
+        searchInputRef.current?.blur();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [highlightedSearchIndex, onSearchResultSelect, searchQuery, searchResults, windowFocus]);
+
+  useEffect(() => {
+    setHighlightedSearchIndex((index) =>
+      Math.min(index, Math.max(0, searchResults.length - 1)),
+    );
+  }, [searchResults.length]);
+
+  useEffect(() => {
+    if (!searchQuery || searchResults.length === 0) return;
+    searchResultsRef.current
+      ?.querySelector(`[data-settings-search-result-index="${highlightedSearchIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlightedSearchIndex, searchQuery, searchResults.length]);
 
   return (
     <div className="flex flex-col h-full select-none w-[320px] bg-muted border-r border-border/50">
@@ -126,16 +211,27 @@ export function Sidebar({
                 <div className="relative">
                   <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                   <input
+                    ref={searchInputRef}
                     type="text"
                     value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onChange={(e) => {
+                      setSearchQuery(e.target.value);
+                      setHighlightedSearchIndex(0);
+                    }}
                     placeholder="Search"
+                    aria-label="Search settings"
                     className="w-full rounded-lg bg-[#E8E8E7] py-0.5 pl-8 pr-8 text-sm placeholder:text-sm placeholder:text-muted-foreground focus:outline-none dark:bg-[#353533]"
                   />
                   {searchQuery && (
                     <button
-                      onClick={() => setSearchQuery("")}
-                      className="absolute right-2 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      type="button"
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => {
+                        setSearchQuery("");
+                        setHighlightedSearchIndex(0);
+                        searchInputRef.current?.focus();
+                      }}
+                      className="absolute right-2 top-1/2 transform -translate-y-1/2 text-muted-foreground can-hover:hover:text-foreground"
                       aria-label="Clear search"
                     >
                       <X className="h-4 w-4" />
@@ -144,6 +240,43 @@ export function Sidebar({
                 </div>
               </div>
 
+              {searchQuery ? (
+                <div ref={searchResultsRef} className="space-y-0.5 py-2">
+                  {searchResults.length > 0 ? searchResults.map((item, index) => {
+                    const isHighlighted = index === highlightedSearchIndex;
+                    return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      data-settings-search-result-index={index}
+                      aria-current={isHighlighted ? "true" : undefined}
+                      onClick={() => {
+                        onSearchResultSelect(item);
+                        setSearchQuery("");
+                        setHighlightedSearchIndex(0);
+                        searchInputRef.current?.blur();
+                      }}
+                      className={cn(
+                        "w-full rounded-lg px-3 py-2 text-left active:bg-background/70",
+                        isHighlighted
+                          ? "bg-[#0A7CFF] text-white"
+                          : "can-hover:hover:bg-background/50",
+                      )}
+                    >
+                      <span className="block text-xs font-medium">{item.label}</span>
+                      <span className={cn(
+                        "block text-[10px] capitalize",
+                        isHighlighted ? "text-white/80" : "text-muted-foreground",
+                      )}>
+                        {item.category.replace("-", " & ")}
+                      </span>
+                    </button>
+                    );
+                  }) : (
+                    <p className="px-3 py-4 text-center text-xs text-muted-foreground">No settings found</p>
+                  )}
+                </div>
+              ) : (<>
               {/* Apple Account */}
               {showAppleAccount && (
                 <div className="py-2">
@@ -201,6 +334,7 @@ export function Sidebar({
                   })}
                 </div>
               </div>
+              </>)}
             </div>
           </div>
         </ScrollArea>

--- a/components/apps/weather/weather-app.tsx
+++ b/components/apps/weather/weather-app.tsx
@@ -27,6 +27,7 @@ import {
   getWeatherDescription,
   getWeatherIconName,
   getWeatherCitySelectionAfterRemoval,
+  getNextWeatherSearchResultIndex,
   type WeatherMood,
   getWeatherScene,
   type WeatherScene,
@@ -652,6 +653,7 @@ export function WeatherApp({
   const inDesktopShell = !!(inShell && windowFocus);
   const containerRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchResultsRef = useRef<HTMLDivElement>(null);
 
   const [customCities, setCustomCities] = useState<CityConfig[]>(() =>
     loadWeatherCustomCities()
@@ -667,6 +669,7 @@ export function WeatherApp({
   const [searchQuery, setSearchQuery] = useState("");
   const [searchActive, setSearchActive] = useState(false);
   const [searchResults, setSearchResults] = useState<CityConfig[]>([]);
+  const [highlightedSearchIndex, setHighlightedSearchIndex] = useState(0);
   const [searchLoading, setSearchLoading] = useState(false);
   const [refreshNotice, setRefreshNotice] = useState<string | null>(null);
   const [scenePreviewMode, setScenePreviewMode] =
@@ -879,6 +882,19 @@ export function WeatherApp({
     [allCities, searchResults]
   );
 
+  useEffect(() => {
+    setHighlightedSearchIndex((index) =>
+      Math.min(index, Math.max(0, searchResultItems.length - 1)),
+    );
+  }, [searchResultItems.length]);
+
+  useEffect(() => {
+    if (!trimmedSearchQuery || searchResultItems.length === 0) return;
+    searchResultsRef.current
+      ?.querySelector(`[data-weather-search-result-index="${highlightedSearchIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlightedSearchIndex, searchResultItems.length, trimmedSearchQuery]);
+
   const handleSelectSearchResult = useCallback(
     (result: CityConfig, existingCityId: string | null) => {
       const targetCityId = existingCityId ?? result.id;
@@ -893,6 +909,7 @@ export function WeatherApp({
 
       setSelectedCityId(targetCityId);
       setSearchQuery("");
+      setHighlightedSearchIndex(0);
       setSearchActive(false);
       searchInputRef.current?.blur();
     },
@@ -975,11 +992,16 @@ export function WeatherApp({
 
       if (event.key === "Escape" && (isSearchFocused || searchActive || !!searchQuery)) {
         event.preventDefault();
-        if (searchQuery) {
+        if (isSearchFocused) {
+          searchInputRef.current?.blur();
+        } else if (searchQuery) {
           setSearchQuery("");
+          setSearchResults([]);
+          setHighlightedSearchIndex(0);
+          setSearchActive(false);
+        } else {
+          setSearchActive(false);
         }
-        setSearchActive(false);
-        (document.activeElement as HTMLElement | null)?.blur();
         return;
       }
 
@@ -993,12 +1015,38 @@ export function WeatherApp({
         event.preventDefault();
         setSearchActive(true);
         window.setTimeout(() => searchInputRef.current?.focus(), 0);
+        return;
+      }
+
+      if (!trimmedSearchQuery || searchResultItems.length === 0) return;
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const direction: 1 | -1 = event.key === "ArrowDown" ? 1 : -1;
+        setHighlightedSearchIndex((index) =>
+          getNextWeatherSearchResultIndex(index, searchResultItems.length, direction),
+        );
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const item = searchResultItems[highlightedSearchIndex];
+        if (!item) return;
+        event.preventDefault();
+        handleSelectSearchResult(item.city, item.existingCityId);
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [windowFocus, searchActive, searchQuery]);
+  }, [
+    handleSelectSearchResult,
+    highlightedSearchIndex,
+    searchActive,
+    searchQuery,
+    searchResultItems,
+    trimmedSearchQuery,
+    windowFocus,
+  ]);
 
   return (
     <div ref={containerRef} className="h-full flex bg-background" data-app="weather">
@@ -1064,7 +1112,10 @@ export function WeatherApp({
                       ref={searchInputRef}
                       type="text"
                       value={searchQuery}
-                      onChange={(event) => setSearchQuery(event.target.value)}
+                      onChange={(event) => {
+                        setSearchQuery(event.target.value);
+                        setHighlightedSearchIndex(0);
+                      }}
                       onFocus={() => setSearchActive(true)}
                       onBlur={() => setSearchActive(false)}
                       onMouseDown={(event) => event.stopPropagation()}
@@ -1084,6 +1135,8 @@ export function WeatherApp({
                         }}
                         onClick={() => {
                           setSearchQuery("");
+                          setSearchResults([]);
+                          setHighlightedSearchIndex(0);
                           searchInputRef.current?.focus();
                         }}
                         className={cn(
@@ -1107,17 +1160,25 @@ export function WeatherApp({
                     {!searchLoading && searchResultItems.length === 0 && (
                       <p className="px-1 py-2 text-sm text-white/76">No matching locations</p>
                     )}
-                    <div className="space-y-1">
-                      {searchResultItems.map(({ city, existingCityId }) => {
+                    <div ref={searchResultsRef} className="space-y-1">
+                      {searchResultItems.map(({ city, existingCityId }, index) => {
                         const [primaryName, ...secondaryParts] = city.name.split(", ");
                         const secondaryName = secondaryParts.join(", ");
+                        const isHighlighted = index === highlightedSearchIndex;
 
                         return (
                           <button
                             key={city.id}
                             type="button"
+                            data-weather-search-result-index={index}
+                            aria-current={isHighlighted ? "true" : undefined}
                             onClick={() => handleSelectSearchResult(city, existingCityId)}
-                            className="w-full rounded-md px-1.5 py-1.5 text-left text-white/90 transition-colors"
+                            className={cn(
+                              "w-full rounded-md px-1.5 py-1.5 text-left text-white/90 transition-colors",
+                              isHighlighted
+                                ? "bg-white/20"
+                                : "can-hover:hover:bg-white/10",
+                            )}
                           >
                             <p className="truncate text-sm [text-shadow:0_1px_2px_rgba(5,14,31,0.45)]">
                               <span className="font-medium text-white/95">{primaryName}</span>

--- a/lib/messages/search.ts
+++ b/lib/messages/search.ts
@@ -1,0 +1,86 @@
+import type { Conversation, Message } from "@/types/messages";
+
+export interface MessageSearchResult {
+  conversation: Conversation;
+  message: Message;
+}
+
+export function getNextMessageSearchResultIndex(
+  currentIndex: number,
+  resultCount: number,
+  direction: 1 | -1,
+): number {
+  if (resultCount <= 0) return 0;
+  return (currentIndex + direction + resultCount) % resultCount;
+}
+
+export function getMessageSearchPreviewText(
+  content: string,
+  query: string,
+  contextLength = 96,
+): string {
+  const messageText = content.replace(/\s+/g, " ").trim();
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return messageText;
+
+  const matchIndex = messageText.toLocaleLowerCase().indexOf(normalizedQuery);
+  if (matchIndex < 0) return messageText;
+
+  const leadingContextLength = Math.min(18, Math.floor(contextLength / 4));
+  const contextStart = Math.max(0, matchIndex - leadingContextLength);
+  const contextEnd = Math.min(
+    messageText.length,
+    Math.max(contextStart + contextLength, matchIndex + normalizedQuery.length),
+  );
+  const excerpt = messageText.slice(contextStart, contextEnd).trim();
+
+  return `${contextStart > 0 ? "…" : ""}${excerpt}${
+    contextEnd < messageText.length ? "…" : ""
+  }`;
+}
+
+export function getConversationSearchName(conversation: Conversation): string {
+  return (
+    conversation.name ||
+    conversation.recipients.map((recipient) => recipient.name).join(", ")
+  );
+}
+
+export function getMessageSearchResults(
+  conversations: Conversation[],
+  query: string,
+  limit = 12,
+): MessageSearchResult[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery || limit <= 0) return [];
+
+  const results: MessageSearchResult[] = [];
+  for (const conversation of conversations) {
+    for (let index = conversation.messages.length - 1; index >= 0; index -= 1) {
+      const message = conversation.messages[index];
+      if (
+        message.sender !== "system" &&
+        message.content.toLocaleLowerCase().includes(normalizedQuery)
+      ) {
+        results.push({ conversation, message });
+        if (results.length === limit) return results;
+      }
+    }
+  }
+
+  return results;
+}
+
+export function getConversationNameMatches(
+  conversations: Conversation[],
+  query: string,
+): Conversation[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return [];
+
+  return conversations.filter((conversation) =>
+    getConversationSearchName(conversation)
+      .toLocaleLowerCase()
+      .includes(normalizedQuery),
+  );
+}

--- a/lib/notes/note-utils.ts
+++ b/lib/notes/note-utils.ts
@@ -142,8 +142,36 @@ export function getNotePreviewText(content: string): string {
     .replace(/!\[[^\]]*\]\([^)]+\)/g, "")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     .replace(/\[[ x]\]/g, "")
-    .replace(/[#*_~`>+\-]/g, "")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s*>+\s?/gm, "")
+    .replace(/^\s*[-+*]\s+/gm, "")
+    .replace(/[*_~`]/g, "")
     .replace(/\n+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+export function getNoteSearchPreviewText(
+  content: string,
+  searchQuery: string,
+  contextLength = 84,
+): string {
+  const preview = getNotePreviewText(content);
+  const query = searchQuery.trim().toLocaleLowerCase();
+  if (!query) return preview;
+
+  const matchIndex = preview.toLocaleLowerCase().indexOf(query);
+  if (matchIndex < 0) return preview;
+
+  const leadingContextLength = Math.min(18, Math.floor(contextLength / 4));
+  const contextStart = Math.max(0, matchIndex - leadingContextLength);
+  const contextEnd = Math.min(
+    preview.length,
+    Math.max(contextStart + contextLength, matchIndex + query.length),
+  );
+  const leadingText = preview.slice(contextStart, contextEnd).trim();
+
+  return `${contextStart > 0 ? "…" : ""}${leadingText}${
+    contextEnd < preview.length ? "…" : ""
+  }`;
 }

--- a/lib/notes/search.ts
+++ b/lib/notes/search.ts
@@ -1,4 +1,5 @@
 import { Note } from "./types";
+import { getNotePreviewText } from "./note-utils";
 
 export function searchNotes(notes: Note[], searchTerm: string, sessionId: string): Note[] {
     const searchLower = searchTerm.trim().toLowerCase();
@@ -8,7 +9,9 @@ export function searchNotes(notes: Note[], searchTerm: string, sessionId: string
       const sessionMatch = note.session_id === sessionId; 
       const isAccessible = isPublic || sessionMatch;
       const titleMatch = note.title.toLowerCase().includes(searchLower);
-      const contentMatch = note.content.toLowerCase().includes(searchLower);
+      const contentMatch = getNotePreviewText(note.content)
+        .toLowerCase()
+        .includes(searchLower);
       const matchesSearch = titleMatch || contentMatch;
 
       return isAccessible && matchesSearch;

--- a/lib/weather.ts
+++ b/lib/weather.ts
@@ -67,6 +67,15 @@ export function getWeatherCitySelectionAfterRemoval(
   return cities[removedIndex + 1]?.id ?? cities[removedIndex - 1]?.id ?? null;
 }
 
+export function getNextWeatherSearchResultIndex(
+  currentIndex: number,
+  resultCount: number,
+  direction: 1 | -1,
+): number {
+  if (resultCount <= 0) return 0;
+  return (currentIndex + direction + resultCount) % resultCount;
+}
+
 interface WeatherThemeDefinition {
   background: string;
   heroGradient: string;

--- a/tests/calendar-search.test.ts
+++ b/tests/calendar-search.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DEFAULT_CALENDARS } from "../components/apps/calendar/data";
+import {
+  getCalendarEventSearchScrollTop,
+  getNextCalendarSearchResultIndex,
+  searchCalendarEvents,
+} from "../components/apps/calendar/search-utils";
+import type { CalendarEvent } from "../components/apps/calendar/types";
+
+const referenceDate = new Date(2026, 8, 5);
+
+test("searches generated event titles and locations", () => {
+  const exerciseResults = searchCalendarEvents([], DEFAULT_CALENDARS, "exercise", referenceDate, 7);
+  const locationResults = searchCalendarEvents([], DEFAULT_CALENDARS, "san francisco", referenceDate, 35);
+
+  assert.ok(exerciseResults.length > 0);
+  assert.ok(locationResults.some((event) => event.location?.includes("san francisco")));
+});
+
+test("puts upcoming matching events before past results", () => {
+  const events: CalendarEvent[] = [
+    { id: "past", title: "Board planning", startDate: "2026-09-01", endDate: "2026-09-01", startTime: "10:00", endTime: "11:00", isAllDay: false, calendarId: "meetings" },
+    { id: "future", title: "Board dinner", startDate: "2026-09-08", endDate: "2026-09-08", startTime: "18:00", endTime: "20:00", isAllDay: false, calendarId: "meals" },
+  ];
+
+  assert.deepEqual(
+    searchCalendarEvents(events, DEFAULT_CALENDARS, "board", referenceDate, 7).map((event) => event.id),
+    ["future", "past"],
+  );
+});
+
+test("searches stored events outside the generated-event window", () => {
+  const events: CalendarEvent[] = [
+    { id: "far-future", title: "Long-range planning", startDate: "2028-09-05", endDate: "2028-09-05", startTime: "10:00", endTime: "11:00", isAllDay: false, calendarId: "meetings" },
+  ];
+
+  assert.deepEqual(
+    searchCalendarEvents(events, DEFAULT_CALENDARS, "long-range", referenceDate).map((event) => event.id),
+    ["far-future"],
+  );
+});
+
+test("wraps Calendar search result keyboard navigation", () => {
+  assert.equal(getNextCalendarSearchResultIndex(0, 3, 1), 1);
+  assert.equal(getNextCalendarSearchResultIndex(2, 3, 1), 0);
+  assert.equal(getNextCalendarSearchResultIndex(0, 3, -1), 2);
+  assert.equal(getNextCalendarSearchResultIndex(0, 0, 1), 0);
+});
+
+test("centers Calendar search selections around their start time", () => {
+  const timedEvent: CalendarEvent = {
+    id: "dinner",
+    title: "Dinner",
+    startDate: "2026-09-05",
+    endDate: "2026-09-05",
+    startTime: "18:30",
+    endTime: "20:00",
+    isAllDay: false,
+    calendarId: "meals",
+  };
+
+  assert.equal(getCalendarEventSearchScrollTop(timedEvent), 910);
+  assert.equal(
+    getCalendarEventSearchScrollTop({ ...timedEvent, startTime: "01:00" }),
+    0,
+  );
+  assert.equal(
+    getCalendarEventSearchScrollTop({ ...timedEvent, isAllDay: true }),
+    null,
+  );
+});

--- a/tests/messages-search.test.ts
+++ b/tests/messages-search.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  getConversationNameMatches,
+  getMessageSearchPreviewText,
+  getMessageSearchResults,
+  getNextMessageSearchResultIndex,
+} from "../lib/messages/search";
+import type { Conversation } from "../types/messages";
+
+const conversations: Conversation[] = [
+  {
+    id: "one",
+    recipients: [{ id: "person-one", name: "Ada Lovelace" }],
+    messages: [
+      { id: "one-old", content: "Analytical Engine", sender: "Ada Lovelace", timestamp: "2026-01-01" },
+      { id: "one-system", content: "Engine notice", sender: "system", timestamp: "2026-01-02" },
+      { id: "one-new", content: "The engine can compose", sender: "me", timestamp: "2026-01-03" },
+    ],
+    lastMessageTime: "2026-01-03",
+    unreadCount: 0,
+  },
+  {
+    id: "two",
+    name: "Babbage group",
+    recipients: [{ id: "person-two", name: "Charles Babbage" }],
+    messages: [
+      { id: "two-match", content: "A difference engine", sender: "Charles Babbage", timestamp: "2026-01-04" },
+    ],
+    lastMessageTime: "2026-01-04",
+    unreadCount: 0,
+  },
+];
+
+describe("Messages search", () => {
+  it("returns message matches newest-first within conversation order", () => {
+    assert.deepEqual(
+      getMessageSearchResults(conversations, "ENGINE").map(({ message }) => message.id),
+      ["one-new", "one-old", "two-match"],
+    );
+  });
+
+  it("omits system messages and honors the result limit", () => {
+    assert.deepEqual(
+      getMessageSearchResults(conversations, "engine", 1).map(({ message }) => message.id),
+      ["one-new"],
+    );
+  });
+
+  it("does not match reaction types", () => {
+    const reactedConversation: Conversation = {
+      ...conversations[0],
+      messages: [
+        {
+          id: "reaction-only",
+          content: "Acknowledged",
+          sender: "Ada Lovelace",
+          timestamp: "2026-01-05",
+          reactions: [
+            { type: "like", sender: "me", timestamp: "2026-01-05" },
+          ],
+        },
+      ],
+    };
+
+    assert.deepEqual(getMessageSearchResults([reactedConversation], "like"), []);
+  });
+
+  it("shows the matching text in long message previews", () => {
+    const preview = getMessageSearchPreviewText(
+      "It's been cool to see AI codegen tools make these dev tools more accessible. We get a lot of users coming from platforms like Bolt, Loveable, and v0.",
+      "like",
+      60,
+    );
+
+    assert.match(preview, /^…/);
+    assert.match(preview, /platforms like Bolt/);
+    assert.ok(preview.indexOf("like") <= 19);
+  });
+
+  it("matches the displayed conversation name", () => {
+    assert.deepEqual(
+      getConversationNameMatches(conversations, "babbage").map(({ id }) => id),
+      ["two"],
+    );
+    assert.deepEqual(
+      getConversationNameMatches(conversations, "ada").map(({ id }) => id),
+      ["one"],
+    );
+  });
+
+  it("wraps keyboard navigation through the visible result list", () => {
+    assert.equal(getNextMessageSearchResultIndex(0, 3, 1), 1);
+    assert.equal(getNextMessageSearchResultIndex(2, 3, 1), 0);
+    assert.equal(getNextMessageSearchResultIndex(0, 3, -1), 2);
+    assert.equal(getNextMessageSearchResultIndex(0, 0, 1), 0);
+  });
+});

--- a/tests/notes-search-preview.test.ts
+++ b/tests/notes-search-preview.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getNotePreviewText,
+  getNoteSearchPreviewText,
+} from "../lib/notes/note-utils";
+import { searchNotes } from "../lib/notes/search";
+import type { Note } from "../lib/notes/types";
+
+function makeNote(overrides: Partial<Note>): Note {
+  return {
+    id: "note-1",
+    slug: "note-1",
+    title: "Bookmarks",
+    content: "Visible note text",
+    created_at: "2026-09-05T12:00:00.000Z",
+    session_id: null,
+    public: true,
+    ...overrides,
+  };
+}
+
+test("shows context around a matching phrase in a long note", () => {
+  const preview = getNoteSearchPreviewText(
+    "Opening paragraph with background details. The decisive launch date is October 4 and the rest follows.",
+    "launch date",
+    36,
+  );
+
+  assert.match(preview, /^…/);
+  assert.match(preview, /launch date is October 4/);
+  assert.match(preview, /…$/);
+});
+
+test("falls back to the beginning when only the title matches", () => {
+  assert.equal(
+    getNoteSearchPreviewText("The body starts here", "missing title term"),
+    "The body starts here",
+  );
+});
+
+test("normalizes markdown before locating the match", () => {
+  assert.equal(
+    getNoteSearchPreviewText("## Plan\n- Ship the **search result**", "search result"),
+    "Plan Ship the search result",
+  );
+});
+
+test("removes Markdown markers without stripping semantic punctuation", () => {
+  assert.equal(
+    getNotePreviewText("## Languages\n- name-dropping\n- C++\n- C#"),
+    "Languages name-dropping C++ C#",
+  );
+});
+
+test("keeps the match near the start so it survives sidebar truncation", () => {
+  const preview = getNoteSearchPreviewText(
+    "The opposite of success isn't failure; it is name-dropping and posturing.",
+    "name",
+  );
+
+  assert.ok(preview.indexOf("name") <= 19);
+  assert.match(preview, /name-dropping/);
+});
+
+test("searches visible note text instead of hidden Markdown link targets", () => {
+  const hiddenUrlMatch = makeNote({
+    id: "hidden-url",
+    slug: "hidden-url",
+    content: "[Visible label](https://example.com/name-only)",
+  });
+  const visibleMatch = makeNote({
+    id: "visible-match",
+    slug: "visible-match",
+    content: "My name is Alana",
+  });
+
+  assert.deepEqual(
+    searchNotes([hiddenUrlMatch, visibleMatch], "name", "session-1").map(
+      (note) => note.id,
+    ),
+    ["visible-match"],
+  );
+});

--- a/tests/settings-search.test.ts
+++ b/tests/settings-search.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getNextSettingsSearchResultIndex,
+  searchSettings,
+} from "../components/apps/settings/search-items";
+
+test("finds a specific setting by familiar language", () => {
+  assert.deepEqual(searchSettings("running apps").map((item) => item.id), ["dock-indicators"]);
+  assert.deepEqual(searchSettings("seconds").map((item) => item.id), ["clock"]);
+});
+
+test("returns the destination pane for subpanel settings", () => {
+  const [storage] = searchSettings("disk space");
+
+  assert.equal(storage.category, "general");
+  assert.equal(storage.panel, "storage");
+});
+
+test("keeps top-level category names searchable", () => {
+  assert.deepEqual(searchSettings("general").map((item) => item.id), ["general"]);
+  assert.deepEqual(searchSettings("desktop & dock").map((item) => item.id), ["desktop-dock"]);
+});
+
+test("wraps Settings search keyboard navigation", () => {
+  assert.equal(getNextSettingsSearchResultIndex(0, 3, 1), 1);
+  assert.equal(getNextSettingsSearchResultIndex(2, 3, 1), 0);
+  assert.equal(getNextSettingsSearchResultIndex(0, 3, -1), 2);
+  assert.equal(getNextSettingsSearchResultIndex(0, 0, 1), 0);
+});

--- a/tests/weather-locations.test.ts
+++ b/tests/weather-locations.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getWeatherCitySelectionAfterRemoval } from "../lib/weather";
+import {
+  getNextWeatherSearchResultIndex,
+  getWeatherCitySelectionAfterRemoval,
+} from "../lib/weather";
 
 const cities = [
   { id: "san-francisco" },
@@ -28,4 +31,11 @@ test("falls back to the previous Weather city at the end of the list", () => {
     getWeatherCitySelectionAfterRemoval(cities, "tokyo", "tokyo"),
     "seattle"
   );
+});
+
+test("wraps Weather search keyboard navigation", () => {
+  assert.equal(getNextWeatherSearchResultIndex(0, 3, 1), 1);
+  assert.equal(getNextWeatherSearchResultIndex(2, 3, 1), 0);
+  assert.equal(getNextWeatherSearchResultIndex(0, 3, -1), 2);
+  assert.equal(getNextWeatherSearchResultIndex(0, 0, 1), 0);
 });


### PR DESCRIPTION
## Today’s delight

Messages search now behaves like a real transcript search instead of a conversation filter. Matching people appear under **Conversations**, matching text appears under **Messages**, and selecting a message result opens that conversation at the exact bubble with a brief arrival highlight.

On mobile, Back returns to the preserved search and its results.

## Why this one

The previous search narrowed the conversation list, but gave no matching excerpt and opened the selected thread at the bottom. Apple’s current Messages guide describes categorized search results and selecting a result to jump to its location in the transcript, so this closes a small but important parity gap: [Search for a conversation in Messages on Mac](https://support.apple.com/guide/messages/search-for-a-conversation-icht6d66aae3/mac).

## Desktop

![Messages search result jumping to the exact desktop transcript bubble](https://github.com/user-attachments/assets/7cf76d69-48df-4cc0-bf27-bc0d9ba5537f)

## Mobile

![Messages search result opened at the exact bubble in a touch-emulated mobile layout](https://github.com/user-attachments/assets/268c5a17-29c2-4c8d-82c4-b0fddc03078d)

## Verification

- `npm run check`
- Desktop browser check: categorized result, matching excerpt, exact-bubble jump, arrival highlight, and unchanged bottom-opening behavior for ordinary conversation selection
- Chrome device emulation at 390×844: `(pointer: coarse)`, `(hover: none)`, five touch points, touch-dispatched result selection, exact bubble visible, and Back preserving the query/result
- `git diff --check`

## Scope

Medium: one focused Messages behavior across six implementation/test files, with no new app, dependency, design token, or persistence format.
