### PR TITLE
Open images and PDFs from iTerm

### DIFF
--- a/components/apps/iterm/iterm-app.tsx
+++ b/components/apps/iterm/iterm-app.tsx
@@ -10,6 +10,11 @@ interface ITermAppProps {
   inShell?: boolean;
   onOpenDirectory?: (directoryPath: string) => void;
   onOpenTextFile?: (filePath: string, content: string) => void;
+  onOpenPreviewFile?: (
+    filePath: string,
+    fileUrl: string,
+    fileType: "image" | "pdf"
+  ) => void;
 }
 
 function formatWorkingDirectory(directory: string): string {
@@ -24,6 +29,7 @@ export function ITermApp({
   inShell = false,
   onOpenDirectory,
   onOpenTextFile,
+  onOpenPreviewFile,
 }: ITermAppProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentDirectory, setCurrentDirectory] = useState(HOME_DIR);
@@ -42,6 +48,7 @@ export function ITermApp({
         <Terminal
           onOpenDirectory={onOpenDirectory}
           onOpenTextFile={onOpenTextFile}
+          onOpenPreviewFile={onOpenPreviewFile}
           onCurrentDirectoryChange={setCurrentDirectory}
         />
       </div>

--- a/components/apps/iterm/terminal.tsx
+++ b/components/apps/iterm/terminal.tsx
@@ -13,6 +13,7 @@ import {
   getFinderOpenDirectoryTarget,
   getFinderProjectRootTarget,
 } from "@/lib/finder-path";
+import { getPreviewMetadataFromPath } from "@/lib/preview-utils";
 
 const USERNAME = "alanagoyal";
 const HOSTNAME = "Alanas-MacBook-Air";
@@ -159,12 +160,18 @@ function isTextFile(filename: string): boolean {
 interface TerminalProps {
   onOpenDirectory?: (directoryPath: string) => void;
   onOpenTextFile?: (filePath: string, content: string) => void;
+  onOpenPreviewFile?: (
+    filePath: string,
+    fileUrl: string,
+    fileType: "image" | "pdf"
+  ) => void;
   onCurrentDirectoryChange?: (directory: string) => void;
 }
 
 export function Terminal({
   onOpenDirectory,
   onOpenTextFile,
+  onOpenPreviewFile,
   onCurrentDirectoryChange,
 }: TerminalProps) {
   const { currentOS } = useSystemSettings();
@@ -506,6 +513,7 @@ export function Terminal({
 
         const staticNode = fileSystem[path];
         const parsed = parseGitHubPath(path);
+        let githubTree: Awaited<ReturnType<typeof fetchGitHubRepoTree>> | null = null;
         let finderDirectoryTarget = staticNode?.type === "dir"
           ? getFinderOpenDirectoryTarget(path)
           : null;
@@ -525,8 +533,8 @@ export function Terminal({
             }
             finderDirectoryTarget = projectRootTarget;
           } else {
-            const tree = await fetchGitHubRepoTree(parsed.repo);
-            const isDirectory = tree.some(
+            githubTree = await fetchGitHubRepoTree(parsed.repo);
+            const isDirectory = githubTree.some(
               (item) => item.type === "dir" && item.path === parsed.filePath
             );
             if (isDirectory) finderDirectoryTarget = path;
@@ -538,6 +546,29 @@ export function Terminal({
             onOpenDirectory(finderDirectoryTarget);
           } else {
             output = "open: Finder is not available";
+          }
+          break;
+        }
+
+        const previewMetadata = getPreviewMetadataFromPath(path);
+        if (previewMetadata) {
+          const githubFileExists = !parsed?.filePath || githubTree?.some(
+            (item) => item.type === "file" && item.path === parsed.filePath
+          );
+          if (!githubFileExists) {
+            output = `open: ${args[0]}: No such file or directory`;
+            break;
+          }
+
+          if (onOpenPreviewFile) {
+            onOpenPreviewFile(
+              path,
+              previewMetadata.fileUrl,
+              previewMetadata.fileType
+            );
+            addRecent({ path, name: path.split("/").pop() || path, type: "file" });
+          } else {
+            output = "open: Preview is not available";
           }
           break;
         }
@@ -595,7 +626,7 @@ export function Terminal({
       { type: "input", content: input, prompt },
       ...(output ? [{ type: "output" as const, content: output }] : []),
     ]);
-  }, [currentDir, commandHistory, getPrompt, resolvePath, fileSystem, isGitHubPath, parseGitHubPath, currentOS, addRecent, onOpenDirectory, onOpenTextFile]);
+  }, [currentDir, commandHistory, getPrompt, resolvePath, fileSystem, isGitHubPath, parseGitHubPath, currentOS, addRecent, onOpenDirectory, onOpenTextFile, onOpenPreviewFile]);
 
   const handleKeyDown = useCallback(async (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && !isExecuting) {

--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -1024,6 +1024,7 @@ function DesktopContent({
               inShell={true}
               onOpenDirectory={handleOpenFinderDirectory}
               onOpenTextFile={handleOpenTextFile}
+              onOpenPreviewFile={handleOpenPreviewFile}
             />
           </Window>
 

--- a/docs/document-apps.md
+++ b/docs/document-apps.md
@@ -22,6 +22,7 @@ This note captures how file-backed document apps launch through Finder in the de
 - Choosing `Preview` from Finder's Applications view focuses the topmost open Preview document window if one exists; otherwise it opens a centered, slightly smaller Finder window at `Desktop`.
 - When Preview is explicitly kept in the desktop Dock, clicking its closed icon opens that same Finder picker at `Desktop`; clicking it with documents open brings its windows forward.
 - Finder opens images and PDFs in `Preview` windows, each backed by a real file path.
+- iTerm's `open` command sends supported repository-backed images and PDFs to Preview, matching its existing Finder-folder and TextEdit-file handoffs.
 - On mobile, all Preview routes redirect to `/notes`; the Finder-picker behavior above is desktop-only.
 
 ## Why This Split Exists
@@ -35,6 +36,7 @@ This note captures how file-backed document apps launch through Finder in the de
 - `lib/app-config.ts` marks Finder as a multi-window app.
 - `lib/file-route-utils.ts` is the source of truth for local sample document paths, Finder fallback targets, and local file metadata shared across Finder, TextEdit, and Preview.
 - `components/desktop/desktop.tsx` focuses an existing TextEdit/Preview document window first, and only falls back to opening a centered, slightly smaller Finder window at `Documents` for TextEdit and `Desktop` for Preview when that app has no open documents.
+- `components/apps/iterm/terminal.tsx` resolves `open` targets and delegates supported image/PDF paths to the desktop shell's existing Preview launcher.
 - `components/desktop/dock.tsx` delegates closed document-app launches to the desktop shell: TextEdit creates an untitled document, while Preview opens its shared Finder picker.
 - `components/desktop/window.tsx` provides the shared desktop window shell, while `components/apps/finder/finder-app.tsx` owns per-window Finder browsing state.
 - `lib/shell-routing.ts` only generates desktop URLs for these apps when a `filePath` is present.
@@ -57,7 +59,9 @@ Run `npm run build`, then verify:
 12. In TextEdit, use File → New and confirm an `Untitled.txt` document opens and appears in Finder's Documents folder.
 13. Use File → Duplicate and Rename, then confirm the copied content, updated title, and Finder-visible file name persist after closing and reopening the document.
 14. Edit a document and confirm the title shows `Edited`; use File → Save and confirm the marker clears before using File → Close.
-15. With an iPhone user agent, confirm `/textedit`, `/textedit/<nested>`, `/preview`, and `/preview/<nested>` redirect to `/notes` while the same routes preserve their existing desktop behavior.
-16. Keep TextEdit and Preview in the desktop Dock, remove Music, then refresh and confirm the persisted membership appears before paint without an enter animation or a flash of the registered defaults.
-17. Quit TextEdit, click its kept Dock icon, and confirm a new untitled TextEdit window opens with a running dot and Quit action.
-18. Quit Preview, click its kept Dock icon twice, and confirm one Finder picker opens at `Desktop` and is focused again while Preview remains dotless and offers Open until an image or PDF is selected.
+15. In iTerm, run `open` for a repository-backed image or PDF and confirm Preview opens the exact file; repeat the command and confirm the existing Preview window is focused.
+16. Replay iTerm `open` with a directory, a text file, and an unsupported path; confirm Finder, TextEdit, and the existing error path remain unchanged.
+17. With an iPhone user agent, confirm `/textedit`, `/textedit/<nested>`, `/preview`, `/preview/<nested>`, and `/iterm` redirect to `/notes` while the same routes preserve their existing desktop behavior.
+18. Keep TextEdit and Preview in the desktop Dock, remove Music, then refresh and confirm the persisted membership appears before paint without an enter animation or a flash of the registered defaults.
+19. Quit TextEdit, click its kept Dock icon, and confirm a new untitled TextEdit window opens with a running dot and Quit action.
+20. Quit Preview, click its kept Dock icon twice, and confirm one Finder picker opens at `Desktop` and is focused again while Preview remains dotless and offers Open until an image or PDF is selected.


### PR DESCRIPTION
## Today's delight

iTerm's existing `open` command now launches supported repository-backed images and PDFs in Preview, completing the command's existing Finder-folder and TextEdit-file handoffs.

## Baseline and delta

- Before: `open` sent directories to Finder and text files to TextEdit, but rejected every image and PDF as a non-text file.
- Now: running `open Projects/alanagoyal/public/finder.png` opens that exact image in Preview; repeating it focuses the existing Preview window instead of duplicating it.
- Preserved: directory opens still launch Finder, text files still launch TextEdit, unsupported and missing paths keep their error results, the command stays in terminal history, and the desktop-only iTerm route still redirects to Notes on mobile.

## Built result — desktop

![Desktop iTerm command opening finder.png in Preview](https://github.com/user-attachments/assets/dce371e0-1897-49e9-99e2-72d7431e3569)

At 1440×900, the screenshot shows the entered iTerm command beside the exact repository image it opened in Preview. The same session also verified repeat-focus without duplicate windows.

## Built result — mobile

![iPhone Notes fallback preserved for the desktop-only iTerm route](https://github.com/user-attachments/assets/de400251-71e0-4932-9b3c-5a5404d9f5c3)

At 390×844 with an iPhone user agent, coarse pointer, hover disabled, and touch enabled, `/iterm` still redirects to the unchanged Notes list.

## macOS inspiration

Direct inspection of the installed macOS 26.5.1 `open(1)` manual documents that `open` opens a file or directory as if its icon were double-clicked and lets LaunchServices choose the default app. This implementation maps that behavior onto the site's established file associations: folders → Finder, text → TextEdit, and now images/PDFs → Preview.

## Why this one

iTerm's last daily delight and last visible touch were both 2026-08-24. It is a neglected registered app, sits outside the current Finder/Settings cooldown, and avoids the broad search work in open PR #308 and the menu-bar work in #298. The result turns an explicit error path into a small, recognizable cross-app capability using existing personal repository assets.

## Verification

- `npm run check` — 154 tests, typecheck, and all 41 production routes passed; lint retained six pre-existing warnings and zero errors
- Desktop: 1440×900; image Preview handoff, repeat-focus, Finder directory handoff, TextEdit file handoff, unsupported-path error, missing-file error, and zero console errors
- Mobile: 390×844 iPhone emulation with `(pointer: coarse)`, `(hover: none)`, and touch enabled; `/iterm` redirected to `/notes`
- `git diff --check`

## Scope

Micro: four existing code/documentation files, 50 additions and 7 deletions, no dependency, backend, schema, keyboard shortcut, or mobile behavior change. Recent merge and open-PR overlap checks found no conflict with this iTerm/Preview bridge.
