### PR TITLE
Add Continue Playing to Games

### DIFF
--- a/components/apps/games/games-app.tsx
+++ b/components/apps/games/games-app.tsx
@@ -511,9 +511,16 @@ export function GamesApp({ waitingPlayer = { waiting: false, name: null }, onWai
   };
   const sortedLibraryGames = useMemo(() => {
     return [...LIBRARY_GAMES].sort((left, right) => sortBy === "name"
-        ? left.name.localeCompare(right.name)
-        : (lastPlayed[right.id] ?? 0) - (lastPlayed[left.id] ?? 0));
+      ? left.name.localeCompare(right.name)
+      : (lastPlayed[right.id] ?? 0) - (lastPlayed[left.id] ?? 0));
   }, [lastPlayed, sortBy]);
+  const continueGame = useMemo(() => {
+    return LIBRARY_GAMES.reduce<(typeof LIBRARY_GAMES)[number] | null>((latest, game) => {
+      if (!lastPlayed[game.id]) return latest;
+      if (!latest || (lastPlayed[game.id] ?? 0) > (lastPlayed[latest.id] ?? 0)) return game;
+      return latest;
+    }, null);
+  }, [lastPlayed]);
   const navAction = screen === "chess" && gameEnded ? (
     <button
       type="button"
@@ -581,6 +588,26 @@ export function GamesApp({ waitingPlayer = { waiting: false, name: null }, onWai
       {screen === "library" && (
         <div className="min-h-0 flex-1 overflow-auto bg-background px-7 pb-7 pt-5">
           <div className="mx-auto max-w-[1180px]">
+            {continueGame && (
+              <section className="mb-7" aria-labelledby="continue-playing-heading">
+                <h1 id="continue-playing-heading" className="mb-3 text-xl font-semibold tracking-tight">Continue Playing</h1>
+                <button
+                  type="button"
+                  data-continue-game={continueGame.id}
+                  onClick={() => openLibraryGame(continueGame.id)}
+                  className="flex w-full max-w-[520px] items-center gap-4 rounded-2xl bg-muted/80 p-3 text-left ring-1 ring-muted-foreground/10 transition-colors can-hover:hover:bg-muted-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0A7CFF]"
+                  aria-label={`Continue playing ${continueGame.name}`}
+                >
+                  <GameTileIcon game={continueGame.id} className="h-[76px] w-[76px] shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[15px] font-semibold">{continueGame.name}</span>
+                    <span className="mt-0.5 block truncate text-xs text-muted-foreground">{relativePlayedAt(lastPlayed[continueGame.id])}</span>
+                    <span className="block truncate text-xs text-muted-foreground">{continueGame.description}</span>
+                  </span>
+                  <span className="shrink-0 rounded-full bg-[#0A7CFF] px-4 py-1.5 text-xs font-semibold text-white">Play</span>
+                </button>
+              </section>
+            )}
             <div className="mb-5 flex items-center justify-between">
               <h1 className="text-xl font-semibold tracking-tight">Your Games</h1>
               <button type="button" onClick={() => setSortBy((value) => value === "recent" ? "name" : "recent")} className="flex h-8 items-center gap-1.5 rounded-full bg-muted px-3 text-xs font-medium text-muted-foreground can-hover:hover:text-foreground" title={`Sort by ${sortBy === "recent" ? "name" : "recently played"}`}><SlidersHorizontal size={14} />{sortBy === "recent" ? "Recent" : "Name"}</button>


### PR DESCRIPTION
## Today's delight

Games now turns its existing recent-play history into a functional **Continue Playing** section. After someone opens a game and returns to the library, the most recently played title appears in a prominent card whose Play action opens that game again; playing a different title updates the card immediately.

## Baseline and delta

- Before: **Your Games** showed six titles, per-game Play buttons, relative last-played labels, and Recent/Name sorting, but no continuation section or shortcut back to the latest title.
- Now: returning from any game reveals a **Continue Playing** card for the most recently opened title, with its artwork, recency, description, and a one-click Play action.
- Preserved: all six library Play actions, Recent/Name sorting, per-game last-played labels, in-game Back navigation, Chess setup, and the unsupported-mobile `/games` → `/notes` contract remain unchanged.

## Built result — desktop

![Games Continue Playing card for the most recently opened game](https://github.com/user-attachments/assets/77f0f2d0-6a1c-4e7e-8ad4-64b6ca9f02dd)

At 1440×900, the card appeared after returning from Snake, reopened Snake, then updated to 2048 after that title was played. All original library controls remained usable; a separate 1280×800 dark-mode pass rendered the same state correctly.

## Built result — mobile

![Notes fallback preserved for Games on an iPhone viewport](https://github.com/user-attachments/assets/353386fb-eb57-41f0-b0bc-fa1ac30b58ff)

Games remains intentionally desktop-only. At 390×844 with an iPhone user agent, touch enabled, `(pointer: coarse)`, `(hover: none)`, and `maxTouchPoints: 1`, `/games` still redirected to the usable Notes shell.

## macOS inspiration

Apple’s current [Games app guide for macOS Tahoe](https://support.apple.com/guide/games/find-download-and-play-games-firdc6c09e54/1.0/mac/26) documents a **Continue Playing** section on Home that lets people select a recent game and choose Play. This implementation maps that behavior onto the site’s truthful, already-persisted library history without inventing cross-device progress or achievements.

## Why this one

Games is the most neglected registered app: it has never been the primary surface of a daily delight, and its last visible change was the five-level campaign expansion on 2026-08-31. The candidate scored 35/35 and avoids the two most recent primary surfaces (`iterm` and `messages`) as well as the open menu-bar eyes PR.

## Verification

- `npm run check` with the repository’s existing local environment — six pre-existing lint warnings, 176 tests passed, typecheck passed, and the 41-route production build passed.
- Focused browser flow: empty-history baseline, Snake play/back/continue, latest-game update to 2048, all six original Play buttons, Recent/Name sorting, and zero console errors.
- Desktop: 1440×900 light mode plus 1280×800 dark-mode rendering.
- Mobile: iPhone 390×844 with true touch/coarse-pointer emulation; `/games` redirected to `/notes` and the Notes search remained usable.
- `git diff --check`

## Scope

Micro: one existing component, 29 additions and 2 deletions. No dependency, backend, schema, keyboard command, personal-content, or mobile-policy change; recent default-branch work and open PRs were checked for overlap.
