### PR TITLE
Add Change Wallpaper desktop shortcut

### DIFF
--- a/components/desktop/desktop.tsx
+++ b/components/desktop/desktop.tsx
@@ -11,6 +11,12 @@ import { MenuBar } from "./menu-bar";
 import { Dock } from "./dock";
 import { Window } from "./window";
 import { DesktopNotificationBanner } from "./messages-notification-banner";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { NotesApp } from "@/components/apps/notes/notes-app";
 import { MessagesApp } from "@/components/apps/messages/messages-app";
 import type { PreviewFileType } from "@/components/apps/preview";
@@ -765,6 +771,28 @@ function DesktopContent({
     }
   }, [openWindow]);
 
+  const handleOpenWallpaperSettings = useCallback(() => {
+    setSettingsCategory("wallpaper");
+    setSettingsPanel(null);
+    setSettingsNavigationRequestId((requestId) => requestId + 1);
+
+    const settingsWindow = getWindow("settings");
+    if (settingsWindow?.isOpen) {
+      if (settingsWindow.isMinimized) {
+        restoreWindow("settings");
+      } else {
+        focusWindow("settings");
+      }
+    } else {
+      openWindow("settings");
+    }
+
+    const nextUrl = getShellUrlForApp("settings", { context: "desktop" });
+    if (nextUrl) {
+      setUrl(nextUrl);
+    }
+  }, [focusWindow, getWindow, openWindow, restoreWindow]);
+
   const handleOpenWifiSettings = useCallback(() => {
     setSettingsCategory("wifi");
     setSettingsPanel(null);
@@ -952,14 +980,25 @@ function DesktopContent({
 
   return (
     <div className="fixed inset-0" data-shell="desktop">
-      <Image
-        src={wallpaperUrl ?? getWallpaperPath(currentOS.id)}
-        alt="Desktop wallpaper"
-        fill
-        className="object-cover -z-10"
-        priority
-        quality={75}
-      />
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div className="absolute inset-0" data-desktop-wallpaper>
+            <Image
+              src={wallpaperUrl ?? getWallpaperPath(currentOS.id)}
+              alt="Desktop wallpaper"
+              fill
+              className="object-cover"
+              priority
+              quality={75}
+            />
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent data-desktop-context-menu>
+          <ContextMenuItem onSelect={handleOpenWallpaperSettings}>
+            Change Wallpaper…
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
       <MenuBar
         onOpenSettings={handleOpenSettings}
         onOpenWifiSettings={handleOpenWifiSettings}


### PR DESCRIPTION
## Today's delight

Secondary-clicking uncovered desktop wallpaper now opens a compact macOS-style shortcut menu. Choosing **Change Wallpaper…** opens and focuses System Settings directly at the existing Wallpaper pane.

## Baseline and delta

- Before: Uncovered desktop wallpaper had no site-owned secondary-click action; right-clicking it neither opened a menu nor navigated anywhere.
- Now: One secondary click reveals `Change Wallpaper…`, and selecting it opens/focuses System Settings at Wallpaper. The menu uses the same translucent, blurred panel and full-width blue highlight as the Dock separator menu.
- Preserved: Ordinary desktop clicks stay inert; right-clicks inside Notes do not trigger the wallpaper menu; existing windows, Dock, menu bar, Settings navigation, wallpaper selection, and iPhone Notes open/Back flow remain unchanged.

## Built result — desktop

![Desktop screenshot of the Dock-matched Change Wallpaper menu highlight](https://github.com/user-attachments/assets/e0944da6-a4e7-4545-bafc-43b04e7cbf5d)

At 1440×900, the privacy-safe capture shows the hovered command over uncovered wallpaper: a 95%-opaque blurred panel, 12px label, and edge-to-edge blue highlight. Selection closes it and opens `/settings` with the Wallpaper panel present.

## Built result — mobile

![Privacy-safe mobile Notes shell verification crop](https://github.com/user-attachments/assets/134a4dab-5427-4cc7-9297-746173cafe73)

The privacy-safe crop shows only the unchanged mobile Notes controls and Search field. At 390×844 @3× with an iPhone user agent, touch enabled, coarse pointer, no hover, and five touch points, `/` continued to route to Notes and the desktop-only shortcut remained absent.

## macOS inspiration

On the installed macOS 26.6.2 system, FinderKit’s English localization includes the exact `Change Wallpaper…` contextual command. Apple’s current [Customize the wallpaper on your Mac](https://support.apple.com/en-ae/guide/mac-help/mchlp3013/mac) guide identifies System Settings → Wallpaper as the native destination. This change maps that uncovered-desktop context action to the site’s existing Wallpaper pane. The shared Mac was locked, so no live native screenshot was captured.

## Why this one

Desktop was a neglected shell surface: its last primary daily delight shipped on 2026-07-23 and its last merged visible touch was 2026-08-12. This one-file shortcut is a useful, authentic bridge into an existing feature, while avoiding the two latest daily surfaces (Music and Games) and open menu-bar PR #298.

## Verification

- `npx eslint components/desktop/desktop.tsx`
- `git diff --check`
- `npm run check` — lint passed with six existing warnings, all 178 tests passed, and standalone typecheck passed; this runner blocks the symlinked dependency tree during Turbopack’s production build
- Desktop: 1440×900; uncovered target, nested Notes exclusion, menu open/dismiss, computed Dock-matched hover styles, and Settings Wallpaper handoff
- Mobile: 390×844 @3×; iPhone UA, touch, coarse pointer, no hover, and unchanged Notes list

## Scope

Micro: one existing desktop shell file, 55 additions and 8 deletions. No dependency, backend, data, shortcut, app-registry, or mobile changes; no overlap with open PR #298.
