### PR TITLE
Add Music album quick play

### DIFF
--- a/components/apps/music/content-views/albums-view.tsx
+++ b/components/apps/music/content-views/albums-view.tsx
@@ -3,13 +3,48 @@
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Pause, Play } from "lucide-react";
+import { useAudio } from "@/lib/music/audio-context";
+import type { PlaylistTrack } from "../types";
+
+interface Album {
+  id: string;
+  name: string;
+  artist: string;
+  albumArt: string;
+  trackCount: number;
+  tracks: PlaylistTrack[];
+}
 
 interface AlbumsViewProps {
-  albums: { id: string; name: string; artist: string; albumArt: string; trackCount: number }[];
+  albums: Album[];
   isMobileView: boolean;
 }
 
 export function AlbumsView({ albums, isMobileView }: AlbumsViewProps) {
+  const { playbackState, play, pause, resume } = useAudio();
+
+  const handleAlbumPlay = (album: Album) => {
+    const isCurrentAlbum =
+      playbackState.currentTrack?.album === album.name &&
+      playbackState.currentTrack.artist === album.artist;
+
+    if (isCurrentAlbum && playbackState.isPlaying) {
+      pause();
+      return;
+    }
+
+    if (isCurrentAlbum) {
+      resume();
+      return;
+    }
+
+    const firstPlayableTrack = album.tracks.find((track) => track.previewUrl);
+    if (firstPlayableTrack) {
+      play(firstPlayableTrack, album.tracks);
+    }
+  };
+
   return (
     <ScrollArea className="h-full">
       <div className={cn("p-6", isMobileView && "p-4 pb-20")}>
@@ -20,21 +55,60 @@ export function AlbumsView({ albums, isMobileView }: AlbumsViewProps) {
             isMobileView ? "grid-cols-2" : "grid-cols-3 desktop:grid-cols-5"
           )}
         >
-          {albums.map((album) => (
-            <div key={album.id}>
-              <div className="relative aspect-square rounded-lg overflow-hidden mb-2 bg-muted shadow-md">
-                <Image
-                  src={album.albumArt}
-                  alt={album.name}
-                  fill
-                  className="object-cover"
-                  unoptimized
-                />
+          {albums.map((album) => {
+            const isCurrentAlbum =
+              playbackState.currentTrack?.album === album.name &&
+              playbackState.currentTrack.artist === album.artist;
+            const isPlayingAlbum = isCurrentAlbum && playbackState.isPlaying;
+            const action = isPlayingAlbum ? "Pause" : isCurrentAlbum ? "Resume" : "Play";
+            const hasPlayableTracks = album.tracks.some((track) => track.previewUrl);
+
+            return (
+              <div key={album.id} className="group min-w-0">
+                <div className="relative aspect-square overflow-hidden rounded-lg bg-muted shadow-md">
+                  <Image
+                    src={album.albumArt}
+                    alt={album.name}
+                    fill
+                    className="object-cover"
+                    unoptimized
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleAlbumPlay(album)}
+                    disabled={!hasPlayableTracks}
+                    aria-label={`${action} ${album.name} by ${album.artist}`}
+                    className={cn(
+                      "absolute inset-0 flex items-center justify-center rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/90 disabled:cursor-default",
+                      isMobileView
+                        ? "bg-black/5"
+                        : "bg-black/0 can-hover:hover:bg-black/35 focus-visible:bg-black/35"
+                    )}
+                  >
+                    {hasPlayableTracks && (
+                      <span
+                        className={cn(
+                          "flex h-11 w-11 items-center justify-center rounded-full text-white shadow-lg backdrop-blur-sm transition-opacity",
+                          isPlayingAlbum ? "bg-red-500" : "bg-black/55",
+                          isMobileView
+                            ? "opacity-100"
+                            : "opacity-0 can-hover:group-hover:opacity-100 group-focus-within:opacity-100"
+                        )}
+                      >
+                        {isPlayingAlbum ? (
+                          <Pause className="h-5 w-5 fill-current" aria-hidden />
+                        ) : (
+                          <Play className="ml-0.5 h-5 w-5 fill-current" aria-hidden />
+                        )}
+                      </span>
+                    )}
+                  </button>
+                </div>
+                <p className="mt-2 truncate text-sm font-medium">{album.name}</p>
+                <p className="truncate text-xs text-muted-foreground">{album.artist}</p>
               </div>
-              <p className="text-sm font-medium truncate">{album.name}</p>
-              <p className="text-xs text-muted-foreground truncate">{album.artist}</p>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </ScrollArea>

--- a/components/apps/music/data.ts
+++ b/components/apps/music/data.ts
@@ -1,4 +1,4 @@
-import { Playlist } from "./types";
+import { Playlist, PlaylistTrack } from "./types";
 
 // Default playlists with hardcoded track data
 export const DEFAULT_PLAYLISTS: Playlist[] = [
@@ -1068,10 +1068,18 @@ export function getAlbumsFromPlaylists(): {
   artist: string;
   albumArt: string;
   trackCount: number;
+  tracks: PlaylistTrack[];
 }[] {
   const albumMap = new Map<
     string,
-    { id: string; name: string; artist: string; albumArt: string; trackCount: number }
+    {
+      id: string;
+      name: string;
+      artist: string;
+      albumArt: string;
+      trackCount: number;
+      tracks: PlaylistTrack[];
+    }
   >();
 
   for (const playlist of DEFAULT_PLAYLISTS) {
@@ -1084,11 +1092,16 @@ export function getAlbumsFromPlaylists(): {
           artist: track.artist,
           albumArt: track.albumArt,
           trackCount: 1,
+          tracks: [track],
         });
       } else {
         const album = albumMap.get(albumKey);
-        if (album) {
+        const alreadyIncluded = album?.tracks.some(
+          (albumTrack) => albumTrack.name === track.name
+        );
+        if (album && !alreadyIncluded) {
           album.trackCount++;
+          album.tracks.push(track);
         }
       }
     }

--- a/tests/music-albums.test.ts
+++ b/tests/music-albums.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getAlbumsFromPlaylists } from "../components/apps/music/data";
+
+test("album library groups unique tracks into playable queues", () => {
+  const albums = getAlbumsFromPlaylists();
+  const album = albums.find(
+    (candidate) =>
+      candidate.name === "Man On The Moon: The End Of Day (Deluxe)" &&
+      candidate.artist === "Kid Cudi"
+  );
+
+  assert.ok(album);
+  assert.equal(album.trackCount, album.tracks.length);
+  assert.deepEqual(
+    album.tracks.map((track) => track.name),
+    ["Soundtrack 2 My Life", "Day 'N' Nite (nightmare)", "Man On The Moon"]
+  );
+  assert.ok(album.tracks.every((track) => track.album === album.name));
+  assert.ok(album.tracks.every((track) => track.artist === album.artist));
+});
+
+test("album queues remove duplicate songs repeated across playlists", () => {
+  const albums = getAlbumsFromPlaylists();
+  const album = albums.find(
+    (candidate) =>
+      candidate.name === "Twelve Carat Toothache" &&
+      candidate.artist === "Post Malone"
+  );
+
+  assert.ok(album);
+  assert.equal(album.trackCount, 1);
+  assert.deepEqual(album.tracks.map((track) => track.name), ["When I'm Alone"]);
+});


### PR DESCRIPTION
## Today's delight

Music's Albums view now offers direct album playback. Hover or focus an album cover on desktop, or use the always-visible touch control on mobile, to start that album's deduplicated track queue and pause or resume it in place.

## Baseline and delta

- Before: Albums displayed cover art, title, and artist, but the cards had no playback action; clicking or tapping an album left the grid unchanged.
- Now: Every playable album has a clear play/pause action that starts an album-specific queue and updates the existing Now Playing surface.
- Preserved: Albums navigation and scrolling, the rest of the Music sidebar and mobile back navigation, existing playlist/home/favorites flows, and the shared Now Playing controls all behave as before.

## Built result — desktop

![Desktop screenshot of Music album quick play](https://github.com/user-attachments/assets/7d1ae2b2-200c-48c0-a87d-c7f78fc06ae6)

At 1440×900, hovering the first album reveals its centered playback control while the existing Now Playing bar confirms that the album queue started. Keyboard focus exposes the same control without changing the album grid's layout.

## Built result — mobile

![Mobile screenshot of Music album quick play](https://github.com/user-attachments/assets/f393c8d6-30c4-417d-8ed0-bcdf50c051fd)

At an emulated iPhone viewport of 390×844 (3× DPR), each album keeps a visible 44-point touch target. A real coarse-pointer touch tap starts the first album and changes that control to Pause while the existing mobile Now Playing bar remains available.

## macOS inspiration

Apple's current Music guide says that in Library → Albums, moving the pointer over a song or album reveals a Play button. This implementation maps that behavior to the desktop cover overlay and gives touch users an equivalent persistent control instead of depending on hover: [Play songs from your library in Music on Mac](https://support.apple.com/guide/music/play-songs-from-your-library-mus36265ad9/mac).

## Why this one

Music was the strongest neglected registered-app candidate: its last daily delight was 2026-08-20 and its last merged visible touch was 2026-08-21. The most recent delights focused Games and iTerm, and the only open PR touches the menu bar, so this restores a missing primary action without overlapping shipped or in-flight work.

## Verification

- `npm run check` (178 tests, typecheck, and production build passed; six pre-existing lint warnings remain)
- Desktop: 1440×900 production build; Albums navigation, hover and keyboard-focus visibility, queue start, pause/resume state, and Now Playing controls checked
- Mobile: iPhone 390×844 at 3× DPR with iPhone user agent, touch emulation, `maxTouchPoints: 5`, coarse pointer, and no hover; album tap, pause state, back/navigation, and Now Playing checked
- `node --import tsx --test tests/music-albums.test.ts tests/music-favorites.test.ts tests/music-recently-played.test.ts` (9 tests passed)

## Scope

Micro: three Music-focused files, no new dependencies or backend work. The 45-day first-parent delight history, recent non-delight changes, all registered apps, and current open PRs were audited before selection; the change does not overlap the last two delight surfaces or any in-flight work.
